### PR TITLE
Mituron/adding acc validator to examples

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
@@ -1,3 +1,4 @@
+// tslint:disable:linebreak-style
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Menu } from 'semantic-ui-react'
@@ -8,6 +9,7 @@ import ComponentControlsCopyLink from './ComponentControlsCopyLink'
 import ComponentControlsShowVariables from './ComponentControlsShowVariables'
 import ComponentControlsMaximize from './ComponentControlsMaximize'
 import ComponentControlsRtl from './ComponentControlsRtl'
+import ComponentControlsRunAccValidator from './ComponentControlsAccValidator'
 
 const ComponentControls: any = props => {
   const {
@@ -16,14 +18,17 @@ const ComponentControls: any = props => {
     showCode,
     showRtl,
     showVariables,
+    runAccValidator,
     onCopyLink,
     onShowCode,
     onShowRtl,
     onShowVariables,
+    onRunAccValidator,
   } = props
 
   return (
     <Menu color="green" icon="labeled" size="tiny" fitted compact text>
+      <ComponentControlsRunAccValidator active={runAccValidator} onClick={onRunAccValidator} />
       <ComponentControlsShowCode active={showCode} onClick={onShowCode} />
       <ComponentControlsShowVariables active={showVariables} onClick={onShowVariables} />
       <ComponentControlsRtl active={showRtl} onClick={onShowRtl} />
@@ -40,10 +45,18 @@ ComponentControls.propTypes = {
   onShowCode: PropTypes.func,
   onShowRtl: PropTypes.func,
   onShowVariables: PropTypes.func,
+  onRunAccValidator: PropTypes.func,
+  runAccValidator: PropTypes.bool,
   showCode: PropTypes.bool,
   showRtl: PropTypes.bool,
   showVariables: PropTypes.bool,
   visible: PropTypes.bool,
 }
 
-export default updateForKeys(['showRtl', 'showCode', 'showVariables', 'visible'])(ComponentControls)
+export default updateForKeys([
+  'showRtl',
+  'showCode',
+  'showVariables',
+  'runAccValidator',
+  'visible',
+])(ComponentControls)

--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
@@ -1,4 +1,3 @@
-// tslint:disable:linebreak-style
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Menu } from 'semantic-ui-react'
@@ -28,9 +27,9 @@ const ComponentControls: any = props => {
 
   return (
     <Menu color="green" icon="labeled" size="tiny" fitted compact text>
-      <ComponentControlsRunAccValidator active={runAccValidator} onClick={onRunAccValidator} />
       <ComponentControlsShowCode active={showCode} onClick={onShowCode} />
       <ComponentControlsShowVariables active={showVariables} onClick={onShowVariables} />
+      <ComponentControlsRunAccValidator active={runAccValidator} onClick={onRunAccValidator} />
       <ComponentControlsRtl active={showRtl} onClick={onShowRtl} />
       <ComponentControlsMaximize examplePath={examplePath} />
       <ComponentControlsCopyLink anchorName={anchorName} onClick={onCopyLink} />

--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsAccValidator.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsAccValidator.tsx
@@ -1,4 +1,3 @@
-// tslint:disable:linebreak-style
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Icon, Menu } from 'semantic-ui-react'
@@ -7,8 +6,8 @@ import { updateForKeys } from 'docs/src/hoc'
 
 const ComponentControlsRunAccValidator: React.SFC = ({ active, onClick }: any) => (
   <Menu.Item active={active} onClick={onClick}>
-    <Icon color={active ? 'green' : 'grey'} size="large" name="accessible" fitted />
-    Accessibility validator
+    <Icon color={active ? 'green' : 'grey'} size="large" name="eye slash" fitted />
+    Accessibility
   </Menu.Item>
 )
 

--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsAccValidator.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsAccValidator.tsx
@@ -1,0 +1,20 @@
+// tslint:disable:linebreak-style
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Icon, Menu } from 'semantic-ui-react'
+
+import { updateForKeys } from 'docs/src/hoc'
+
+const ComponentControlsRunAccValidator: React.SFC = ({ active, onClick }: any) => (
+  <Menu.Item active={active} onClick={onClick}>
+    <Icon color={active ? 'green' : 'grey'} size="large" name="accessible" fitted />
+    Accessibility validator
+  </Menu.Item>
+)
+
+ComponentControlsRunAccValidator.propTypes = {
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
+}
+
+export default updateForKeys(['active'])(ComponentControlsRunAccValidator)

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -1,4 +1,3 @@
-// tslint:disable:linebreak-style
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { PureComponent, isValidElement, CSSProperties } from 'react'

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/react-dom": "^16.0.6",
     "@types/react-router": "^4.0.27",
     "awesome-typescript-loader": "^4.0.1",
+    "axe-core": "^3.0.3",
     "connect-history-api-fallback": "^1.3.0",
     "copy-to-clipboard": "^3.0.8",
     "cross-env": "^5.1.4",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# [Accessibility validator on example]

Integrating Axe-core accessibility validator for each example. 
https://axe-core.org/docs/

Validator took particular example/element(s) and return report. 

Report will be displayed in the same way as others features are displayed("Try it" or "Theme it")

Screenshot from localhost:
![image](https://user-images.githubusercontent.com/22620150/43395962-47657d5c-9400-11e8-8b2e-4eeffe017011.png)


