### PR TITLE
fix: removed interfaces for the props in the components

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,36 +1,18 @@
 import PropTypes from 'prop-types'
-import React, { ReactNode, CSSProperties, SyntheticEvent } from 'react'
+import React, { ReactNode, SyntheticEvent } from 'react'
 
-import { UIComponent, childrenExist, customPropTypes, IRenderResultConfig } from '../../lib'
+import { UIComponent, childrenExist, customPropTypes } from '../../lib'
 import buttonRules from './buttonRules'
 import buttonVariables from './buttonVariables'
 import Icon from '../Icon'
 import Text from '../Text'
-
-export type IconPosition = 'before' | 'after'
-export type ButtonType = 'primary' | 'secondary'
-
-export interface IButtonProps {
-  as?: string
-  children?: ReactNode
-  circular?: boolean
-  className?: string
-  content?: ReactNode
-  disabled?: boolean
-  fluid?: boolean
-  icon?: boolean | string
-  iconPosition?: IconPosition
-  onClick?: (e: SyntheticEvent, props: IButtonProps) => void
-  style?: CSSProperties
-  type?: ButtonType
-}
 
 /**
  * A button.
  * @accessibility This is example usage of the accessibility tag.
  * This should be replaced with the actual description after the PR is merged
  */
-class Button extends UIComponent<IButtonProps, any> {
+class Button extends UIComponent<any, any> {
   public static displayName = 'Button'
 
   public static className = 'ui-button'
@@ -96,11 +78,7 @@ class Button extends UIComponent<IButtonProps, any> {
     as: 'button',
   }
 
-  public renderComponent({
-    ElementType,
-    classes,
-    rest,
-  }: IRenderResultConfig<IButtonProps>): ReactNode {
+  public renderComponent({ ElementType, classes, rest }): ReactNode {
     const { children, content, disabled, icon, iconPosition, type } = this.props
     const primary = type === 'primary'
 

--- a/src/components/Button/buttonRules.ts
+++ b/src/components/Button/buttonRules.ts
@@ -1,10 +1,9 @@
 import { pxToRem } from '../../lib'
 import { disabledStyle, truncateStyle } from '../../styles/customCSS'
 import { IButtonVariables } from './buttonVariables'
-import { IButtonProps } from './Button'
 
 export default {
-  root: ({ props, variables }: { props: IButtonProps; variables: IButtonVariables }) => {
+  root: ({ props, variables }: { props: any; variables: IButtonVariables }) => {
     const { circular, disabled, fluid, icon, iconPosition, type } = props
     const primary = type === 'primary'
     const secondary = type === 'secondary'

--- a/src/components/Divider/dividerVariables.ts
+++ b/src/components/Divider/dividerVariables.ts
@@ -1,13 +1,4 @@
-export interface IDividerVariables {
-  defaultColor: string
-  defaultBackgroundColor: string
-  typePrimaryColor: string
-  typePrimaryBackgroundColor: string
-  typeSecondaryColor: string
-  typeSecondaryBackgroundColor: string
-}
-
-export default (siteVars: any): IDividerVariables => {
+export default (siteVars: any) => {
   return {
     defaultColor: siteVars.gray04,
     defaultBackgroundColor: siteVars.gray12,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 import HeaderDescription from './HeaderDescription'
 import headerRules from './headerRules'
-import headerVariables from './headerVariables'
 
 /**
  * A header provides a short summary of content
@@ -44,8 +43,6 @@ class Header extends UIComponent<any, any> {
   static handledProps = ['as', 'children', 'className', 'content', 'description', 'textAlign']
 
   static rules = headerRules
-
-  static variables = headerVariables
 
   static Description = HeaderDescription
 

--- a/src/components/Header/headerVariables.ts
+++ b/src/components/Header/headerVariables.ts
@@ -1,1 +1,0 @@
-export default () => ({})

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,46 +1,13 @@
-import React, { CSSProperties } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { customPropTypes, UIComponent, SUI } from '../../lib'
 
 import iconRules from './iconRules'
 import iconVariables from './iconVariables'
 
-export type IconColor =
-  | 'white'
-  | 'red'
-  | 'orange'
-  | 'yellow'
-  | 'olive'
-  | 'green'
-  | 'teal'
-  | 'blue'
-  | 'violet'
-  | 'purple'
-  | 'pink'
-  | 'brown'
-  | 'grey'
-  | 'black'
-
-export type IconSize = 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'
-
 export type IconXSpacing = 'none' | 'before' | 'after' | 'both'
 
-export interface IconProps {
-  as?: string
-  bordered?: boolean
-  circular?: boolean
-  className?: string
-  color?: IconColor
-  disabled?: boolean
-  kind?: string
-  name?: string
-  size?: IconSize
-  xSpacing?: IconXSpacing
-  style?: CSSProperties
-  title?: string
-}
-
-class Icon extends UIComponent<IconProps, {}> {
+class Icon extends UIComponent<any, any> {
   static className = 'ui-icon'
 
   static displayName = 'Icon'

--- a/src/components/Icon/iconRules.ts
+++ b/src/components/Icon/iconRules.ts
@@ -1,11 +1,11 @@
 import fontAwesomeIcons from './fontAwesomeIconRules'
 import { disabledStyle, fittedStyle } from '../../styles/customCSS'
-import { IconProps, IconXSpacing } from './Icon'
+import { IconXSpacing } from './Icon'
 import { IconVariables } from './iconVariables'
-import { CSSProperties } from '../../../node_modules/@types/react'
+import { CSSProperties } from 'react'
 
 export interface IconRulesParams {
-  props: IconProps
+  props: any
   variables: IconVariables
 }
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,28 +1,13 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { ReactNode } from 'react'
+import React from 'react'
 
 import { AutoControlledComponent, childrenExist, customPropTypes } from '../../lib'
 import MenuItem from './MenuItem'
 import menuRules from './menuRules'
 import menuVariables from './menuVariables'
 
-export type MenuType = 'primary' | 'secondary'
-export type MenuShape = 'pills' | 'pointing' | 'underlined'
-
-export interface IMenuProps {
-  as?: string
-  activeIndex?: number | string
-  children?: ReactNode
-  className?: string
-  defaultActiveIndex?: number | string
-  items?: any
-  shape?: MenuShape
-  type?: MenuType
-  vertical?: boolean
-}
-
-class Menu extends AutoControlledComponent<IMenuProps, any> {
+class Menu extends AutoControlledComponent<any, any> {
   static displayName = 'Menu'
 
   static className = 'ui-menu'

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,29 +1,14 @@
 import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { ReactNode } from 'react'
+import React from 'react'
 
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
-
-import { MenuType, MenuShape } from './Menu'
 
 import menuItemRules from './menuItemRules'
 import menuVariables from './menuVariables'
 
-export interface IMenuItemProps {
-  active?: boolean
-  as?: string
-  children?: ReactNode
-  className?: string
-  content?: ReactNode
-  index?: number
-  onClick?: (any, IMenuItemProps) => void
-  shape?: MenuShape
-  type?: MenuType
-  vertical?: boolean
-}
-
-class MenuItem extends UIComponent<IMenuItemProps, any> {
+class MenuItem extends UIComponent<any, any> {
   static displayName = 'MenuItem'
 
   static className = 'ui-menu__item'

--- a/src/components/Menu/menuItemRules.ts
+++ b/src/components/Menu/menuItemRules.ts
@@ -1,12 +1,11 @@
 import { pxToRem } from '../../lib'
-import { IMenuItemProps } from './MenuItem'
 
 const underlinedItem = (color: string) => ({
   borderBottom: `solid 5px ${color}`,
   transition: 'color .1s ease',
 })
 
-const itemSeparator = ({ props, variables }: { props: IMenuItemProps; variables: any }) => {
+const itemSeparator = ({ props, variables }) => {
   const { active, shape, type, vertical } = props
   return {
     ...((!shape || shape === 'pointing') && {
@@ -31,7 +30,7 @@ const itemSeparator = ({ props, variables }: { props: IMenuItemProps; variables:
 }
 
 export default {
-  root: ({ props, variables }: { props: IMenuItemProps; variables: any }) => {
+  root: ({ props, variables }) => {
     const { active, shape, type } = props
     return {
       color: variables.defaultColor,

--- a/src/components/Menu/menuRules.ts
+++ b/src/components/Menu/menuRules.ts
@@ -1,12 +1,11 @@
 import { pxToRem } from '../../lib'
-import { IMenuProps } from './Menu'
 
 const solidBorder = (color: string) => ({
   border: `1px solid ${color}`,
 })
 
 export default {
-  root: ({ props, variables }: { props: IMenuProps; variables: any }) => {
+  root: ({ props, variables }) => {
     const { type, shape, vertical } = props
     return {
       display: 'flex',

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,30 +1,14 @@
 import PropTypes from 'prop-types'
 import React, { ReactNode } from 'react'
 
-import { childrenExist, customPropTypes, UIComponent, IRenderResultConfig } from '../../lib'
+import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 import textRules from './textRules'
 import textVariables from './textVariables'
-
-export type ITextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2x' | '3x' | '4x'
-
-export interface ITextProps {
-  as?: string
-  atMention?: boolean
-  className?: string
-  content?: ReactNode
-  disabled?: boolean
-  error?: boolean
-  size?: ITextSize
-  important?: boolean
-  success?: boolean
-  timestamp?: boolean
-  truncated?: boolean
-}
 
 /**
  * A component containing text
  */
-class Text extends UIComponent<ITextProps, {}> {
+class Text extends UIComponent<any, any> {
   static className = 'ui-text'
 
   static propTypes = {
@@ -84,7 +68,7 @@ class Text extends UIComponent<ITextProps, {}> {
 
   static variables = textVariables
 
-  renderComponent({ ElementType, classes, rest }: IRenderResultConfig<ITextProps>): ReactNode {
+  renderComponent({ ElementType, classes, rest }): ReactNode {
     const { children, content } = this.props
     return (
       <ElementType {...rest} className={classes.root}>

--- a/src/components/Text/textRules.ts
+++ b/src/components/Text/textRules.ts
@@ -25,10 +25,9 @@ import {
 import { Sizes } from '../../lib/enums'
 import { truncateStyle } from '../../styles/customCSS'
 import { ITextVariables } from './textVariables'
-import { ITextProps } from './Text'
 
 export interface TextRulesParams {
-  props: ITextProps
+  props: any
   variables: ITextVariables
 }
 


### PR DESCRIPTION
# Removing components interfaces

This PRs is introduced in order to remove the already created interfaces for the component's prop, as discussed in the PR: https://github.com/stardust-ui/react/pull/33 This is done in order to avoid having to add properties that are not in the interface, like the variables, styles and other HTML props, once they are used.