### PR TITLE
fix(docs): styling variables pane

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -535,7 +535,9 @@ class ComponentExample extends React.PureComponent<IComponentExampleProps, IComp
         </Divider>
         <Provider.Consumer
           render={({ siteVariables }) => {
-            const variablesFilename = `./${displayName}/${_.camelCase(displayName)}Variables.ts`
+            const variablesFilename = `./components/${displayName}/${_.camelCase(
+              displayName,
+            )}Variables.ts`
             const hasVariablesFile = _.includes(variablesContext.keys(), variablesFilename)
 
             if (!hasVariablesFile) {

--- a/docs/src/utils/variablesContext.ts
+++ b/docs/src/utils/variablesContext.ts
@@ -1,6 +1,6 @@
 /**
  * Get the Webpack Context for all src component variables.
  */
-const variablesContext = require.context('src/components/', true, /\w+Variables\.ts$/)
+const variablesContext = require.context('src/themes/teams', true, /\w+Variables\.ts$/)
 
 export default variablesContext


### PR DESCRIPTION
# Problem

Currently, after latest theming changes, for all the components we have the following problem - **_irregardless of whether there are any variables defined for the component or not_**:

![image](https://user-images.githubusercontent.com/9024564/43906264-209045ea-9bf3-11e8-82cd-caad55689610.png)

So, essentially, variables-based styling is broken for docs.

# Short-term solution

Is provided by means of this PR - essentially, it is about adjusting the paths used. While it will fix this functionality (and unblock development process for certain components where visual experiments are critical), there are, however, some rough point related to that (see the next section).

# Long-term solution

We should carefully think whether we should introduce default variables as part of some team - essentially, it seems to be wrong to define data that defines component's interface (such as its variables) somewhere other than component's directory. 

My thought on this is that we should define default ones in the same directory where component resides (as it was before), due to this piece of data is critically necessary
- to define component's styling interface (that will be subsequently **_consumed_** by themes, docs, anything)
- to define critical pieces of data that are necessary to provide base component's look. This thing should be unsplittable from the component itself, because it makes component to be an independent unit. Now, in contrast, we have the following story for the component's file:

```js
// !! what it this directory will be moved to other place? other module? it will break component then.
import variables from '../themes/FooComponent/variables' // 

...
```

**_The same story applies for `styles` as well_** - base ones should be placed alongside with `Component.tsx` in the component's directory.


