### PR TITLE
fix(menu): use Menu variables in MenuItem styles

### DIFF
--- a/src/themes/teams/componentVariables.ts
+++ b/src/themes/teams/componentVariables.ts
@@ -22,4 +22,6 @@ export { default as ListItem } from './components/List/listItemVariables'
 
 export { default as Menu } from './components/Menu/menuVariables'
 
+export { default as MenuItem } from './components/Menu/menuVariables'
+
 export { default as Text } from './components/Text/textVariables'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Menu

`MenuItem` reuses `Menu` variables. It has always been that way but new theming broke it.

### TODO

- [x] Conformance test
- [ ] Update the CHANGELOG.md
