### PR TITLE
[POC] Render MenuItem as li > button

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -93,7 +93,7 @@ class MenuItem extends UIComponent<any, any> {
         {childrenExist(children) ? (
           children
         ) : (
-          <a
+          <button
             className={cx('ui-menu__item__anchor', classes.anchor)}
             onClick={this.handleClick}
             {...accessibility.attributes.anchor}
@@ -103,7 +103,7 @@ class MenuItem extends UIComponent<any, any> {
                 defaultProps: { xSpacing: !!content ? 'after' : 'none' },
               })}
             {content}
-          </a>
+          </button>
         )}
       </ElementType>
     )

--- a/src/themes/teams/componentVariables.ts
+++ b/src/themes/teams/componentVariables.ts
@@ -22,4 +22,6 @@ export { default as ListItem } from './components/List/listItemVariables'
 
 export { default as Menu } from './components/Menu/menuVariables'
 
+export { default as MenuItem } from './components/Menu/menuVariables'
+
 export { default as Text } from './components/Text/textVariables'

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -34,6 +34,14 @@ const itemSeparator = ({ props, variables }: { props: any; variables }): ICSSInJ
   }
 }
 
+const linkAsButtonExperiment: ICSSInJSStyle = {
+  background: 'none',
+  border: 'none',
+  textAlign: 'left',
+  width: '100%',
+  lineHeight: 1,
+}
+
 const menuItemStyles = {
   root: ({ props, variables }: { props: any; variables: IMenuVariables }): ICSSInJSStyle => {
     const { active, icons, shape, type, vertical } = props
@@ -130,6 +138,7 @@ const menuItemStyles = {
     return {
       color: 'inherit',
       display: 'block',
+      ...linkAsButtonExperiment,
       ...(shape === 'underlined'
         ? { padding: `0 0 ${pxToRem(8)} 0` }
         : { padding: `${pxToRem(14)} ${pxToRem(18)}` }),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Menu

**!!! DO NOT MERGE !!!**

For accessibility reasons, Menu renders as `ul > li > a` with `onClick` handler on `a`, see #44.
This still does not work as expected, see #61.

This is a Proof of Concept which renders the menu as `ul > li > button` to test if it helps with the accessibility.

There should be no visual regression, however UTs are failing at the moment.

### TODO

- [ ] Conformance test
- [ ] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [ ] Update the CHANGELOG.md
