### PR TITLE
test: add create react app project test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,5 +50,8 @@ jobs:
           name: Report coverage
           command: bash <(curl -s https://codecov.io/bash)
       - run:
+          name: Project Tests
+          command: yarn test:projects:cra-ts
+      - run:
           name: Visual Tests
           command: yarn test:visual

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ docs/dist/
 dll/
 node_modules/
 .vscode/
+
+test/projects/

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,4 +14,6 @@ docs/src/componentMenu.json
 docs/src/exampleMenus
 docs/dist/
 
+test/projects/
+
 package.json

--- a/build/gulp/sh.ts
+++ b/build/gulp/sh.ts
@@ -1,21 +1,25 @@
 import { spawn } from 'child_process'
 
-const sh = (command, cb) => {
-  const [cmd, ...args] = command.split(' ')
+const sh = (command: string) => {
+  return new Promise((resolve, reject) => {
+    const [cmd, ...args] = command.split(' ')
 
-  const options = {
-    cwd: process.cwd(),
-    env: process.env,
-    stdio: 'inherit',
-    shell: true,
-  }
+    const options = {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: [0, 1, 2],
+      shell: true,
+    }
 
-  const child = spawn(cmd, args, options)
+    const child = spawn(cmd, args, options)
 
-  child.on('close', code => {
-    if (code === 0) return cb()
+    child.on('close', code => {
+      if (code === 0) {
+        resolve()
+      }
 
-    cb(new Error(`child process exited with code ${code}`))
+      reject(new Error(`child process exited with code ${code}`))
+    })
   })
 }
 

--- a/build/gulp/tasks/docs.ts
+++ b/build/gulp/tasks/docs.ts
@@ -110,11 +110,10 @@ task('build:docs:images', () =>
 task('build:docs:toc', () =>
   src(markdownSrc, { since: lastRun('build:docs:toc') }).pipe(
     through2.obj((file, enc, done) => {
-      sh(`doctoc ${file.path} --github --maxlevel 4`, err => {
-        if (err) return done(err)
-
-        sh(`git add ${file.path}`, done)
-      })
+      sh(`doctoc ${file.path} --github --maxlevel 4`)
+        .then(() => sh(`git add ${file.path}`))
+        .then(done)
+        .catch(done)
     }),
   ),
 )
@@ -161,7 +160,9 @@ task(
 
 task('deploy:docs', cb => {
   const relativePath = path.relative(process.cwd(), paths.docsDist())
-  sh(`gh-pages -d ${relativePath} -m "deploy docs [ci skip]"`, cb)
+  sh(`gh-pages -d ${relativePath} -m "deploy docs [ci skip]"`)
+    .then(cb)
+    .catch(cb)
 })
 
 // ----------------------------------------

--- a/build/gulp/tasks/screener.ts
+++ b/build/gulp/tasks/screener.ts
@@ -10,12 +10,16 @@ const { paths } = config
 // ----------------------------------------
 
 task('screener:runner', cb => {
-  sh(`screener-runner --conf ${paths.base('screener.config.js')}`, err => {
-    cb(err)
-
-    // kill the server
-    process.exit(err ? 1 : 0)
-  })
+  // kill the server when done
+  sh(`screener-runner --conf ${paths.base('screener.config.js')}`)
+    .then(() => {
+      cb()
+      process.exit(0)
+    })
+    .catch(err => {
+      cb(err)
+      process.exit(1)
+    })
 })
 
 // ----------------------------------------

--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -31,19 +31,21 @@ task('clean:test:projects:cra-ts', cb => {
 //  - Link our package
 //  - Try and run a build
 task('build:test:projects:cra-ts', () => {
-  const appTSX = `import * as React from 'react';
-import { Avatar, Button, Header, Image, Input } from '@stardust-ui/react';
+  const appTSX = `import { Avatar, Button, Header, Image, Input, Provider, themes } from '@stardust-ui/react';
+import * as React from 'react';
 
 class App extends React.Component {
   public render() {
     return (
-      <div>
-        <Avatar src="//placehold.it" />
-        <Button content="Click me" />
-        <Header content="This is " />
-        <Image src="//placehold.it" />
-        <Input placeholder="Type here" />
-      </div>
+      <Provider theme={themes.teams}>
+        <div>
+          <Avatar src="//placehold.it" />
+          <Button content="Click me" />
+          <Header content="This is " />
+          <Image src="//placehold.it" />
+          <Input placeholder="Type here" />
+        </div>
+      </Provider>
     );
   }
 }

--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -2,6 +2,8 @@ import * as fs from 'fs'
 import { task, series } from 'gulp'
 import * as rimraf from 'rimraf'
 import sh from '../sh'
+import * as mkdirp from 'mkdirp'
+
 import config from '../../../config'
 
 const pkg = require('../../../package.json')
@@ -61,6 +63,8 @@ export default App;
   const runInTSApp = cmd => () => sh(`cd ${tsAppPath()} && ${cmd}`)
 
   return Promise.resolve()
+    .then(() => mkdirp.sync(projectsPath()))
+
     .then(log('Creating React App'))
     .then(runInProjects(`create-react-app ${tsAppPath()} --scripts-version=react-scripts-ts`))
 

--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -1,0 +1,93 @@
+import * as fs from 'fs'
+import { task, series } from 'gulp'
+import * as rimraf from 'rimraf'
+import sh from '../sh'
+import config from '../../../config'
+
+const pkg = require('../../../package.json')
+
+const { paths } = config
+
+const projectsPath = (...args) => paths.test('projects', ...args)
+const tsAppPath = (...args) => projectsPath('cra-ts', ...args)
+
+// ----------------------------------------
+// Clean
+// ----------------------------------------
+
+task('clean:test:projects:cra-ts', cb => {
+  rimraf(tsAppPath(), cb)
+})
+
+// ----------------------------------------
+// Build
+// ----------------------------------------
+
+// TS Project:
+//  - Create a new react test app
+//  - Update the App.tsx to include some stardust imports
+//  - Link our package
+//  - Try and run a build
+task('build:test:projects:cra-ts', () => {
+  const appTSX = `import * as React from 'react';
+import { Avatar, Button, Header, Image, Input } from '@stardust-ui/react';
+
+class App extends React.Component {
+  public render() {
+    return (
+      <div>
+        <Avatar src="//placehold.it" />
+        <Button content="Click me" />
+        <Header content="This is " />
+        <Image src="//placehold.it" />
+        <Input placeholder="Type here" />
+      </div>
+    );
+  }
+}
+
+export default App;
+`
+
+  const log = (msg: string) => arg => {
+    console.log()
+    console.log('='.repeat(80))
+    console.log('CRA TS:', msg)
+    console.log('='.repeat(80))
+    return arg
+  }
+
+  const runInProjects = cmd => () => sh(`cd ${projectsPath()} && ${cmd}`)
+  const runInTSApp = cmd => () => sh(`cd ${tsAppPath()} && ${cmd}`)
+
+  return Promise.resolve()
+    .then(log('Creating React App'))
+    .then(runInProjects(`create-react-app ${tsAppPath()} --scripts-version=react-scripts-ts`))
+
+    .then(log('Updating App.tsx'))
+    .then(() => {
+      fs.writeFileSync(tsAppPath('src', 'App.tsx'), appTSX)
+    })
+
+    .then(log('Building Stardust'))
+    .then(() => sh('yarn build:dist'))
+
+    .then(log('Copying dist to React App'))
+    .then(() => {
+      fs.linkSync(paths.dist(), tsAppPath('node_modules', pkg.name))
+    })
+
+    .then(log(`Linking ${pkg.name}`))
+    .then(runInTSApp(`yarn link ${pkg.name}`))
+
+    .then(log('Installing dependencies'))
+    .then(runInTSApp('yarn install'))
+
+    .then(log('Building!'))
+    .then(runInTSApp('yarn build'))
+})
+
+// ----------------------------------------
+// Test
+// ----------------------------------------
+task('test:projects:cra-ts', series('clean:test:projects:cra-ts', 'build:test:projects:cra-ts'))

--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -77,9 +77,6 @@ export default App;
       fs.linkSync(paths.dist(), tsAppPath('node_modules', pkg.name))
     })
 
-    .then(log(`Linking ${pkg.name}`))
-    .then(runInTSApp(`yarn link ${pkg.name}`))
-
     .then(log('Installing dependencies'))
     .then(runInTSApp('yarn install'))
 

--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -31,7 +31,16 @@ task('clean:test:projects:cra-ts', cb => {
 //  - Link our package
 //  - Try and run a build
 task('build:test:projects:cra-ts', () => {
-  const appTSX = `import { Avatar, Button, Header, Image, Input, Provider, themes } from '@stardust-ui/react';
+  const appTSX = `import {
+  Avatar,
+  Button,
+  Header,
+  Image,
+  Input,
+  Popup,
+  Provider,
+  themes
+} from '@stardust-ui/react';
 import * as React from 'react';
 
 class App extends React.Component {
@@ -39,6 +48,7 @@ class App extends React.Component {
     return (
       <Provider theme={themes.teams}>
         <div>
+          <Popup trigger={<Button content="Popup" />} content="Popup content" />
           <Avatar src="//placehold.it" />
           <Button content="Click me" />
           <Header content="This is " />

--- a/build/tsconfig.es.json
+++ b/build/tsconfig.es.json
@@ -1,10 +1,8 @@
 {
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
-    "module": "esnext"
-  },
-  "include": [
-    "../src",
-    "../types"
-  ]
+    "module": "esnext",
+    "target": "esnext",
+    "outDir": "../dist/es"
+  }
 }

--- a/config.ts
+++ b/config.ts
@@ -36,6 +36,7 @@ const paths = {
   docsDist: base.bind(null, envConfig.dir_docs_dist),
   docsSrc: base.bind(null, envConfig.dir_docs_src),
   umdDist: base.bind(null, envConfig.dir_umd_dist),
+  test: base.bind(null, 'test'),
 }
 
 const config = {

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -12,6 +12,7 @@ require('./build/gulp/tasks/docs')
 require('./build/gulp/tasks/generate')
 require('./build/gulp/tasks/screener')
 require('./build/gulp/tasks/git')
+require('./build/gulp/tasks/test-projects')
 
 // global tasks
 task('build', series('dll', parallel('dist', 'build:docs')))

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "leven": "^2.1.0",
     "lint-staged": "^7.0.2",
     "merge2": "^1.2.2",
+    "mkdirp": "^0.5.1",
     "normalize.css": "^8.0.0",
     "prettier": "1.12.0",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pretest": "yarn satisfied && gulp build:docs:docgen",
     "test": "cross-env NODE_ENV=test jest --coverage",
     "test:visual": "gulp screener",
+    "test:projects:cra-ts": "gulp test:projects:cra-ts",
     "test:watch": "yarn test --watchAll",
     "generate:component": "gulp generate:component"
   },
@@ -105,6 +106,7 @@
     "connect-history-api-fallback": "^1.3.0",
     "copy-to-clipboard": "^3.0.8",
     "copy-webpack-plugin": "^4.5.2",
+    "create-react-app": "^1.5.2",
     "cross-env": "^5.1.4",
     "debug": "^3.0.1",
     "doctoc": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5502,9 +5502,15 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5502,13 +5502,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@~0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.1:
+mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,8 +47,8 @@
     any-observable "^0.3.0"
 
 "@types/classnames@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.4.tgz#d3ee9ebf714aa34006707b8f4a58fd46b642305a"
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.6.tgz#dbe8a666156d556ed018e15a4c65f08937c3f628"
 
 "@types/gulp-load-plugins@^0.0.31":
   version "0.0.31"
@@ -70,35 +70,52 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
 
 "@types/jest@^23.1.0":
-  version "23.1.5"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.1.5.tgz#e31be003956e1fa8c860124d99bea9ae327ae37b"
+  version "23.3.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.2.tgz#07b90f6adf75d42c34230c026a2529e56c249dbb"
 
-"@types/node@*", "@types/node@^10.3.2":
+"@types/node@*":
   version "10.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
+
+"@types/node@^10.3.2":
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
 
 "@types/node@^8.0.19":
   version "8.10.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.24.tgz#302a8f0c00bd1bf364471b6687258617c5d410fc"
 
+"@types/prop-types@*":
+  version "15.5.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.0.6":
-  version "16.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
 "@types/react-router@^4.0.27":
-  version "4.0.27"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.27.tgz#553f54df7c4b09d6046b0201ce9b91c46b2940e3"
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.31.tgz#416bac49d746800810886c7b8582a622ed9604fc"
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.3.17":
+"@types/react@*":
   version "16.4.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
   dependencies:
+    csstype "^2.2.0"
+
+"@types/react@^16.3.17":
+  version "16.4.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.14.tgz#47c604c8e46ed674bbdf4aabf82b34b9041c6a04"
+  dependencies:
+    "@types/prop-types" "*"
     csstype "^2.2.0"
 
 "@types/through2@*":
@@ -803,6 +820,12 @@ binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
 
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  dependencies:
+    inherits "~2.0.0"
+
 bluebird@^3.0.5, bluebird@^3.3.3, bluebird@^3.4.1, bluebird@^3.4.7:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
@@ -975,6 +998,10 @@ buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
 
+buffer-from@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.2.tgz#15f4b9bcef012044df31142c14333caf6e0260d0"
+
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
@@ -1002,6 +1029,10 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
 
 bytes@2.3.0:
   version "2.3.0"
@@ -1592,6 +1623,21 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-app@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/create-react-app/-/create-react-app-1.5.2.tgz#2639e5d2f88e8777977beb6a8d9cbc04cf70091e"
+  dependencies:
+    chalk "^1.1.1"
+    commander "^2.9.0"
+    cross-spawn "^4.0.0"
+    envinfo "3.4.2"
+    fs-extra "^1.0.0"
+    hyperquest "^2.1.2"
+    semver "^5.0.3"
+    tar-pack "^3.4.0"
+    tmp "0.0.31"
+    validate-npm-package-name "^3.0.0"
+
 create-react-context@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
@@ -1605,6 +1651,13 @@ cross-env@^5.1.4:
   dependencies:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
+
+cross-spawn@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1995,7 +2048,7 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-duplexer2@0.0.2:
+duplexer2@0.0.2, duplexer2@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
   dependencies:
@@ -2110,6 +2163,14 @@ enhanced-resolve@^3.4.0:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+envinfo@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-3.4.2.tgz#f06648836155b81e1d7b4a1c3fca3f6b5f38789b"
+  dependencies:
+    minimist "^1.2.0"
+    os-name "^2.0.1"
+    which "^1.2.14"
 
 enzyme-adapter-react-16@^1.0.1:
   version "1.1.1"
@@ -2891,6 +2952,14 @@ fs-extra@^0.26.5:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+
 fs-extra@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
@@ -2940,6 +3009,23 @@ fsevents@^1.0.0, fsevents@^1.2.2, fsevents@^1.2.3:
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
+
+fstream-ignore@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
+  dependencies:
+    fstream "^1.0.0"
+    inherits "2"
+    minimatch "^3.0.0"
+
+fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
 
 function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
@@ -3611,6 +3697,14 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
+hyperquest@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/hyperquest/-/hyperquest-2.1.3.tgz#523127d7a343181b40bf324e231d2576edf52633"
+  dependencies:
+    buffer-from "^0.1.1"
+    duplexer2 "~0.0.2"
+    through2 "~0.6.3"
+
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -3679,7 +3773,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -5158,6 +5252,10 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+macos-release@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -5351,7 +5449,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5404,7 +5502,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5913,7 +6011,14 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
+os-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
+  dependencies:
+    macos-release "^1.0.0"
+    win-release "^1.0.0"
+
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -6631,7 +6736,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -6643,9 +6748,9 @@ read-pkg@^2.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@1.0, readable-stream@~1.0.17:
+readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17:
   version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -7001,7 +7106,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -7148,6 +7253,10 @@ semver-greatest-satisfied-range@^1.1.0:
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.0.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 send@0.16.2:
   version "0.16.2"
@@ -7673,6 +7782,27 @@ tapable@^0.2.5, tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
+tar-pack@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
+  dependencies:
+    debug "^2.2.0"
+    fstream "^1.0.10"
+    fstream-ignore "^1.0.5"
+    once "^1.3.3"
+    readable-stream "^2.1.4"
+    rimraf "^2.5.1"
+    tar "^2.2.1"
+    uid-number "^0.0.6"
+
+tar@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.2"
+    inherits "2"
+
 tar@^4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
@@ -7742,6 +7872,13 @@ through2@^2.0.0, through2@^2.0.3, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
+through2@~0.6.3:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -7769,6 +7906,12 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
+
+tmp@0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -8063,6 +8206,10 @@ uglifyjs-webpack-plugin@^0.4.6:
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
 
+uid-number@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -8291,6 +8438,12 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  dependencies:
+    builtins "^1.0.3"
 
 value-equal@^0.4.0:
   version "0.4.0"
@@ -8527,6 +8680,12 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
+win-release@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
+  dependencies:
+    semver "^5.0.1"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -8581,7 +8740,7 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
### Why?

We only test our components pre-distribution.  This test adds a test that consumes our package in a real project.  This allows us to catch errors that a user would see when building Stardust in their repo.

### How?

Local: `yarn test:projects:cra-ts`

CI: runs automatically

## What?

This PR adds a test that spins up a fresh React app using `create-react-app`.  It then runs a Stardust build, copies our `/dist` into the new React app and tries to compile a few components.

### Results

The current error we have in `0.5.1` is revealed:

```
node_modules/@types/react/index.d.ts(2432,13): error TS2717: Subsequent property
declarations must have the same type. Property 'time' must be of type
'DetailedHTMLProps<TimeHTMLAttributes<HTMLElement>, HTMLElement>', but here has type
'DetailedHTMLProps<TimeHTMLAttributes<HTMLElement>, HTMLElement>'.
```