### PR TITLE
fix(typings): theme.d.ts strongly typed definition fixed to support "strictNullChecks": true compiler option

### DIFF
--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -87,7 +87,7 @@ export type ComponentPartStyleFunction =
   | ((styleParam?: ComponentStyleFunctionParam) => ICSSInJSStyle)
   | undefined
 
-export type ComponentPartStyle = ComponentPartStyleFunction | ICSSInJSStyle | undefined
+export type ComponentPartStyle = ComponentPartStyleFunction | ICSSInJSStyle
 
 export interface IComponentPartStylesInput {
   [part: string]: ComponentPartStyle
@@ -102,7 +102,7 @@ export interface IComponentPartStylesPrepared {
 }
 
 export interface IComponentPartClasses {
-  [part: string]: string
+  [part: string]: string | undefined
 
   root?: string
 }


### PR DESCRIPTION
if a customer of the Stardust UI library consumes library with compiler option `strictNullChecks` is set to `true` then the following interface is having conflict, as there is a possibility that indexed property will have the name `root` which is already defined as nullable property `root?` and it conflicts with the definition.

![image](https://user-images.githubusercontent.com/5530260/44150119-9c281f48-a09e-11e8-8ad5-57b2fe64a05a.png)

