### PR TITLE
chore: add RTL support to visual testing

### DIFF
--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -12,13 +12,30 @@ import Router from './routes'
 // Rendering
 // ----------------------------------------
 
+const getUrlParams = (search = '') => {
+  const hashes = search.slice(search.indexOf('?') + 1).split('&')
+  return hashes.reduce((acc, hash) => {
+    // eslint-disable-next-line
+    const [key, val] = hash.split('=')
+    return {
+      ...acc,
+      [key]: decodeURIComponent(val),
+    }
+  }, {})
+}
+
+const rtl = getUrlParams(window.location.search)['rtl'] === 'true'
+
 const mountNode = document.createElement('div')
+if (rtl) {
+  mountNode.setAttribute('dir', 'rtl')
+}
 document.body.appendChild(mountNode)
 
 const render = NewApp =>
   ReactDOM.render(
     <AppContainer>
-      <Provider theme={theme} staticStyles={staticStyles} fontFaces={fontFaces}>
+      <Provider theme={{ ...theme, ...{ rtl } }} staticStyles={staticStyles} fontFaces={fontFaces}>
         <NewApp />
       </Provider>
     </AppContainer>,

--- a/screener.config.js
+++ b/screener.config.js
@@ -26,15 +26,21 @@ const screenerConfig = {
   },
 
   // screenshot every example in maximized mode
-  states: glob
-    .sync('docs/src/examples/**/*.tsx', { ignore: ['**/index.tsx', '**/*.knobs.tsx'] })
-    .map(examplePath => {
+  states: _.flatMap(
+    glob.sync('docs/src/examples/**/*.tsx', { ignore: ['**/index.tsx', '**/*.knobs.tsx'] }),
+    examplePath => {
       const { name: nameWithoutExtension, base: nameWithExtension } = path.parse(examplePath)
 
-      return {
-        url: `http://localhost:8080/maximize/${_.kebabCase(nameWithoutExtension)}`,
-        name: nameWithExtension,
-      }
+      return [
+        {
+          url: `http://localhost:8080/maximize/${_.kebabCase(nameWithoutExtension)}`,
+          name: nameWithExtension,
+        },
+        {
+          url: `http://localhost:8080/maximize/${_.kebabCase(nameWithoutExtension)}?rtl=true`,
+          name: `${nameWithExtension}-rtl`,
+        },
+      ]
     }),
 }
 

--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -3,7 +3,12 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import { Provider as RendererProvider, ThemeProvider } from 'react-fela'
 
-import { felaRenderer as felaLtrRenderer, mergeThemes, toCompactArray } from '../../lib'
+import {
+  felaRenderer as felaLtrRenderer,
+  felaRtlRenderer,
+  mergeThemes,
+  toCompactArray,
+} from '../../lib'
 import {
   FontFaces,
   IThemePrepared,
@@ -58,7 +63,7 @@ class Provider extends React.Component<IProviderProps, any> {
 
   static Consumer = ProviderConsumer
 
-  renderStaticStyles = () => {
+  renderStaticStyles = renderer => {
     // RTL WARNING
     // This function sets static styles which are global and renderer agnostic
     // With current implementation, static styles cannot differ between LTR and RTL
@@ -70,7 +75,7 @@ class Provider extends React.Component<IProviderProps, any> {
 
     const renderObject = (object: StaticStyleObject) => {
       _.forEach(object, (style, selector) => {
-        felaLtrRenderer.renderStatic(style, selector)
+        renderer.renderStatic(style, selector)
       })
     }
 
@@ -78,7 +83,7 @@ class Provider extends React.Component<IProviderProps, any> {
 
     staticStylesArr.forEach((staticStyle: StaticStyle) => {
       if (typeof staticStyle === 'string') {
-        felaLtrRenderer.renderStatic(staticStyle)
+        renderer.renderStatic(staticStyle)
       } else if (_.isPlainObject(staticStyle)) {
         renderObject(staticStyle as StaticStyleObject)
       } else if (_.isFunction(staticStyle)) {
@@ -91,7 +96,7 @@ class Provider extends React.Component<IProviderProps, any> {
     })
   }
 
-  renderFontFaces = () => {
+  renderFontFaces = renderer => {
     // RTL WARNING
     // This function sets static styles which are global and renderer agnostic
     // With current implementation, static styles cannot differ between LTR and RTL
@@ -105,7 +110,7 @@ class Provider extends React.Component<IProviderProps, any> {
       if (!_.isPlainObject(font)) {
         throw new Error(`fontFaces must be objects, got: ${typeof font}`)
       }
-      felaLtrRenderer.renderFont(font.name, font.path, font.style)
+      renderer.renderFont(font.name, font.path, font.style)
     }
 
     fontFaces.forEach(fontObject => {
@@ -114,8 +119,10 @@ class Provider extends React.Component<IProviderProps, any> {
   }
 
   componentDidMount() {
-    this.renderStaticStyles()
-    this.renderFontFaces()
+    const { theme } = this.props
+    const renderer = theme && theme.rtl ? felaRtlRenderer : felaLtrRenderer
+    this.renderStaticStyles(renderer)
+    this.renderFontFaces(renderer)
   }
 
   render() {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
Adding `?rtl=true` to the URL for maximized URL, renders the example as RTL (`dir=rtl` + RTL styles).

For each example, Screener renders both LTR and RTL views of the example.