### PR TITLE
fix: typings in dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 
 - Fix `MenuItem` broken styles @miroslavstastny ([#94](https://github.com/stardust-ui/react/pull/94))
+- Fix wrong typings generated for dist @kuzhelov ([#99](https://github.com/stardust-ui/react/pull/99))
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/build/gulp/plugins/gulp-use-relative-import-paths.ts
+++ b/build/gulp/plugins/gulp-use-relative-import-paths.ts
@@ -1,0 +1,64 @@
+import * as path from 'path'
+const g = require('gulp-load-plugins')()
+
+type BasePathProvider = {
+  base: (relativePath: string) => string
+}
+
+type Config = {
+  forImportStartsWith: string
+  paths: BasePathProvider
+}
+
+type Transform<From, To> = (from: From) => To
+
+const replace = (line: string, what: RegExp, how: Transform<RegExpExecArray, string>) => {
+  let replacedLine = line
+
+  let match = what.exec(line)
+  while (match != null) {
+    const replacement = how(match)
+    replacedLine = replacedLine.replace(match[0], replacement)
+    match = what.exec(line)
+  }
+
+  return replacedLine
+}
+
+const replaceInlinedImportPaths = (content: string, how: Transform<string, string>) => {
+  const InlinedImportRegexp = /import\(['"]([^.].*?)['"]\)/g
+
+  return content
+    .split('\n')
+    .map(line =>
+      replace(line, InlinedImportRegexp, match => {
+        const originalImportStatement = match[0]
+        const originalImportPath = match[1]
+
+        if (!originalImportPath) {
+          return originalImportStatement
+        }
+
+        const modifiedImportPath = how(originalImportPath)
+        return originalImportStatement.replace(originalImportPath, modifiedImportPath)
+      }),
+    )
+    .join('\n')
+}
+
+export default ({ forImportStartsWith, paths }: Config) =>
+  g.transform('utf8', (content, file) => {
+    const originalSrcFilePath = file.path
+
+    const contentWithReplacement = replaceInlinedImportPaths(content, importPath => {
+      if (forImportStartsWith && !importPath.startsWith(forImportStartsWith)) {
+        return importPath
+      }
+
+      const absoluteSrcImportPath = paths.base(importPath)
+
+      return path.relative(path.dirname(originalSrcFilePath), absoluteSrcImportPath)
+    })
+
+    return contentWithReplacement
+  })

--- a/build/gulp/plugins/gulp-use-relative-import-paths.ts
+++ b/build/gulp/plugins/gulp-use-relative-import-paths.ts
@@ -61,9 +61,7 @@ export default ({ forImportStartsWith, paths }: Config) =>
         absoluteSrcImportPath,
       )
 
-      return path.dirname(relativeImportPath) === '.' && !relativeImportPath.startsWith('.')
-        ? `./${relativeImportPath}`
-        : relativeImportPath
+      return relativeImportPath.startsWith('.') ? relativeImportPath : `./${relativeImportPath}`
     })
 
     return contentWithReplacement

--- a/build/gulp/plugins/gulp-use-relative-import-paths.ts
+++ b/build/gulp/plugins/gulp-use-relative-import-paths.ts
@@ -56,8 +56,14 @@ export default ({ forImportStartsWith, paths }: Config) =>
       }
 
       const absoluteSrcImportPath = paths.base(importPath)
+      const relativeImportPath = path.relative(
+        path.dirname(originalSrcFilePath),
+        absoluteSrcImportPath,
+      )
 
-      return path.relative(path.dirname(originalSrcFilePath), absoluteSrcImportPath)
+      return path.dirname(relativeImportPath) === '.' && !relativeImportPath.startsWith('.')
+        ? `./${relativeImportPath}`
+        : relativeImportPath
     })
 
     return contentWithReplacement

--- a/build/gulp/tasks/dist.ts
+++ b/build/gulp/tasks/dist.ts
@@ -8,6 +8,7 @@ import config from '../../../config'
 const { paths } = config
 const g = require('gulp-load-plugins')()
 const { log, PluginError } = g.util
+import gulpUseRelativeImportPaths from '../plugins/gulp-use-relative-import-paths'
 
 // ----------------------------------------
 // Clean
@@ -29,7 +30,9 @@ task('build:dist:commonjs', () => {
   const types = src(paths.base('types/**'))
 
   return merge2([
-    dts.pipe(dest(paths.dist('commonjs'))),
+    dts
+      .pipe(gulpUseRelativeImportPaths({ forImportStartsWith: 'src', paths }))
+      .pipe(dest(paths.dist('commonjs'))),
     js.pipe(dest(paths.dist('commonjs'))),
     types.pipe(dest(paths.dist('types'))),
   ])
@@ -44,7 +47,9 @@ task('build:dist:es', () => {
   const types = src(paths.base('types/**'))
 
   return merge2([
-    dts.pipe(dest(paths.dist('es'))),
+    dts
+      .pipe(gulpUseRelativeImportPaths({ forImportStartsWith: 'src', paths }))
+      .pipe(dest(paths.dist('es'))),
     js.pipe(dest(paths.dist('es'))),
     types.pipe(dest(paths.dist('types'))),
   ])

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "gulp-plumber": "^1.2.0",
     "gulp-rename": "^1.3.0",
     "gulp-replace": "^1.0.0",
+    "gulp-transform": "^3.0.5",
     "gulp-typescript": "^5.0.0-alpha.1",
     "gulp-util": "^3.0.8",
     "html-webpack-plugin": "^2.30.1",

--- a/src/components/Provider/ProviderConsumer.tsx
+++ b/src/components/Provider/ProviderConsumer.tsx
@@ -2,20 +2,16 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import { FelaTheme } from 'react-fela'
 
-// TODO: TypeScript incorrectly compiles typings defined in component files
-// TODO: see: https://github.com/stardust-ui/react/issues/87#issuecomment-412657622
-//
-// import { IThemePrepared } from '../../../types/theme'
-//
-// export interface IProviderConsumerProps {
-//   render: (theme: IThemePrepared) => React.ReactNode
-// }
+import { IThemePrepared } from '../../../types/theme'
+
+export interface IProviderConsumerProps {
+  render: (theme: IThemePrepared) => React.ReactNode
+}
 
 /**
  * The Provider's Consumer is for accessing the theme.
  */
-// TODO: restore provider consumer interface once above bug is fixed
-const ProviderConsumer: React.SFC<any> = props => <FelaTheme {...props} />
+const ProviderConsumer: React.SFC<IProviderConsumerProps> = props => <FelaTheme {...props} />
 
 ProviderConsumer.propTypes = {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,15 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gulp-util@*":
+  version "3.0.34"
+  resolved "https://registry.yarnpkg.com/@types/gulp-util/-/gulp-util-3.0.34.tgz#d1291ebf706d93f46eb8df11344bbfd96247697e"
+  dependencies:
+    "@types/node" "*"
+    "@types/through2" "*"
+    "@types/vinyl" "*"
+    chalk "^2.2.0"
+
 "@types/history@*":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
@@ -91,6 +100,18 @@
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
   dependencies:
     csstype "^2.2.0"
+
+"@types/through2@*":
+  version "2.0.33"
+  resolved "https://registry.yarnpkg.com/@types/through2/-/through2-2.0.33.tgz#1ff2e88a100dfb5b140e7bb98791f1194400d131"
+  dependencies:
+    "@types/node" "*"
+
+"@types/vinyl@*":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.2.tgz#4f3b8dae8f5828d3800ef709b0cff488ee852de3"
+  dependencies:
+    "@types/node" "*"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -1064,7 +1085,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.2.0, chalk@^2.3.0, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -3113,6 +3134,15 @@ gulp-replace@^1.0.0:
     istextorbinary "2.2.1"
     readable-stream "^2.0.1"
     replacestream "^4.0.0"
+
+gulp-transform@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/gulp-transform/-/gulp-transform-3.0.5.tgz#6972674a77dc30672d6b7746a173ef0506fe37b2"
+  dependencies:
+    "@types/gulp-util" "*"
+    "@types/node" "*"
+    gulp-util "^3.0.8"
+    tslib "^1.7.1"
 
 gulp-typescript@^5.0.0-alpha.1:
   version "5.0.0-alpha.3"


### PR DESCRIPTION
Proposed solution to fix #87.

The idea, essentially, is to replace inlined imports with absolute typing file path on its relative analog (the one that we would like to obtain from TS compiler but cannot do that) - during build process as separate stage added into gulp's pipeline.

## Benefits
We won't need to require devs to do this unintuitive hack anymore to circumvent problem of TS transpiling

```ts
public static defaultProps = {
    ...
    // without explicit 'as' cast to DefaultBehavior's type (!!) this will introduce aforementioned problem for generated TS definitions
    accessibility: DefaultBehavior as Accessibility,
}
```


## Design priorities
- being easily removable (in case if better fix will be introduced)
- affect only those parts that we pretty sure are problematic
- introduce robust logic