### PR TITLE
chore: add visual-test route

### DIFF
--- a/docs/src/components/VisualTestLayout.tsx
+++ b/docs/src/components/VisualTestLayout.tsx
@@ -1,0 +1,56 @@
+import * as _ from 'lodash/fp'
+import PropTypes from 'prop-types'
+import * as React from 'react'
+
+import { exampleContext, parseExamplePath } from 'docs/src/utils'
+import Provider from 'src/components/Provider/Provider'
+import PageNotFound from '../views/PageNotFound'
+
+const allExamplePaths = exampleContext.keys()
+
+const VisualTestLayout: any = props => {
+  const { match } = props
+  const displayName = _.startCase(match.params.kebabComponentName).replace(/ /g, '')
+
+  const componentExamplePaths = _.filter(path => {
+    if (/index\.tsx$/.test(path)) return false
+
+    return displayName === parseExamplePath(path).displayName
+  }, allExamplePaths)
+
+  if (_.isEmpty(componentExamplePaths)) return <PageNotFound />
+
+  return componentExamplePaths.map(path => {
+    const ExampleComponent = exampleContext(path).default
+    const { exampleName } = parseExamplePath(path)
+
+    return (
+      <div key={path} style={{ padding: '1rem', margin: '1rem', border: '2px solid black' }}>
+        <h3>{exampleName}</h3>
+
+        <h3>Default</h3>
+        <ExampleComponent />
+
+        <h3>Default - RTL</h3>
+        <Provider theme={{ rtl: true }}>
+          <div dir="rtl">
+            <ExampleComponent />
+          </div>
+        </Provider>
+      </div>
+    )
+  })
+}
+
+VisualTestLayout.propTypes = {
+  children: PropTypes.node,
+  history: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      displayName: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+}
+
+export default VisualTestLayout

--- a/docs/src/components/VisualTestLayout.tsx
+++ b/docs/src/components/VisualTestLayout.tsx
@@ -8,6 +8,13 @@ import PageNotFound from '../views/PageNotFound'
 
 const allExamplePaths = exampleContext.keys()
 
+const exampleStyle = {
+  padding: '1rem',
+  margin: '1rem',
+  height: '100vh',
+  border: '2px solid black',
+}
+
 const VisualTestLayout: any = props => {
   const { match } = props
   const displayName = _.startCase(match.params.kebabComponentName).replace(/ /g, '')
@@ -25,18 +32,20 @@ const VisualTestLayout: any = props => {
     const { exampleName } = parseExamplePath(path)
 
     return (
-      <div key={path} style={{ padding: '1rem', margin: '1rem', border: '2px solid black' }}>
-        <h3>{exampleName}</h3>
+      <div key={path}>
+        <div style={exampleStyle}>
+          <h3>{exampleName} - Default Theme, LTR</h3>
+          <ExampleComponent />
+        </div>
 
-        <h3>Default</h3>
-        <ExampleComponent />
-
-        <h3>Default - RTL</h3>
-        <Provider theme={{ rtl: true }}>
-          <div dir="rtl">
-            <ExampleComponent />
-          </div>
-        </Provider>
+        <div style={exampleStyle}>
+          <h3>{exampleName} - Default Theme, RTL</h3>
+          <Provider theme={{ rtl: true }}>
+            <div dir="rtl">
+              <ExampleComponent />
+            </div>
+          </Provider>
+        </div>
       </div>
     )
   })

--- a/docs/src/routes.tsx
+++ b/docs/src/routes.tsx
@@ -7,11 +7,13 @@ import DocsRoot from './components/DocsRoot'
 
 import Introduction from './views/Introduction'
 import PageNotFound from './views/PageNotFound'
+import VisualTestLayout from './components/VisualTestLayout'
 
 const Router = () => (
   <BrowserRouter basename={__BASENAME__}>
     <Switch>
       <Route exact path="/maximize/:exampleName" component={ExternalExampleLayout} />
+      <Route exact path="/visual-test/:kebabComponentName" component={VisualTestLayout} />
       <Switch>
         <DocsLayout exact path="/" component={Introduction} />
         <DocsLayout exact path="/:type/:name" component={DocsRoot} sidebar />

--- a/screener.config.js
+++ b/screener.config.js
@@ -29,11 +29,11 @@ const screenerConfig = {
   states: glob
     .sync('docs/src/examples/**/*.tsx', { ignore: ['**/index.tsx', '**/*.knobs.tsx'] })
     .map(examplePath => {
-      const { name: nameWithoutExtension, base: nameWithExtension } = path.parse(examplePath)
+      const displayName = path.basename(path.dirname(path.dirname(examplePath)))
 
       return {
-        url: `http://localhost:8080/maximize/${_.kebabCase(nameWithoutExtension)}`,
-        name: nameWithExtension,
+        url: `http://localhost:8080/visual-test/${_.kebabCase(displayName)}`,
+        name: displayName,
       }
     }),
 }

--- a/screener.config.js
+++ b/screener.config.js
@@ -26,16 +26,14 @@ const screenerConfig = {
   },
 
   // screenshot every example in maximized mode
-  states: glob
-    .sync('docs/src/examples/**/*.tsx', { ignore: ['**/index.tsx', '**/*.knobs.tsx'] })
-    .map(examplePath => {
-      const displayName = path.basename(path.dirname(path.dirname(examplePath)))
+  states: glob.sync('src/components/*').map(componentPath => {
+    const displayName = path.basename(componentPath)
 
-      return {
-        url: `http://localhost:8080/visual-test/${_.kebabCase(displayName)}`,
-        name: displayName,
-      }
-    }),
+    return {
+      url: `http://localhost:8080/visual-test/${_.kebabCase(displayName)}`,
+      name: displayName,
+    }
+  }),
 }
 
 if (process.env.CI) {

--- a/src/lib/mergeThemes.ts
+++ b/src/lib/mergeThemes.ts
@@ -56,6 +56,8 @@ export const mergeComponentVariables = (
   const initial = siteVariables => callable(target)(siteVariables)
 
   return sources.reduce<ComponentVariablesPrepared>((acc, next) => {
+    if (!next) return acc
+
     return siteVariables => ({
       ...acc(siteVariables),
       ...callable(next)(siteVariables),
@@ -92,6 +94,8 @@ export const mergeThemeVariables = (
   const displayNames = _.union(_.keys(target), ..._.map(sources, _.keys))
 
   return sources.reduce((acc, next) => {
+    if (!next) return acc
+
     return displayNames.reduce((componentVariables, displayName) => {
       // Break references to avoid an infinite loop.
       // We are replacing functions with new ones that calls the originals.

--- a/test/specs/lib/mergeThemes-test.ts
+++ b/test/specs/lib/mergeThemes-test.ts
@@ -1,9 +1,24 @@
 import mergeThemes from '../../../src/lib/mergeThemes'
-import { felaRtlRenderer, felaRenderer } from '../../../src/lib'
+import { felaRenderer, felaRtlRenderer } from '../../../src/lib'
 
 describe('mergeThemes', () => {
   test('gracefully handles undefined themes', () => {
     expect(() => mergeThemes(undefined, undefined)).not.toThrow()
+  })
+
+  test('always returns an object', () => {
+    expect(mergeThemes(undefined, undefined)).toMatchObject({})
+    expect(mergeThemes(null, undefined)).toMatchObject({})
+    expect(mergeThemes(undefined, null)).toMatchObject({})
+    expect(mergeThemes(null, null)).toMatchObject({})
+
+    expect(mergeThemes({}, undefined)).toMatchObject({})
+    expect(mergeThemes(undefined, {})).toMatchObject({})
+    expect(mergeThemes({}, {})).toMatchObject({})
+
+    expect(mergeThemes({}, null)).toMatchObject({})
+    expect(mergeThemes(null, {})).toMatchObject({})
+    expect(mergeThemes({}, {})).toMatchObject({})
   })
 
   test('gracefully handles merging a theme in with undefined values', () => {

--- a/test/specs/lib/mergeThemes-test.ts
+++ b/test/specs/lib/mergeThemes-test.ts
@@ -6,6 +6,38 @@ describe('mergeThemes', () => {
     expect(() => mergeThemes(undefined, undefined)).not.toThrow()
   })
 
+  test('gracefully handles merging a theme in with undefined values', () => {
+    const target = {
+      siteVariables: { color: 'black' },
+      componentVariables: { Button: { color: 'black' } },
+      componentStyles: { Button: { root: { color: 'black' } } },
+      rtl: true,
+    }
+    const source = {
+      siteVariables: undefined,
+      componentVariables: undefined,
+      componentStyles: undefined,
+      rtl: undefined,
+    }
+    expect(() => mergeThemes(target, source)).not.toThrow()
+  })
+
+  test('gracefully handles merging onto a theme with undefined values', () => {
+    const target = {
+      siteVariables: undefined,
+      componentVariables: undefined,
+      componentStyles: undefined,
+      rtl: undefined,
+    }
+    const source = {
+      siteVariables: { color: 'black' },
+      componentVariables: { Button: { color: 'black' } },
+      componentStyles: { Button: { root: { color: 'black' } } },
+      rtl: true,
+    }
+    expect(() => mergeThemes(target, source)).not.toThrow()
+  })
+
   describe('siteVariables', () => {
     test('merges top level keys', () => {
       const target = { siteVariables: { overridden: false, keep: true } }


### PR DESCRIPTION
We currently separately test every example for every component.  We have consumed over 50% of our 20,000 images per month in just a few days.

This PR introduces a new route `visual-test` that renders all the examples for a single component on one page.  It also renders an RTL version.

The markup is very minimal, a couple divs and headers to indicate which examples are being rendered.  Now, we can just take a single image of this route.

****
http://localhost:8080/visual-test/button

![image](https://user-images.githubusercontent.com/5067638/44250058-c74b2080-a1a7-11e8-88f2-830e461fd9dd.png)
