### PR TITLE
RFC: generate PropTypes, handledProps

### DIFF
--- a/build/gulp/tasks/dist.ts
+++ b/build/gulp/tasks/dist.ts
@@ -1,6 +1,7 @@
 import { task, series, parallel, src, dest } from 'gulp'
 import * as merge2 from 'merge2'
 import * as rimraf from 'rimraf'
+import * as ttypescript from 'ttypescript'
 import * as webpack from 'webpack'
 
 import config from '../../../config'
@@ -25,7 +26,11 @@ task('build:dist:commonjs', () => {
   const settings = { declaration: true }
   const typescript = g.typescript.createProject(tsConfig, settings)
 
-  const { dts, js } = src(paths.src('**/*.{ts,tsx}')).pipe(typescript())
+  const { dts, js } = src(paths.src('**/*.{ts,tsx}')).pipe(
+    typescript({
+      typescript: ttypescript,
+    }),
+  )
   const types = src(paths.base('types/**'))
 
   return merge2([
@@ -37,7 +42,10 @@ task('build:dist:commonjs', () => {
 
 task('build:dist:es', () => {
   const tsConfig = paths.base('build/tsconfig.es.json')
-  const settings = { declaration: true }
+  const settings = {
+    declaration: true,
+    typescript: ttypescript,
+  }
   const typescript = g.typescript.createProject(tsConfig, settings)
 
   const { dts, js } = src(paths.src('**/*.{ts,tsx}')).pipe(typescript())

--- a/build/tsconfig.common.json
+++ b/build/tsconfig.common.json
@@ -8,6 +8,9 @@
       "@stardust-ui/react": ["src"],
       "*": ["*", "types/*"]
     },
+    "plugins": [
+      {"transform": "./transformers/propTypes.ts"}
+    ],
     "types": [
       "node",
       "jest"

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "ts-node": "^6.1.0",
     "tslint": "^5.10.0",
     "tslint-config-airbnb": "^5.9.2",
+    "ttypescript": "^1.5.4",
     "typescript": "^3.0.1",
     "webpack": "^3.5.4",
     "webpack-dev-middleware": "^1.12.0",

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -135,14 +135,7 @@ class Avatar extends UIComponent<any, any> {
     return (
       <ElementType {...rest} className={classes.root}>
         {src ? (
-          <Image
-            styles={{ root: styles.imageAvatar }}
-            fluid
-            avatar
-            src={src}
-            alt={alt}
-            title={name}
-          />
+          <Image />
         ) : (
           <Label
             styles={{ root: styles.avatarNameContainer }}

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -5,10 +5,18 @@ import { customPropTypes, UIComponent } from '../../lib'
 import { ImageBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/interfaces'
 
+export interface ImageProps {
+  /** An image may be formatted to appear inline with text as an avatar. */
+  avatar: boolean
+
+  /** An image can appear circular. */
+  circular: boolean
+}
+
 /**
  * An image is a graphic representation of something.
  */
-class Image extends UIComponent<any, any> {
+class Image extends UIComponent<ImageProps, any> {
   static className = 'ui-image'
 
   static displayName = 'Image'

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -7,10 +7,10 @@ import { Accessibility } from '../../lib/accessibility/interfaces'
 
 export interface ImageProps {
   /** An image may be formatted to appear inline with text as an avatar. */
-  avatar: boolean
+  avatar?: boolean
 
   /** An image can appear circular. */
-  circular: boolean
+  circular?: boolean
 }
 
 /**
@@ -20,32 +20,6 @@ class Image extends UIComponent<ImageProps, any> {
   static className = 'ui-image'
 
   static displayName = 'Image'
-
-  static propTypes = {
-    /** Accessibility behavior if overridden by the user. */
-    accessibility: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-
-    /** An element type to render as. */
-    as: customPropTypes.as,
-
-    /** An image may be formatted to appear inline with text as an avatar. */
-    avatar: PropTypes.bool,
-
-    /** An image can appear circular. */
-    circular: PropTypes.bool,
-
-    /** Additional classes. */
-    className: PropTypes.string,
-
-    /** An image can take up the width of its container. */
-    fluid: PropTypes.bool,
-
-    /** Custom styles to be applied for component. */
-    styles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-
-    /** Custom variables to be applied for component. */
-    variables: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-  }
 
   static handledProps = [
     'accessibility',

--- a/transformers/propTypes.ts
+++ b/transformers/propTypes.ts
@@ -1,0 +1,62 @@
+import * as _ from 'lodash'
+import * as ts from 'typescript'
+
+const getPropsType = (node: ts.ClassDeclaration) => {
+  if (node.heritageClauses.length > 1) {
+    throw new Error('"ClassDeclaration" contains more that one "HeritageClause"')
+  }
+
+  const clause = node.heritageClauses[0]
+  const types = clause.types
+
+  if (types.length > 1) {
+    throw new Error('"HeritageClause" contains more that one "ExpressionWithTypeArguments"')
+  }
+
+  const typeExpression: ts.ExpressionWithTypeArguments = types[0]
+  const typeArguments = typeExpression.typeArguments
+
+  // @ts-ignore
+  const propsType = typeArguments[0] as ts.TypeReference
+
+  typeArguments.forEach((typeArgument: ts.TypeReferenceNode) => {
+    console.log(typeArgument)
+  })
+}
+
+const isComponentDeclaration = (node: ts.ClassDeclaration) =>
+  _.some(node.heritageClauses, (clause: ts.HeritageClause) =>
+    _.some(
+      clause.types,
+      (type: ts.ExpressionWithTypeArguments) =>
+        type.expression.kind === ts.SyntaxKind.Identifier &&
+        (type.expression as ts.Identifier).text === 'UIComponent',
+    ),
+  )
+
+const visitNode = (node: ts.Node) => {
+  if (node.kind === ts.SyntaxKind.ClassDeclaration) {
+    const classDeclaration = node as ts.ClassDeclaration
+
+    if (isComponentDeclaration(classDeclaration)) {
+      getPropsType(classDeclaration)
+      // console.log(getPropsType(classDeclaration))
+    }
+
+    return
+  }
+
+  node.forEachChild(visitNode)
+}
+
+const propTypes = (program: ts.Program) => {
+  return (ctx: ts.TransformationContext) => {
+    return (sourceFile: ts.SourceFile) => {
+      sourceFile.forEachChild(visitNode)
+
+      return sourceFile
+    }
+  }
+}
+
+export default propTypes

--- a/yarn.lock
+++ b/yarn.lock
@@ -6711,7 +6711,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.7.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -7618,7 +7618,7 @@ ts-jest@^22.4.6:
     source-map-support "^0.5.5"
     yargs "^11.0.0"
 
-ts-node@^6.1.0:
+ts-node@^6.0.2, ts-node@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.2.0.tgz#65a0ae2acce319ea4fd7ac8d7c9f1f90c5da6baf"
   dependencies:
@@ -7701,6 +7701,13 @@ tsutils@^2.12.1, tsutils@^2.24.0, tsutils@^2.27.0:
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+
+ttypescript@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.4.tgz#d2476bf49c99101c7f9fa6f996a239cb44080770"
+  dependencies:
+    resolve "^1.7.1"
+    ts-node "^6.0.2"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
# RFC

Hey there!

I've made a dirty POC to check that it's possible. My proposal contains some usefull things.

### `propTypes`
Addresses #7. I almost sure that we should generate `propTypes` from interfaces, this PR is an initial POC for this. We also can to add there the environment checks.

### `handledProps`

As we use AST transforms, we can easily add `handledProps`, too 👍 

----

This PR heavily relies on [ttypescript](https://github.com/cevek/ttypescript), please let me know what you think about this.