### PR TITLE
feat(Input): inline text - adding inline prop for Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Menu `iconOnly`, MenuItem `iconOnly` and `icon` props @miroslavstastny ([#73](https://github.com/stardust-ui/react/pull/73))
 - Add `Grid` component base implementation @Bugaa92 ([#93](https://github.com/stardust-ui/react/pull/93))
 - Add basic `Segment` component @kuzhelov ([#103](https://github.com/stardust-ui/react/pull/103))
+- Add Input `label` and `labelPosition` props @alinais ([]())
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Menu `iconOnly`, MenuItem `iconOnly` and `icon` props @miroslavstastny ([#73](https://github.com/stardust-ui/react/pull/73))
 - Add `Grid` component base implementation @Bugaa92 ([#93](https://github.com/stardust-ui/react/pull/93))
 - Add basic `Segment` component @kuzhelov ([#103](https://github.com/stardust-ui/react/pull/103))
-- Add Input `label` and `labelPosition` props @alinais ([#120](https://github.com/stardust-ui/react/pull/120))
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Menu `iconOnly`, MenuItem `iconOnly` and `icon` props @miroslavstastny ([#73](https://github.com/stardust-ui/react/pull/73))
 - Add `Grid` component base implementation @Bugaa92 ([#93](https://github.com/stardust-ui/react/pull/93))
 - Add basic `Segment` component @kuzhelov ([#103](https://github.com/stardust-ui/react/pull/103))
+- Add Input `label` and `labelPosition` props @alinais ([]())
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `Portal`, `PortalInner` and `Ref` components base implementation @Bugaa92 ([#144](https://github.com/stardust-ui/react/pull/144))
 - Support all Semantic UI FontAwesome icon names @levithomason ([#211](https://github.com/stardust-ui/react/pull/211))
 - Add `Popup` component base implementation @Bugaa92 ([#150](https://github.com/stardust-ui/react/pull/150))
+- Add Input `inline` prop @alinais ([#120](https://github.com/stardust-ui/react/pull/120))
 
 <!--------------------------------[ v0.5.0 ]------------------------------- -->
 ## [v0.5.0](https://github.com/stardust-ui/react/tree/v0.5.0) (2018-08-30)
@@ -91,7 +92,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Menu `iconOnly`, MenuItem `iconOnly` and `icon` props @miroslavstastny ([#73](https://github.com/stardust-ui/react/pull/73))
 - Add `Grid` component base implementation @Bugaa92 ([#93](https://github.com/stardust-ui/react/pull/93))
 - Add basic `Segment` component @kuzhelov ([#103](https://github.com/stardust-ui/react/pull/103))
-- Add Input `label` and `labelPosition` props @alinais ([#120](https://github.com/stardust-ui/react/pull/120))
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Menu `iconOnly`, MenuItem `iconOnly` and `icon` props @miroslavstastny ([#73](https://github.com/stardust-ui/react/pull/73))
 - Add `Grid` component base implementation @Bugaa92 ([#93](https://github.com/stardust-ui/react/pull/93))
 - Add basic `Segment` component @kuzhelov ([#103](https://github.com/stardust-ui/react/pull/103))
-- Add Input `label` and `labelPosition` props @alinais ([]())
+- Add Input `label` and `labelPosition` props @alinais ([#120](https://github.com/stardust-ui/react/pull/120))
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Menu `iconOnly`, MenuItem `iconOnly` and `icon` props @miroslavstastny ([#73](https://github.com/stardust-ui/react/pull/73))
 - Add `Grid` component base implementation @Bugaa92 ([#93](https://github.com/stardust-ui/react/pull/93))
 - Add basic `Segment` component @kuzhelov ([#103](https://github.com/stardust-ui/react/pull/103))
-- Add Input `label` and `labelPosition` props @alinais ([]())
+- Add Input `label` and `labelPosition` props @alinais ([#120](https://github.com/stardust-ui/react/pull/120))
 
 <!--------------------------------[ v0.2.7 ]------------------------------- -->
 ## [v0.2.7](https://github.com/stardust-ui/react/tree/v0.2.7) (2018-08-13)

--- a/docs/src/examples/components/Input/Types/InputExample.shorthand.tsx
+++ b/docs/src/examples/components/Input/Types/InputExample.shorthand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Input } from '@stardust-ui/react'
 
 const InputExample = () => <Input placeholder="Search..." />

--- a/docs/src/examples/components/Input/Variations/InputExampleClearable.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleClearable.shorthand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Input } from '@stardust-ui/react'
 
 const InputExampleClearableShorthand = () => <Input clearable placeholder="Search..." />

--- a/docs/src/examples/components/Input/Variations/InputExampleFluid.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleFluid.shorthand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Input } from '@stardust-ui/react'
 
 const InputExample = () => <Input fluid icon="search" placeholder="Search..." />

--- a/docs/src/examples/components/Input/Variations/InputExampleIcon.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleIcon.shorthand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Input } from '@stardust-ui/react'
 
 const InputExampleIcon = () => <Input icon="search" placeholder="Search..." />

--- a/docs/src/examples/components/Input/Variations/InputExampleIconClearable.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleIconClearable.shorthand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Input } from '@stardust-ui/react'
 
 const InputExampleIconClearableShorthand = () => (

--- a/docs/src/examples/components/Input/Variations/InputExampleInline.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleInline.shorthand.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Input } from '@stardust-ui/react'
+
+const InputExampleInline = () => (
+  <div>
+    Some text inline with the <Input inline placeholder="input name" /> and more text.
+  </div>
+)
+
+export default InputExampleInline

--- a/docs/src/examples/components/Input/Variations/InputExampleLabel.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleLabel.shorthand.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import { Input } from '@stardust-ui/react'
-
-const InputExampleLabel = () => <Input label="Your name" placeholder="My Name" />
-
-export default InputExampleLabel

--- a/docs/src/examples/components/Input/Variations/InputExampleLabel.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleLabel.shorthand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Input } from '@stardust-ui/react'
 
 const InputExampleLabel = () => <Input label="Your name" placeholder="My Name" />

--- a/docs/src/examples/components/Input/Variations/InputExampleLabel.shorthand.tsx
+++ b/docs/src/examples/components/Input/Variations/InputExampleLabel.shorthand.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react'
+import { Input } from '@stardust-ui/react'
+
+const InputExampleLabel = () => <Input label="Your name" placeholder="My Name" />
+
+export default InputExampleLabel

--- a/docs/src/examples/components/Input/Variations/index.tsx
+++ b/docs/src/examples/components/Input/Variations/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import ComponentExample from 'docs/src/components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 

--- a/docs/src/examples/components/Input/Variations/index.tsx
+++ b/docs/src/examples/components/Input/Variations/index.tsx
@@ -24,6 +24,11 @@ const Variations = () => (
       description="An input with a given icon can be clearable (the given icon will change into clear button on typing)."
       examplePath="components/Input/Variations/InputExampleIconClearable"
     />
+    <ComponentExample
+      title="Label"
+      description="An input can be preceeded or succeeded by a text."
+      examplePath="components/Input/Variations/InputExampleLabel"
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/components/Input/Variations/index.tsx
+++ b/docs/src/examples/components/Input/Variations/index.tsx
@@ -25,9 +25,9 @@ const Variations = () => (
       examplePath="components/Input/Variations/InputExampleIconClearable"
     />
     <ComponentExample
-      title="Label"
-      description="An input can be preceeded or succeeded by a text."
-      examplePath="components/Input/Variations/InputExampleLabel"
+      title="Inline"
+      description="An input can be used inline with text."
+      examplePath="components/Input/Variations/InputExampleInline"
     />
   </ExampleSection>
 )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -34,7 +34,6 @@ export interface IInputProps {
   styles?: IComponentPartStylesInput
   variables?: ComponentVariablesInput
 }
-import Label from '../Label'
 
 /**
  * An Input
@@ -191,7 +190,7 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
   }
 
   renderComponent({ ElementType, classes, styles }) {
-    const { input, label, labelPosition, type } = this.props
+    const { input, type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const { onChange } = htmlInputProps as any

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -26,6 +26,7 @@ export interface IInputProps {
   defaultValue?: string
   fluid?: boolean
   icon?: ItemShorthand
+  inline?: boolean
   input?: ItemShorthand
   onChange?: ComponentEventHandler<IInputProps>
   value?: string
@@ -63,20 +64,17 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     /** The default value of the input. */
     defaultValue: PropTypes.string,
 
-    /** A button can take the width of its container. */
+    /** An input can take the width of its container. */
     fluid: PropTypes.bool,
 
     /** Optional Icon to display inside the Input. */
     icon: customPropTypes.itemShorthand,
 
+    /** An input can be used inline with text */
+    inline: PropTypes.bool,
+
     /** Shorthand for creating the HTML Input. */
     input: customPropTypes.itemShorthand,
-
-    /** Shorthand for creating a Label.  */
-    label: customPropTypes.itemShorthand,
-
-    /** The Label text can appear before or after the input element.  */
-    labelPosition: PropTypes.oneOf(['start', 'end']),
 
     /**
      * Called on change.
@@ -106,9 +104,8 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     'defaultValue',
     'fluid',
     'icon',
+    'inline',
     'input',
-    'label',
-    'labelPosition',
     'onChange',
     'styles',
     'type',
@@ -201,16 +198,8 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
 
     const inputClasses = classes.input
 
-    const labelAtEnd = labelPosition === 'end'
-    const labelAtStart = !labelAtEnd
-
     return (
       <ElementType className={classes.root} {...restProps} {...htmlInputProps}>
-        {labelAtStart &&
-          label &&
-          Label.create(label, {
-            defaultProps: { styles: { root: styles.label } },
-          })}
         {createHTMLInput(input || type, {
           defaultProps: htmlInputProps,
           overrideProps: {
@@ -222,11 +211,6 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
           Icon.create(this.computeIcon(), {
             defaultProps: { styles: { root: styles.icon } },
             overrideProps: this.handleIconOverrides,
-          })}
-        {labelAtEnd &&
-          label &&
-          Label.create(label, {
-            defaultProps: { styles: { root: styles.label } },
           })}
       </ElementType>
     )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -186,7 +186,7 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
   }
 
   renderComponent({ ElementType, classes, styles }) {
-    const { input, type } = this.props
+    const { type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const { onChange } = htmlInputProps as any
@@ -194,8 +194,8 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     const inputClasses = classes.input
 
     return (
-      <ElementType className={classes.root} {...restProps} {...htmlInputProps}>
-        {createHTMLInput(input || type, {
+      <ElementType className={classes.root} {...restProps} onChange={onChange}>
+        {createHTMLInput(type, {
           defaultProps: htmlInputProps,
           overrideProps: {
             className: inputClasses,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -34,7 +34,6 @@ export interface IInputProps {
   styles?: IComponentPartStylesInput
   variables?: ComponentVariablesInput
 }
-import Label from '../Label'
 
 /**
  * An Input
@@ -187,7 +186,7 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
   }
 
   renderComponent({ ElementType, classes, styles }) {
-    const { input, label, labelPosition, type } = this.props
+    const { input, type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const { onChange } = htmlInputProps as any

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -33,6 +33,7 @@ export interface IInputProps {
   styles?: IComponentPartStylesInput
   variables?: ComponentVariablesInput
 }
+import Label from '../Label'
 
 /**
  * An Input
@@ -68,6 +69,15 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     /** Optional Icon to display inside the Input. */
     icon: customPropTypes.itemShorthand,
 
+    /** Shorthand for creating the HTML Input. */
+    input: customPropTypes.itemShorthand,
+
+    /** Shorthand for creating a Label.  */
+    label: customPropTypes.itemShorthand,
+
+    /** The Label text can appear before or after the input element.  */
+    labelPosition: PropTypes.oneOf(['start', 'end']),
+
     /**
      * Called on change.
      *
@@ -96,6 +106,9 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     'defaultValue',
     'fluid',
     'icon',
+    'input',
+    'label',
+    'labelPosition',
     'onChange',
     'styles',
     'type',
@@ -181,16 +194,24 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
   }
 
   renderComponent({ ElementType, classes, styles }) {
-    const { type } = this.props
+    const { input, label, labelPosition, type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const { onChange } = htmlInputProps as any
 
     const inputClasses = classes.input
 
+    const labelAtEnd = labelPosition === 'end'
+    const labelAtStart = !labelAtEnd
+
     return (
-      <ElementType className={classes.root} {...restProps} onChange={onChange}>
-        {createHTMLInput(type, {
+      <ElementType className={classes.root} {...restProps} {...htmlInputProps}>
+        {labelAtStart &&
+          label &&
+          Label.create(label, {
+            defaultProps: { styles: { root: styles.label } },
+          })}
+        {createHTMLInput(input || type, {
           defaultProps: htmlInputProps,
           overrideProps: {
             className: inputClasses,
@@ -201,6 +222,11 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
           Icon.create(this.computeIcon(), {
             defaultProps: { styles: { root: styles.icon } },
             overrideProps: this.handleIconOverrides,
+          })}
+        {labelAtEnd &&
+          label &&
+          Label.create(label, {
+            defaultProps: { styles: { root: styles.label } },
           })}
       </ElementType>
     )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -72,9 +72,6 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     /** An input can be used inline with text */
     inline: PropTypes.bool,
 
-    /** Shorthand for creating the HTML Input. */
-    input: customPropTypes.itemShorthand,
-
     /**
      * Called on change.
      *
@@ -104,7 +101,6 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     'fluid',
     'icon',
     'inline',
-    'input',
     'onChange',
     'styles',
     'type',
@@ -190,7 +186,7 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
   }
 
   renderComponent({ ElementType, classes, styles }) {
-    const { input, type } = this.props
+    const { type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const { onChange } = htmlInputProps as any
@@ -198,8 +194,8 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     const inputClasses = classes.input
 
     return (
-      <ElementType className={classes.root} {...restProps} {...htmlInputProps}>
-        {createHTMLInput(input || type, {
+      <ElementType className={classes.root} {...restProps} onChange={onChange}>
+        {createHTMLInput(type, {
           defaultProps: htmlInputProps,
           overrideProps: {
             className: inputClasses,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -34,6 +34,7 @@ export interface IInputProps {
   styles?: IComponentPartStylesInput
   variables?: ComponentVariablesInput
 }
+import Label from '../Label'
 
 /**
  * An Input
@@ -186,16 +187,24 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
   }
 
   renderComponent({ ElementType, classes, styles }) {
-    const { type } = this.props
+    const { input, label, labelPosition, type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
     const { onChange } = htmlInputProps as any
 
     const inputClasses = classes.input
 
+    const labelAtEnd = labelPosition === 'end'
+    const labelAtStart = !labelAtEnd
+
     return (
-      <ElementType className={classes.root} {...restProps} onChange={onChange}>
-        {createHTMLInput(type, {
+      <ElementType className={classes.root} {...restProps} {...htmlInputProps}>
+        {labelAtStart &&
+          label &&
+          Label.create(label, {
+            defaultProps: { styles: { root: styles.label } },
+          })}
+        {createHTMLInput(input || type, {
           defaultProps: htmlInputProps,
           overrideProps: {
             className: inputClasses,
@@ -206,6 +215,11 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
           Icon.create(this.computeIcon(), {
             defaultProps: { styles: { root: styles.icon } },
             overrideProps: this.handleIconOverrides,
+          })}
+        {labelAtEnd &&
+          label &&
+          Label.create(label, {
+            defaultProps: { styles: { root: styles.label } },
           })}
       </ElementType>
     )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -194,16 +194,8 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
 
     const inputClasses = classes.input
 
-    const labelAtEnd = labelPosition === 'end'
-    const labelAtStart = !labelAtEnd
-
     return (
       <ElementType className={classes.root} {...restProps} {...htmlInputProps}>
-        {labelAtStart &&
-          label &&
-          Label.create(label, {
-            defaultProps: { styles: { root: styles.label } },
-          })}
         {createHTMLInput(input || type, {
           defaultProps: htmlInputProps,
           overrideProps: {
@@ -215,11 +207,6 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
           Icon.create(this.computeIcon(), {
             defaultProps: { styles: { root: styles.icon } },
             overrideProps: this.handleIconOverrides,
-          })}
-        {labelAtEnd &&
-          label &&
-          Label.create(label, {
-            defaultProps: { styles: { root: styles.label } },
           })}
       </ElementType>
     )

--- a/src/themes/teams/components/Input/inputStyles.ts
+++ b/src/themes/teams/components/Input/inputStyles.ts
@@ -40,13 +40,6 @@ const inputStyles: IComponentPartStylesInput = {
       outline: 0,
     }
   },
-
-  label: ({ props, variables }): ICSSInJSStyle => {
-    return {
-      position: 'relative',
-      backgroundColor: 'transparent',
-    }
-  },
 }
 
 export default inputStyles

--- a/src/themes/teams/components/Input/inputStyles.ts
+++ b/src/themes/teams/components/Input/inputStyles.ts
@@ -40,6 +40,13 @@ const inputStyles: IComponentPartStylesInput = {
       outline: 0,
     }
   },
+
+  label: ({ props, variables }): ICSSInJSStyle => {
+    return {
+      position: 'relative',
+      backgroundColor: 'transparent',
+    }
+  },
 }
 
 export default inputStyles

--- a/src/themes/teams/components/Input/inputStyles.ts
+++ b/src/themes/teams/components/Input/inputStyles.ts
@@ -39,6 +39,13 @@ const inputStyles: IComponentPartStylesInput = {
       outline: 0,
     }
   },
+
+  label: ({ props, variables }): ICSSInJSStyle => {
+    return {
+      position: 'relative',
+      backgroundColor: 'transparent',
+    }
+  },
 }
 
 export default inputStyles

--- a/src/themes/teams/components/Input/inputStyles.ts
+++ b/src/themes/teams/components/Input/inputStyles.ts
@@ -14,7 +14,7 @@ const inputStyles: IComponentPartStylesInput = {
   },
 
   input: ({ props, variables }): ICSSInJSStyle => {
-    const { fluid } = props
+    const { fluid, inline } = props
 
     return {
       outline: 0,
@@ -25,6 +25,7 @@ const inputStyles: IComponentPartStylesInput = {
       backgroundColor: variables.backgroundColor,
       padding: variables.inputPadding,
       ...(fluid && { width: '100%' }),
+      ...(inline && { float: 'left' }),
       ':focus': {
         borderColor: variables.inputFocusBorderColor,
         borderRadius: variables.inputFocusBorderRadius,
@@ -37,13 +38,6 @@ const inputStyles: IComponentPartStylesInput = {
       position: variables.iconPosition,
       right: variables.iconRight,
       outline: 0,
-    }
-  },
-
-  label: ({ props, variables }): ICSSInJSStyle => {
-    return {
-      position: 'relative',
-      backgroundColor: 'transparent',
     }
   },
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Input Inline Text

Adding inline property to Input component to make possible the inline text addition.

### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [x] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# API Proposal

## inline

![image](https://user-images.githubusercontent.com/1826985/45229162-6a81e800-b2c5-11e8-9896-14b7a216f5b6.png)

The input can be added inline with the text.

```jsx
(
  <div>Some text inline with the <Input inline placeholder="input name" /> and more text.</div>
)
```

```html
<div>
  Some text inline with the
  <div class="ui-input ..." placeholder="input name" type="text" value="">
    <input type="text" placeholder="input name" value="" class="..." />
  </div> and more text.
</div>
```
