### PR TITLE
fix(docs): regexp for component examples selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Split Menu `shape` prop to separate `pills`, `pointing` and `underlined` props @miroslavstastny ([#114](https://github.com/stardust-ui/react/pull/114))
 
+### Fixes
+- Fix docs pages presenting examples of wrong component @kuzhelov ([#124](https://github.com/stardust-ui/react/pull/124))
+
 ### Features
 - Add basic `Radio` component @alinais ([#100](https://github.com/stardust-ui/react/pull/100))
 

--- a/docs/src/components/ComponentDoc/ComponentExamples.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExamples.tsx
@@ -34,7 +34,7 @@ export default class ComponentExamples extends React.Component<IComponentExample
 
     // rule #1
     const indexPath = _.find(allPaths, path =>
-      new RegExp(`([/]|^)${displayName}[/]index[.]tsx$`).test(path),
+      new RegExp(`(\/|^)${displayName}\/index\.tsx$`).test(path),
     )
     if (!indexPath) {
       return null

--- a/docs/src/components/ComponentDoc/ComponentExamples.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExamples.tsx
@@ -33,7 +33,9 @@ export default class ComponentExamples extends React.Component<IComponentExample
     const allPaths = exampleContext.keys()
 
     // rule #1
-    const indexPath = _.find(allPaths, path => new RegExp(`${displayName}/index.tsx$`).test(path))
+    const indexPath = _.find(allPaths, path =>
+      new RegExp(`([/]|^)${displayName}[/]index[.]tsx$`).test(path),
+    )
     if (!indexPath) {
       return null
     }


### PR DESCRIPTION
Problem was discovered when on the page of `Layout` component examples for `ItemLayout` were presented. This was caused by the fact that used regexp was too lose to filter out false positive matches.

## Previously

* note that `ItemLayout` examples are presented on `Layout` page

![image](https://user-images.githubusercontent.com/9024564/44525423-2ac1da80-a6e1-11e8-9179-5542a3e2e3cd.png)
