### PR TITLE
test: add missing mergeThemes export tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix docs pages presenting examples of wrong component @kuzhelov ([#124](https://github.com/stardust-ui/react/pull/124))
+- Fix component variables when merging themes @levithomason ([#128](https://github.com/stardust-ui/react/pull/128))
 
 ### Features
 - Add basic `Radio` component @alinais ([#100](https://github.com/stardust-ui/react/pull/100))

--- a/src/lib/mergeThemes.ts
+++ b/src/lib/mergeThemes.ts
@@ -93,6 +93,8 @@ export const mergeThemeVariables = (
 
   return sources.reduce((acc, next) => {
     return displayNames.reduce((componentVariables, displayName) => {
+      if (!next) return acc
+
       // Break references to avoid an infinite loop.
       // We are replacing functions with new ones that calls the originals.
       const originalTarget = acc[displayName]

--- a/test/specs/lib/mergeThemes/mergeComponentStyles-test.ts
+++ b/test/specs/lib/mergeThemes/mergeComponentStyles-test.ts
@@ -1,0 +1,104 @@
+import { mergeComponentStyles } from '../../../../src/lib/mergeThemes'
+
+describe('mergeComponentStyles', () => {
+  test(`always returns an object`, () => {
+    expect(mergeComponentStyles({}, {})).toMatchObject({})
+    expect(mergeComponentStyles(null, null)).toMatchObject({})
+    expect(mergeComponentStyles(undefined, undefined)).toMatchObject({})
+
+    expect(mergeComponentStyles(null, undefined)).toMatchObject({})
+    expect(mergeComponentStyles(undefined, null)).toMatchObject({})
+
+    expect(mergeComponentStyles({}, undefined)).toMatchObject({})
+    expect(mergeComponentStyles(undefined, {})).toMatchObject({})
+
+    expect(mergeComponentStyles({}, null)).toMatchObject({})
+    expect(mergeComponentStyles(null, {})).toMatchObject({})
+  })
+
+  test('gracefully handles null and undefined', () => {
+    const styles = { root: { color: 'black' } }
+    const stylesWithNull = { root: { color: null }, icon: null }
+    const stylesWithUndefined = { root: { color: undefined }, icon: undefined }
+
+    expect(() => mergeComponentStyles(styles, null)).not.toThrow()
+    expect(() => mergeComponentStyles(styles, stylesWithNull)).not.toThrow()
+
+    expect(() => mergeComponentStyles(null, styles)).not.toThrow()
+    expect(() => mergeComponentStyles(stylesWithNull, styles)).not.toThrow()
+
+    expect(() => mergeComponentStyles(styles, undefined)).not.toThrow()
+    expect(() => mergeComponentStyles(styles, stylesWithUndefined)).not.toThrow()
+
+    expect(() => mergeComponentStyles(undefined, styles)).not.toThrow()
+    expect(() => mergeComponentStyles(stylesWithUndefined, styles)).not.toThrow()
+  })
+
+  test('component parts are merged', () => {
+    const target = { root: {} }
+    const source = { icon: {} }
+
+    const merged = mergeComponentStyles(target, source)
+
+    expect(merged).toHaveProperty('root')
+    expect(merged).toHaveProperty('icon')
+  })
+
+  test('component part objects are converted to functions', () => {
+    const target = { root: {} }
+    const source = { root: {} }
+
+    const merged = mergeComponentStyles(target, source)
+
+    expect(merged.root).toBeInstanceOf(Function)
+    expect(merged.root).toBeInstanceOf(Function)
+  })
+
+  test('component part styles are deeply merged', () => {
+    const target = {
+      root: {
+        display: 'inline-block',
+        color: 'green',
+        '::before': {
+          content: 'before content',
+        },
+      },
+    }
+    const source = {
+      root: {
+        color: 'blue',
+        '::before': {
+          color: 'red',
+        },
+      },
+    }
+    const merged = mergeComponentStyles(target, source)
+
+    expect(merged.root()).toMatchObject({
+      display: 'inline-block',
+      color: 'blue',
+      '::before': {
+        content: 'before content',
+        color: 'red',
+      },
+    })
+  })
+
+  test('functions can accept and apply params', () => {
+    const target = { root: param => ({ target: true, ...param }) }
+    const source = { root: param => ({ source: true, ...param }) }
+
+    const merged = mergeComponentStyles(target, source)
+
+    const styleParam = {
+      variables: { iconSize: 'large' },
+      props: { primary: true },
+    }
+
+    expect(merged.root(styleParam)).toMatchObject({
+      source: true,
+      target: true,
+      ...styleParam,
+    })
+  })
+})

--- a/test/specs/lib/mergeThemes/mergeComponentVariables-test.ts
+++ b/test/specs/lib/mergeThemes/mergeComponentVariables-test.ts
@@ -1,0 +1,61 @@
+import { mergeComponentVariables } from '../../../../src/lib/mergeThemes'
+
+describe('mergeComponentVariables', () => {
+  test(`always returns a function that returns an object`, () => {
+    expect(mergeComponentVariables({}, {})()).toMatchObject({})
+    expect(mergeComponentVariables(null, null)()).toMatchObject({})
+    expect(mergeComponentVariables(undefined, undefined)()).toMatchObject({})
+
+    expect(mergeComponentVariables(null, undefined)()).toMatchObject({})
+    expect(mergeComponentVariables(undefined, null)()).toMatchObject({})
+
+    expect(mergeComponentVariables({}, undefined)()).toMatchObject({})
+    expect(mergeComponentVariables(undefined, {})()).toMatchObject({})
+
+    expect(mergeComponentVariables({}, null)()).toMatchObject({})
+    expect(mergeComponentVariables(null, {})()).toMatchObject({})
+  })
+
+  test('gracefully handles null and undefined', () => {
+    expect(() => mergeComponentVariables({ color: 'black' }, null)).not.toThrow()
+    expect(() => mergeComponentVariables({ color: 'black' }, { color: null })).not.toThrow()
+
+    expect(() => mergeComponentVariables(null, { color: 'black' })).not.toThrow()
+    expect(() => mergeComponentVariables({ color: null }, { color: 'black' })).not.toThrow()
+
+    expect(() => mergeComponentVariables({ color: 'black' }, undefined)).not.toThrow()
+    expect(() => mergeComponentVariables({ color: 'black' }, { color: undefined })).not.toThrow()
+
+    expect(() => mergeComponentVariables(undefined, { color: 'black' })).not.toThrow()
+    expect(() => mergeComponentVariables({ color: undefined }, { color: 'black' })).not.toThrow()
+  })
+
+  test('merged functions return merged variables', () => {
+    const target = () => ({ one: 1, three: 3 })
+    const source = () => ({ one: 'one', two: 'two' })
+
+    const merged = mergeComponentVariables(target, source)
+
+    expect(merged()).toMatchObject({
+      one: 'one',
+      two: 'two',
+      three: 3,
+    })
+  })
+
+  test('merged functions accept and apply siteVariables', () => {
+    const target = siteVariables => ({ one: 1, target: true, ...siteVariables })
+    const source = siteVariables => ({ two: 2, source: true, ...siteVariables })
+
+    const merged = mergeComponentVariables(target, source)
+
+    const siteVariables = { one: 'one', two: 'two' }
+
+    expect(merged(siteVariables)).toMatchObject({
+      one: 'one',
+      two: 'two',
+      source: true,
+      target: true,
+    })
+  })
+})

--- a/test/specs/lib/mergeThemes/mergeRTL-test.ts
+++ b/test/specs/lib/mergeThemes/mergeRTL-test.ts
@@ -1,0 +1,32 @@
+import { mergeRTL } from '../../../../src/lib/mergeThemes'
+
+describe('mergeRTL', () => {
+  test('latest boolean value wins', () => {
+    expect(mergeRTL(false, true)).toEqual(true)
+    expect(mergeRTL(true, false)).toEqual(false)
+
+    expect(mergeRTL(null, true)).toEqual(true)
+    expect(mergeRTL(null, false)).toEqual(false)
+
+    expect(mergeRTL(undefined, true)).toEqual(true)
+    expect(mergeRTL(undefined, false)).toEqual(false)
+  })
+
+  test('null values do not override boolean values', () => {
+    expect(mergeRTL(false, null)).toEqual(false)
+    expect(mergeRTL(true, null)).toEqual(true)
+  })
+
+  test('undefined values do not override boolean values', () => {
+    expect(mergeRTL(false, undefined)).toEqual(false)
+    expect(mergeRTL(true, undefined)).toEqual(true)
+  })
+
+  test('default to false if no boolean was provided', () => {
+    expect(mergeRTL(null, null)).toEqual(false)
+    expect(mergeRTL(null, undefined)).toEqual(false)
+
+    expect(mergeRTL(undefined, null)).toEqual(false)
+    expect(mergeRTL(undefined, undefined)).toEqual(false)
+  })
+})

--- a/test/specs/lib/mergeThemes/mergeSiteVariables-test.ts
+++ b/test/specs/lib/mergeThemes/mergeSiteVariables-test.ts
@@ -1,0 +1,50 @@
+import { mergeSiteVariables } from '../../../../src/lib/mergeThemes'
+
+describe('mergeSiteVariables', () => {
+  test(`always returns an object`, () => {
+    expect(mergeSiteVariables({}, {})).toMatchObject({})
+    expect(mergeSiteVariables(null, null)).toMatchObject({})
+    expect(mergeSiteVariables(undefined, undefined)).toMatchObject({})
+
+    expect(mergeSiteVariables(null, undefined)).toMatchObject({})
+    expect(mergeSiteVariables(undefined, null)).toMatchObject({})
+
+    expect(mergeSiteVariables({}, undefined)).toMatchObject({})
+    expect(mergeSiteVariables(undefined, {})).toMatchObject({})
+
+    expect(mergeSiteVariables({}, null)).toMatchObject({})
+    expect(mergeSiteVariables(null, {})).toMatchObject({})
+  })
+
+  test('gracefully handles null and undefined', () => {
+    expect(() => mergeSiteVariables({ color: 'black' }, null)).not.toThrow()
+    expect(() => mergeSiteVariables({ color: 'black' }, { color: null })).not.toThrow()
+
+    expect(() => mergeSiteVariables(null, { color: 'black' })).not.toThrow()
+    expect(() => mergeSiteVariables({ color: null }, { color: 'black' })).not.toThrow()
+
+    expect(() => mergeSiteVariables({ color: 'black' }, undefined)).not.toThrow()
+    expect(() => mergeSiteVariables({ color: 'black' }, { color: undefined })).not.toThrow()
+
+    expect(() => mergeSiteVariables(undefined, { color: 'black' })).not.toThrow()
+    expect(() => mergeSiteVariables({ color: undefined }, { color: 'black' })).not.toThrow()
+  })
+
+  test('merges top level keys', () => {
+    const target = { overridden: false, keep: true }
+    const source = { overridden: true, add: true }
+
+    expect(mergeSiteVariables(target, source)).toMatchObject({
+      overridden: true,
+      keep: true,
+      add: true,
+    })
+  })
+
+  test('disregards nested keys', () => {
+    const target = { nested: { replaced: true } }
+    const source = { nested: { other: 'value' } }
+
+    expect(mergeSiteVariables(target, source)).toMatchObject({ nested: { other: 'value' } })
+  })
+})

--- a/test/specs/lib/mergeThemes/mergeThemes-test.ts
+++ b/test/specs/lib/mergeThemes/mergeThemes-test.ts
@@ -1,9 +1,52 @@
-import mergeThemes from '../../../src/lib/mergeThemes'
-import { felaRtlRenderer, felaRenderer } from '../../../src/lib'
+import mergeThemes from '../../../../src/lib/mergeThemes'
+import { felaRenderer, felaRtlRenderer } from '../../../../src/lib'
 
 describe('mergeThemes', () => {
-  test('gracefully handles undefined themes', () => {
-    expect(() => mergeThemes(undefined, undefined)).not.toThrow()
+  test(`always returns an object`, () => {
+    expect(mergeThemes({}, {})).toMatchObject({})
+    expect(mergeThemes(null, null)).toMatchObject({})
+    expect(mergeThemes(undefined, undefined)).toMatchObject({})
+
+    expect(mergeThemes(null, undefined)).toMatchObject({})
+    expect(mergeThemes(undefined, null)).toMatchObject({})
+
+    expect(mergeThemes({}, undefined)).toMatchObject({})
+    expect(mergeThemes(undefined, {})).toMatchObject({})
+
+    expect(mergeThemes({}, null)).toMatchObject({})
+    expect(mergeThemes(null, {})).toMatchObject({})
+  })
+
+  test('gracefully handles merging a theme in with undefined values', () => {
+    const target = {
+      siteVariables: { color: 'black' },
+      componentVariables: { Button: { color: 'black' } },
+      componentStyles: { Button: { root: { color: 'black' } } },
+      rtl: true,
+    }
+    const source = {
+      siteVariables: undefined,
+      componentVariables: undefined,
+      componentStyles: undefined,
+      rtl: undefined,
+    }
+    expect(() => mergeThemes(target, source)).not.toThrow()
+  })
+
+  test('gracefully handles merging onto a theme with undefined values', () => {
+    const target = {
+      siteVariables: undefined,
+      componentVariables: undefined,
+      componentStyles: undefined,
+      rtl: undefined,
+    }
+    const source = {
+      siteVariables: { color: 'black' },
+      componentVariables: { Button: { color: 'black' } },
+      componentStyles: { Button: { root: { color: 'black' } } },
+      rtl: true,
+    }
+    expect(() => mergeThemes(target, source)).not.toThrow()
   })
 
   describe('siteVariables', () => {
@@ -179,10 +222,8 @@ describe('mergeThemes', () => {
       const merged = mergeThemes(target, source)
 
       const styleParam = {
-        siteVariables: { brand: '#38E' },
         variables: { iconSize: 'large' },
         props: { primary: true },
-        rtl: false,
       }
 
       expect(merged.componentStyles.Button.root(styleParam)).toMatchObject({


### PR DESCRIPTION
There is currently a bug when passing a partial `theme` that does not contain `componentVariables` to the `Provider`.  The `Provider` throws as it tries to merge keys that don't exist.

This PR fixes that small bug and also adds full test coverage to `mergeThemes` and all of its exports.

/cc @miroslavstastny this includes the fixes and tests from #106  plus many more.  I also addressed your comments here regarding using `mergeComponentVariables` directly and breaking Header's variables.  There are now tests for this usage as well.

***

This PR seems to have fixed 4 previously broken Header examples showing the `description` prop where color was not being applied:

![image](https://user-images.githubusercontent.com/5067638/44566673-af354d00-a723-11e8-8099-f1a88018d13c.png)

...merging as this is blocking my work in getting started documentation.