### PR TITLE
feat(portal): simple base implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Button `text` prop @mnajdova ([#177](https://github.com/stardust-ui/react/pull/177))
 - Add accessibility keyboard action handlers @sophieH29 ([#121](https://github.com/stardust-ui/react/pull/121))
 - Add accessibility description for `Text` component @codepretty ([#205](https://github.com/stardust-ui/react/pull/205))
+- Add `Portal`, `PortalInner` and `Ref` components base implementation @Bugaa92 ([#144](https://github.com/stardust-ui/react/pull/144))
 
 <!--------------------------------[ v0.5.0 ]------------------------------- -->
 ## [v0.5.0](https://github.com/stardust-ui/react/tree/v0.5.0) (2018-08-30)

--- a/docs/src/examples/components/Portal/Types/PortalExample.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExample.shorthand.tsx
@@ -1,62 +1,51 @@
 import React from 'react'
 import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
 
-class PortalExamplePortal extends React.Component<any, any> {
-  public state = {
-    log: [],
-    logCount: 0,
-  }
+class PortalExamplePortal extends React.Component {
+  state = { log: [], logCount: 0 }
 
-  public render() {
-    const { log, logCount } = this.state
-
-    const controls = (
-      <div>
-        <Button size="small" onClick={this.clearLog} content="Clear" />
-        <span>
-          Event Log <Label circular>{logCount}</Label>
-        </span>
-        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
-      </div>
-    )
-
-    const portalContent = (
-      <div
-        style={{
-          background: '#ddd',
-          position: 'fixed',
-          left: '40%',
-          top: '45%',
-          zIndex: 1000,
-        }}
-      >
-        <Header>This is a basic portal</Header>
-        <p>Portals have tons of great callback functions to hook into.</p>
-        <p>To close, simply click the close button or click away</p>
-      </div>
-    )
-
-    return (
-      <div>
-        {
-          <Portal
-            content={portalContent}
-            trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}
-          />
-        }
-        <Divider />
-        {controls}
-      </div>
-    )
-  }
-
-  private handleClick = () =>
+  handleClick = () =>
     this.setState({
       log: [`${new Date().toLocaleTimeString()}: handleClick`, ...this.state.log].slice(0, 20),
       logCount: this.state.logCount + 1,
     })
 
-  private clearLog = () => this.setState({ log: [], logCount: 0 })
+  clearLog = () => this.setState({ log: [], logCount: 0 })
+
+  render() {
+    const { log, logCount } = this.state
+
+    return (
+      <div>
+        <Portal
+          content={
+            <div
+              style={{
+                background: '#ddd',
+                position: 'fixed',
+                left: '40%',
+                top: '45%',
+                zIndex: 1000,
+              }}
+            >
+              <Header>This is a basic portal</Header>
+              <p>Portals have tons of great callback functions to hook into.</p>
+              <p>To close, simply click the close button or click away</p>
+            </div>
+          }
+          trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}
+        />
+        <Divider />
+        <div>
+          <Button size="small" onClick={this.clearLog} content="Clear" />
+          <span>
+            Event Log <Label circular>{logCount}</Label>
+          </span>
+          <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+        </div>
+      </div>
+    )
+  }
 }
 
 export default PortalExamplePortal

--- a/docs/src/examples/components/Portal/Types/PortalExample.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExample.shorthand.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
+
+class PortalExamplePortal extends React.Component<any, any> {
+  public state = {
+    log: [],
+    logCount: 0,
+  }
+
+  public render() {
+    const { log, logCount } = this.state
+
+    const controls = (
+      <div>
+        <Button size="small" onClick={this.clearLog} content="Clear" />
+        <span>
+          Event Log <Label circular>{logCount}</Label>
+        </span>
+        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+      </div>
+    )
+
+    const portalContent = (
+      <div
+        style={{
+          background: '#ddd',
+          position: 'fixed',
+          left: '40%',
+          top: '45%',
+          zIndex: 1000,
+        }}
+      >
+        <Header>This is a basic portal</Header>
+        <p>Portals have tons of great callback functions to hook into.</p>
+        <p>To close, simply click the close button or click away</p>
+      </div>
+    )
+
+    return (
+      <div>
+        {
+          <Portal
+            content={portalContent}
+            trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}
+          />
+        }
+        <Divider />
+        {controls}
+      </div>
+    )
+  }
+
+  private handleClick = () =>
+    this.setState({
+      log: [`${new Date().toLocaleTimeString()}: handleClick`, ...this.state.log].slice(0, 20),
+      logCount: this.state.logCount + 1,
+    })
+
+  private clearLog = () => this.setState({ log: [], logCount: 0 })
+}
+
+export default PortalExamplePortal

--- a/docs/src/examples/components/Portal/Types/PortalExample.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExample.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
+
+class PortalExamplePortal extends React.Component<any, any> {
+  public state = {
+    log: [],
+    logCount: 0,
+  }
+
+  public render() {
+    const { log, logCount } = this.state
+
+    const controls = (
+      <div>
+        <Button size="small" onClick={this.clearLog} content="Clear" />
+        <span>
+          Event Log <Label circular>{logCount}</Label>
+        </span>
+        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+      </div>
+    )
+
+    const portalContent = (
+      <div
+        style={{
+          background: '#ddd',
+          position: 'fixed',
+          left: '40%',
+          top: '45%',
+          zIndex: 1000,
+        }}
+      >
+        <Header>This is a basic portal</Header>
+        <p>Portals have tons of great callback functions to hook into.</p>
+        <p>To close, simply click the close button or click away</p>
+      </div>
+    )
+
+    return (
+      <div>
+        {
+          <Portal trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}>
+            {portalContent}
+          </Portal>
+        }
+        <Divider />
+        {controls}
+      </div>
+    )
+  }
+
+  private handleClick = () =>
+    this.setState({
+      log: [`${new Date().toLocaleTimeString()}: handleClick`, ...this.state.log].slice(0, 20),
+      logCount: this.state.logCount + 1,
+    })
+
+  private clearLog = () => this.setState({ log: [], logCount: 0 })
+}
+
+export default PortalExamplePortal

--- a/docs/src/examples/components/Portal/Types/PortalExample.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExample.tsx
@@ -1,61 +1,48 @@
 import React from 'react'
 import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
 
-class PortalExamplePortal extends React.Component<any, any> {
-  public state = {
-    log: [],
-    logCount: 0,
-  }
+class PortalExamplePortal extends React.Component {
+  state = { log: [], logCount: 0 }
 
-  public render() {
-    const { log, logCount } = this.state
-
-    const controls = (
-      <div>
-        <Button size="small" onClick={this.clearLog} content="Clear" />
-        <span>
-          Event Log <Label circular>{logCount}</Label>
-        </span>
-        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
-      </div>
-    )
-
-    const portalContent = (
-      <div
-        style={{
-          background: '#ddd',
-          position: 'fixed',
-          left: '40%',
-          top: '45%',
-          zIndex: 1000,
-        }}
-      >
-        <Header>This is a basic portal</Header>
-        <p>Portals have tons of great callback functions to hook into.</p>
-        <p>To close, simply click the close button or click away</p>
-      </div>
-    )
-
-    return (
-      <div>
-        {
-          <Portal trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}>
-            {portalContent}
-          </Portal>
-        }
-        <Divider />
-        {controls}
-      </div>
-    )
-  }
-
-  private handleClick = () =>
+  handleClick = () =>
     this.setState({
       log: [`${new Date().toLocaleTimeString()}: handleClick`, ...this.state.log].slice(0, 20),
       logCount: this.state.logCount + 1,
     })
 
-  private clearLog = () => this.setState({ log: [], logCount: 0 })
+  clearLog = () => this.setState({ log: [], logCount: 0 })
+
+  render() {
+    const { log, logCount } = this.state
+
+    return (
+      <div>
+        <Portal trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}>
+          <div
+            style={{
+              background: '#ddd',
+              position: 'fixed',
+              left: '40%',
+              top: '45%',
+              zIndex: 1000,
+            }}
+          >
+            <Header>This is a basic portal</Header>
+            <p>Portals have tons of great callback functions to hook into.</p>
+            <p>To close, simply click the close button or click away</p>
+          </div>
+        </Portal>
+        <Divider />
+        <div>
+          <Button size="small" onClick={this.clearLog} content="Clear" />
+          <span>
+            Event Log <Label circular>{logCount}</Label>
+          </span>
+          <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+        </div>
+      </div>
+    )
+  }
 }
 
 export default PortalExamplePortal

--- a/docs/src/examples/components/Portal/Types/PortalExampleControlled.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleControlled.shorthand.tsx
@@ -1,65 +1,58 @@
-import * as React from 'react'
+import React from 'react'
 import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
 
-class PortalExampleControlled extends React.Component<any, any> {
-  public state = {
-    log: [],
-    logCount: 0,
-    open: false,
-  }
+class PortalExampleControlled extends React.Component {
+  state = { log: [], logCount: 0, open: false }
 
-  public render() {
-    const { log, logCount, open } = this.state
-    const content = open ? 'Close Portal' : 'Open Portal'
-
-    const controls = (
-      <div>
-        <Button content={content} onClick={this.handleClick.bind(this, content)} />
-        <Divider />
-        <Button size="small" onClick={this.clearLog} content="Clear" />
-        <span>
-          Event Log <Label circular>{logCount}</Label>
-        </span>
-        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
-      </div>
-    )
-
-    const portalContent = (
-      <div
-        style={{
-          background: '#ddd',
-          position: 'fixed',
-          left: '40%',
-          top: '45%',
-          zIndex: 1000,
-        }}
-      >
-        <Header>This is a controlled portal</Header>
-        <p>Portals have tons of great callback functions to hook into.</p>
-        <p>To close, simply click the close button</p>
-      </div>
-    )
-
-    return (
-      <div>
-        {controls}
-        {<Portal open={open} content={portalContent} />}
-      </div>
-    )
-  }
-
-  private handleClick = (logContent: string) => {
+  handleClick = (logContent: string) => {
     this.setState({ open: !this.state.open })
     this.writeLog(logContent)
   }
 
-  private clearLog = () => this.setState({ log: [], logCount: 0 })
+  clearLog = () => this.setState({ log: [], logCount: 0 })
 
-  private writeLog = eventName =>
+  writeLog = eventName =>
     this.setState({
       log: [`${new Date().toLocaleTimeString()}: ${eventName}`, ...this.state.log].slice(0, 20),
       logCount: this.state.logCount + 1,
     })
+
+  render() {
+    const { log, logCount, open } = this.state
+    const btnContent = open ? 'Close Portal' : 'Open Portal'
+
+    return (
+      <div>
+        <div>
+          <Button content={btnContent} onClick={this.handleClick.bind(this, btnContent)} />
+          <Divider />
+          <Button size="small" onClick={this.clearLog} content="Clear" />
+          <span>
+            Event Log <Label circular>{logCount}</Label>
+          </span>
+          <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+        </div>
+        <Portal
+          open={open}
+          content={
+            <div
+              style={{
+                background: '#ddd',
+                position: 'fixed',
+                left: '40%',
+                top: '45%',
+                zIndex: 1000,
+              }}
+            >
+              <Header>This is a controlled portal</Header>
+              <p>Portals have tons of great callback functions to hook into.</p>
+              <p>To close, simply click the close button</p>
+            </div>
+          }
+        />
+      </div>
+    )
+  }
 }
 
 export default PortalExampleControlled

--- a/docs/src/examples/components/Portal/Types/PortalExampleControlled.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleControlled.shorthand.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
+
+class PortalExampleControlled extends React.Component<any, any> {
+  public state = {
+    log: [],
+    logCount: 0,
+    open: false,
+  }
+
+  public render() {
+    const { log, logCount, open } = this.state
+    const content = open ? 'Close Portal' : 'Open Portal'
+
+    const controls = (
+      <div>
+        <Button content={content} onClick={this.handleClick.bind(this, content)} />
+        <Divider />
+        <Button size="small" onClick={this.clearLog} content="Clear" />
+        <span>
+          Event Log <Label circular>{logCount}</Label>
+        </span>
+        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+      </div>
+    )
+
+    const portalContent = (
+      <div
+        style={{
+          background: '#ddd',
+          position: 'fixed',
+          left: '40%',
+          top: '45%',
+          zIndex: 1000,
+        }}
+      >
+        <Header>This is a controlled portal</Header>
+        <p>Portals have tons of great callback functions to hook into.</p>
+        <p>To close, simply click the close button</p>
+      </div>
+    )
+
+    return (
+      <div>
+        {controls}
+        {<Portal open={open} content={portalContent} />}
+      </div>
+    )
+  }
+
+  private handleClick = (logContent: string) => {
+    this.setState({ open: !this.state.open })
+    this.writeLog(logContent)
+  }
+
+  private clearLog = () => this.setState({ log: [], logCount: 0 })
+
+  private writeLog = eventName =>
+    this.setState({
+      log: [`${new Date().toLocaleTimeString()}: ${eventName}`, ...this.state.log].slice(0, 20),
+      logCount: this.state.logCount + 1,
+    })
+}
+
+export default PortalExampleControlled

--- a/docs/src/examples/components/Portal/Types/PortalExampleControlled.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleControlled.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
+
+class PortalExampleControlled extends React.Component<any, any> {
+  public state = {
+    log: [],
+    logCount: 0,
+    open: false,
+  }
+
+  public render() {
+    const { log, logCount, open } = this.state
+    const content = open ? 'Close Portal' : 'Open Portal'
+
+    const controls = (
+      <div>
+        <Button content={content} onClick={this.handleClick.bind(this, content)} />
+        <Divider />
+        <Button size="small" onClick={this.clearLog} content="Clear" />
+        <span>
+          Event Log <Label circular>{logCount}</Label>
+        </span>
+        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+      </div>
+    )
+
+    const portalContent = (
+      <div
+        style={{
+          background: '#ddd',
+          position: 'fixed',
+          left: '40%',
+          top: '45%',
+          zIndex: 1000,
+        }}
+      >
+        <Header>This is a controlled portal</Header>
+        <p>Portals have tons of great callback functions to hook into.</p>
+        <p>To close, simply click the close button</p>
+      </div>
+    )
+
+    return (
+      <div>
+        {controls}
+        {<Portal open={open}>{portalContent}</Portal>}
+      </div>
+    )
+  }
+
+  private handleClick = (logContent: string) => {
+    this.setState({ open: !this.state.open })
+    this.writeLog(logContent)
+  }
+
+  private clearLog = () => this.setState({ log: [], logCount: 0 })
+
+  private writeLog = eventName =>
+    this.setState({
+      log: [`${new Date().toLocaleTimeString()}: ${eventName}`, ...this.state.log].slice(0, 20),
+      logCount: this.state.logCount + 1,
+    })
+}
+
+export default PortalExampleControlled

--- a/docs/src/examples/components/Portal/Types/PortalExampleControlled.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleControlled.tsx
@@ -1,65 +1,55 @@
-import * as React from 'react'
+import React from 'react'
 import { Button, Divider, Header, Label, Portal } from '@stardust-ui/react'
 
-class PortalExampleControlled extends React.Component<any, any> {
-  public state = {
-    log: [],
-    logCount: 0,
-    open: false,
-  }
+class PortalExampleControlled extends React.Component {
+  state = { log: [], logCount: 0, open: false }
 
-  public render() {
-    const { log, logCount, open } = this.state
-    const content = open ? 'Close Portal' : 'Open Portal'
-
-    const controls = (
-      <div>
-        <Button content={content} onClick={this.handleClick.bind(this, content)} />
-        <Divider />
-        <Button size="small" onClick={this.clearLog} content="Clear" />
-        <span>
-          Event Log <Label circular>{logCount}</Label>
-        </span>
-        <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
-      </div>
-    )
-
-    const portalContent = (
-      <div
-        style={{
-          background: '#ddd',
-          position: 'fixed',
-          left: '40%',
-          top: '45%',
-          zIndex: 1000,
-        }}
-      >
-        <Header>This is a controlled portal</Header>
-        <p>Portals have tons of great callback functions to hook into.</p>
-        <p>To close, simply click the close button</p>
-      </div>
-    )
-
-    return (
-      <div>
-        {controls}
-        {<Portal open={open}>{portalContent}</Portal>}
-      </div>
-    )
-  }
-
-  private handleClick = (logContent: string) => {
+  handleClick = (logContent: string) => {
     this.setState({ open: !this.state.open })
     this.writeLog(logContent)
   }
 
-  private clearLog = () => this.setState({ log: [], logCount: 0 })
+  clearLog = () => this.setState({ log: [], logCount: 0 })
 
-  private writeLog = eventName =>
+  writeLog = eventName =>
     this.setState({
       log: [`${new Date().toLocaleTimeString()}: ${eventName}`, ...this.state.log].slice(0, 20),
       logCount: this.state.logCount + 1,
     })
+
+  render() {
+    const { log, logCount, open } = this.state
+    const btnContent = open ? 'Close Portal' : 'Open Portal'
+
+    return (
+      <div>
+        <div>
+          <Button content={btnContent} onClick={this.handleClick.bind(this, btnContent)} />
+          <Divider />
+          <Button size="small" onClick={this.clearLog} content="Clear" />
+          <span>
+            Event Log <Label circular>{logCount}</Label>
+          </span>
+          <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+        </div>
+        <Portal open={open}>
+          <div
+            style={{
+              background: '#ddd',
+              position: 'fixed',
+              left: '40%',
+              top: '45%',
+              zIndex: 1000,
+            }}
+          >
+            <Header>This is a controlled portal</Header>
+            <p>Portals have tons of great callback functions to hook into.</p>
+            <p>To close, simply click the close button</p>
+          </div>
+        </Portal>
+      </div>
+    )
+  }
 }
 
 export default PortalExampleControlled

--- a/docs/src/examples/components/Portal/Types/index.tsx
+++ b/docs/src/examples/components/Portal/Types/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ComponentExample from 'docs/src/components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
+
+const PortalTypesExamples = () => (
+  <ExampleSection title="Types">
+    <ComponentExample
+      title="Basic"
+      description="A basic portal."
+      examplePath="components/Portal/Types/PortalExample"
+    />
+    <ComponentExample
+      title="Controlled"
+      description="A controlled portal."
+      examplePath="components/Portal/Types/PortalExampleControlled"
+    />
+  </ExampleSection>
+)
+
+export default PortalTypesExamples

--- a/docs/src/examples/components/Portal/index.tsx
+++ b/docs/src/examples/components/Portal/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import Types from './Types'
+
+const PortalExamples = () => (
+  <div>
+    <Types />
+  </div>
+)
+
+export default PortalExamples

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,0 +1,151 @@
+import * as PropTypes from 'prop-types'
+import * as React from 'react'
+import { invoke } from 'lodash'
+
+import {
+  childrenExist,
+  customPropTypes,
+  AutoControlledComponent,
+  eventStack,
+  doesNodeContainClick,
+} from '../../lib'
+import { ItemShorthand, Extendable } from '../../../types/utils'
+import Ref from '../Ref'
+import PortalInner from './PortalInner'
+
+type ReactMouseEvent = React.MouseEvent<HTMLElement>
+
+export interface IPortalProps {
+  content?: ItemShorthand | ItemShorthand[]
+  defaultOpen?: boolean
+  onMount?: (props: IPortalProps) => void
+  onUnmount?: (props: IPortalProps) => void
+  open?: boolean
+  trigger?: JSX.Element
+  triggerRef?: (node: HTMLElement) => void
+}
+
+/**
+ * A component that allows you to render children outside their parent.
+ */
+class Portal extends AutoControlledComponent<Extendable<IPortalProps>, any> {
+  private portalNode: HTMLElement
+  private triggerNode: HTMLElement
+
+  public static autoControlledProps = ['open']
+
+  public static propTypes = {
+    /** Primary content. */
+    children: PropTypes.node,
+
+    /** Shorthand for primary content. */
+    content: customPropTypes.contentShorthand,
+
+    /** Initial value of open. */
+    defaultOpen: PropTypes.bool,
+
+    /**
+     * Called when the portal is mounted on the DOM.
+     *
+     * @param {object} data - All props.
+     */
+    onMount: PropTypes.func,
+
+    /**
+     * Called when the portal is unmounted from the DOM.
+     *
+     * @param {object} data - All props.
+     */
+    onUnmount: PropTypes.func,
+
+    /** Controls whether or not the portal is displayed. */
+    open: PropTypes.bool,
+
+    /** Element to be rendered in-place where the portal is defined. */
+    trigger: PropTypes.node,
+
+    /**
+     * Called with a ref to the trigger node.
+     *
+     * @param {JSX.Element} node - Referred node.
+     */
+    triggerRef: PropTypes.func,
+  }
+
+  public render() {
+    return (
+      <React.Fragment>
+        {this.renderPortal()}
+        {this.renderTrigger()}
+      </React.Fragment>
+    )
+  }
+
+  private renderPortal(): JSX.Element | undefined {
+    const { children, content } = this.props
+    const { open } = this.state
+
+    return (
+      open && (
+        <Ref innerRef={this.handlePortalRef}>
+          <PortalInner onMount={this.handleMount} onUnmount={this.handleUnmount}>
+            {childrenExist(children) ? children : content}
+          </PortalInner>
+        </Ref>
+      )
+    )
+  }
+
+  private renderTrigger(): JSX.Element | undefined {
+    const { trigger } = this.props
+
+    return (
+      trigger && (
+        <Ref innerRef={this.handleTriggerRef}>
+          {React.cloneElement(trigger, { onClick: this.handleTriggerClick })}
+        </Ref>
+      )
+    )
+  }
+
+  private handleMount = () => {
+    eventStack.sub('click', this.handleDocumentClick)
+    invoke(this.props, 'onMount', this.props)
+  }
+
+  private handleUnmount = () => {
+    eventStack.unsub('click', this.handleDocumentClick)
+    invoke(this.props, 'onUnmount', this.props)
+  }
+
+  private handlePortalRef = (portalNode: HTMLElement) => {
+    this.portalNode = portalNode
+  }
+
+  private handleTriggerRef = (triggerNode: HTMLElement) => {
+    this.triggerNode = triggerNode
+
+    invoke(this.props, 'triggerRef', triggerNode)
+  }
+
+  private handleTriggerClick = (e: ReactMouseEvent, ...rest) => {
+    const { trigger } = this.props
+
+    invoke(trigger, 'props.onClick', e, ...rest) // Call original event handler
+    this.trySetState({ open: !this.state.open })
+  }
+
+  private handleDocumentClick = (e: ReactMouseEvent) => {
+    if (
+      !this.portalNode || // no portal
+      doesNodeContainClick(this.triggerNode, e) || // event happened in trigger (delegate to trigger handlers)
+      doesNodeContainClick(this.portalNode, e) // event happened in the portal
+    ) {
+      return // ignore the click
+    }
+
+    this.trySetState({ open: false })
+  }
+}
+
+export default Portal

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,6 +1,6 @@
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
-import { invoke } from 'lodash'
+import * as _ from 'lodash'
 
 import {
   childrenExist,
@@ -9,13 +9,14 @@ import {
   eventStack,
   doesNodeContainClick,
 } from '../../lib'
-import { ItemShorthand, Extendable } from '../../../types/utils'
+import { ItemShorthand, Extendable, ReactChildren } from '../../../types/utils'
 import Ref from '../Ref'
 import PortalInner from './PortalInner'
 
 type ReactMouseEvent = React.MouseEvent<HTMLElement>
 
 export interface IPortalProps {
+  children?: ReactChildren
   content?: ItemShorthand | ItemShorthand[]
   defaultOpen?: boolean
   onMount?: (props: IPortalProps) => void
@@ -25,10 +26,14 @@ export interface IPortalProps {
   triggerRef?: (node: HTMLElement) => void
 }
 
+export interface IPortalState {
+  open?: boolean
+}
+
 /**
  * A component that allows you to render children outside their parent.
  */
-class Portal extends AutoControlledComponent<Extendable<IPortalProps>, any> {
+class Portal extends AutoControlledComponent<IPortalProps, IPortalState> {
   private portalNode: HTMLElement
   private triggerNode: HTMLElement
 
@@ -72,7 +77,18 @@ class Portal extends AutoControlledComponent<Extendable<IPortalProps>, any> {
     triggerRef: PropTypes.func,
   }
 
-  public render() {
+  public static handledProps = [
+    'children',
+    'content',
+    'defaultOpen',
+    'onMount',
+    'onUnmount',
+    'open',
+    'trigger',
+    'triggerRef',
+  ]
+
+  public renderComponent(): React.ReactNode {
     return (
       <React.Fragment>
         {this.renderPortal()}
@@ -110,12 +126,12 @@ class Portal extends AutoControlledComponent<Extendable<IPortalProps>, any> {
 
   private handleMount = () => {
     eventStack.sub('click', this.handleDocumentClick)
-    invoke(this.props, 'onMount', this.props)
+    _.invoke(this.props, 'onMount', this.props)
   }
 
   private handleUnmount = () => {
     eventStack.unsub('click', this.handleDocumentClick)
-    invoke(this.props, 'onUnmount', this.props)
+    _.invoke(this.props, 'onUnmount', this.props)
   }
 
   private handlePortalRef = (portalNode: HTMLElement) => {
@@ -125,13 +141,13 @@ class Portal extends AutoControlledComponent<Extendable<IPortalProps>, any> {
   private handleTriggerRef = (triggerNode: HTMLElement) => {
     this.triggerNode = triggerNode
 
-    invoke(this.props, 'triggerRef', triggerNode)
+    _.invoke(this.props, 'triggerRef', triggerNode)
   }
 
   private handleTriggerClick = (e: ReactMouseEvent, ...rest) => {
     const { trigger } = this.props
 
-    invoke(trigger, 'props.onClick', e, ...rest) // Call original event handler
+    _.invoke(trigger, 'props.onClick', e, ...rest) // Call original event handler
     this.trySetState({ open: !this.state.open })
   }
 

--- a/src/components/Portal/PortalInner.tsx
+++ b/src/components/Portal/PortalInner.tsx
@@ -1,0 +1,48 @@
+import * as PropTypes from 'prop-types'
+import { invoke } from 'lodash'
+import { Component } from 'react'
+import { createPortal } from 'react-dom'
+import { Extendable } from '../../../types/utils'
+
+export interface IPortalProps {
+  onMount?: (props: IPortalProps) => void
+  onUnmount?: (props: IPortalProps) => void
+}
+
+/**
+ * An inner component that allows you to render children outside their parent.
+ */
+class PortalInner extends Component<Extendable<IPortalProps>, any> {
+  public static propTypes = {
+    /** Primary content. */
+    children: PropTypes.node,
+
+    /**
+     * Called when the portal is mounted on the DOM
+     *
+     * @param {object} data - All props.
+     */
+    onMount: PropTypes.func,
+
+    /**
+     * Called when the portal is unmounted from the DOM
+     *
+     * @param {object} data - All props.
+     */
+    onUnmount: PropTypes.func,
+  }
+
+  public componentDidMount() {
+    invoke(this.props, 'onMount', { ...this.props })
+  }
+
+  public componentWillUnmount() {
+    invoke(this.props, 'onUnmount', { ...this.props })
+  }
+
+  public render() {
+    return createPortal(this.props.children, document.body)
+  }
+}
+
+export default PortalInner

--- a/src/components/Portal/PortalInner.tsx
+++ b/src/components/Portal/PortalInner.tsx
@@ -1,21 +1,27 @@
 import * as PropTypes from 'prop-types'
-import { invoke } from 'lodash'
+import * as _ from 'lodash'
 import { Component } from 'react'
 import { createPortal } from 'react-dom'
-import { Extendable } from '../../../types/utils'
+import { ReactChildren } from '../../../types/utils'
+import { isBrowser } from '../../lib'
 
-export interface IPortalProps {
-  onMount?: (props: IPortalProps) => void
-  onUnmount?: (props: IPortalProps) => void
+export interface IPortalInnerProps {
+  children?: ReactChildren
+  context?: HTMLElement
+  onMount?: (props: IPortalInnerProps) => void
+  onUnmount?: (props: IPortalInnerProps) => void
 }
 
 /**
  * An inner component that allows you to render children outside their parent.
  */
-class PortalInner extends Component<Extendable<IPortalProps>, any> {
+class PortalInner extends Component<IPortalInnerProps> {
   public static propTypes = {
     /** Primary content. */
-    children: PropTypes.node,
+    children: PropTypes.node.isRequired,
+
+    /** Existing element the portal should be bound to. */
+    context: PropTypes.object,
 
     /**
      * Called when the portal is mounted on the DOM
@@ -32,16 +38,22 @@ class PortalInner extends Component<Extendable<IPortalProps>, any> {
     onUnmount: PropTypes.func,
   }
 
+  public static defaultProps = {
+    context: isBrowser() ? document.body : null,
+  }
+
   public componentDidMount() {
-    invoke(this.props, 'onMount', { ...this.props })
+    _.invoke(this.props, 'onMount', this.props)
   }
 
   public componentWillUnmount() {
-    invoke(this.props, 'onUnmount', { ...this.props })
+    _.invoke(this.props, 'onUnmount', this.props)
   }
 
   public render() {
-    return createPortal(this.props.children, document.body)
+    const { children, context } = this.props
+
+    return context && createPortal(children, context)
   }
 }
 

--- a/src/components/Portal/index.ts
+++ b/src/components/Portal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Portal'

--- a/src/components/Ref/Ref.tsx
+++ b/src/components/Ref/Ref.tsx
@@ -1,10 +1,11 @@
 import * as PropTypes from 'prop-types'
-import { invoke } from 'lodash'
+import * as _ from 'lodash'
 import { Children, Component } from 'react'
 import { findDOMNode } from 'react-dom'
-import { Extendable } from '../../../types/utils'
+import { ReactChildren } from 'utils'
 
 export interface IRefProps {
+  children?: ReactChildren
   innerRef?: (ref: HTMLElement) => void
 }
 
@@ -12,7 +13,7 @@ export interface IRefProps {
  * This component exposes a callback prop that always returns the DOM node of both functional and class component
  * children.
  */
-export default class Ref extends Component<Extendable<IRefProps>, any> {
+export default class Ref extends Component<IRefProps> {
   static propTypes = {
     /** Primary content. */
     children: PropTypes.element,
@@ -26,7 +27,7 @@ export default class Ref extends Component<Extendable<IRefProps>, any> {
   }
 
   componentDidMount() {
-    invoke(this.props, 'innerRef', findDOMNode(this))
+    _.invoke(this.props, 'innerRef', findDOMNode(this))
   }
 
   render() {

--- a/src/components/Ref/Ref.tsx
+++ b/src/components/Ref/Ref.tsx
@@ -1,0 +1,35 @@
+import * as PropTypes from 'prop-types'
+import { invoke } from 'lodash'
+import { Children, Component } from 'react'
+import { findDOMNode } from 'react-dom'
+import { Extendable } from '../../../types/utils'
+
+export interface IRefProps {
+  innerRef?: (ref: HTMLElement) => void
+}
+
+/**
+ * This component exposes a callback prop that always returns the DOM node of both functional and class component
+ * children.
+ */
+export default class Ref extends Component<Extendable<IRefProps>, any> {
+  static propTypes = {
+    /** Primary content. */
+    children: PropTypes.element,
+
+    /**
+     * Called when componentDidMount.
+     *
+     * @param {HTMLElement} node - Referred node.
+     */
+    innerRef: PropTypes.func,
+  }
+
+  componentDidMount() {
+    invoke(this.props, 'innerRef', findDOMNode(this))
+  }
+
+  render() {
+    return Children.only(this.props.children)
+  }
+}

--- a/src/components/Ref/index.ts
+++ b/src/components/Ref/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Ref'

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,3 +32,4 @@ export { default as ToolbarBehavior } from './lib/accessibility/Behaviors/Toolba
 export {
   default as ToolbarButtonBehavior,
 } from './lib/accessibility/Behaviors/Toolbar/ToolbarButtonBehavior'
+export { default as Portal } from './components/Portal'

--- a/test/specs/components/Portal/Portal-test.tsx
+++ b/test/specs/components/Portal/Portal-test.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react'
+import _ from 'lodash'
+import { mount } from 'enzyme'
+import { domEvent } from '../../../utils'
+
+import Portal, { IPortalProps } from 'src/components/Portal/Portal'
+import PortalInner from 'src/components/Portal/PortalInner'
+
+describe('Portal', () => {
+  let wrapper: any
+
+  const mountPortal = (props: IPortalProps = {}, options?) =>
+    (wrapper = mount(<Portal content={<p />} {...props} />, options))
+
+  const testPortalInnerIsOpen = (visible: boolean) => {
+    expect(wrapper.find(PortalInner).length).toBe(visible ? 1 : 0)
+  }
+
+  const testPortalState = (content: React.ReactNode, state: 'open' | 'closed') => {
+    const portalIsOpen = state === 'open'
+
+    testPortalInnerIsOpen(portalIsOpen)
+    expect(wrapper.contains(content)).toBe(portalIsOpen)
+  }
+
+  describe('open', () => {
+    it('opens the portal when toggled from false to true', () => {
+      const content = <p />
+      mountPortal({ content })
+      testPortalState(content, 'closed')
+
+      wrapper.setProps({ open: true })
+      testPortalState(content, 'open')
+    })
+
+    it('closes the portal when toggled from true to false ', () => {
+      const content = <p />
+      mountPortal({ content, open: true })
+      testPortalState(content, 'open')
+
+      wrapper.setProps({ open: false })
+      testPortalState(content, 'closed')
+    })
+  })
+
+  describe('click', () => {
+    it('opens the portal on trigger click when true', () => {
+      const spy = jest.fn()
+      mountPortal({ trigger: <button onClick={spy}> button </button> })
+      testPortalInnerIsOpen(false)
+
+      wrapper.find('button').simulate('click')
+      testPortalInnerIsOpen(true)
+    })
+
+    it('closes the portal on click when set', () => {
+      mountPortal({ trigger: <button />, defaultOpen: true })
+      testPortalInnerIsOpen(true)
+
+      wrapper.find('button').simulate('click')
+      testPortalInnerIsOpen(false)
+    })
+  })
+
+  describe('document click', () => {
+    it('closes the portal', () => {
+      mountPortal({ defaultOpen: true })
+      testPortalInnerIsOpen(true)
+
+      domEvent.click(document)
+      wrapper.update()
+      testPortalInnerIsOpen(false)
+    })
+
+    it('does not close on click inside', () => {
+      mountPortal({ content: <p id="inner" />, defaultOpen: true })
+      testPortalInnerIsOpen(true)
+
+      domEvent.click('#inner')
+      wrapper.update()
+      testPortalInnerIsOpen(true)
+    })
+  })
+
+  describe('onMount', () => {
+    it('called when portal opens', () => {
+      const props = { open: false, onMount: jest.fn() }
+      mountPortal(props)
+      wrapper.setProps({ open: true })
+
+      expect(props.onMount).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('onUnmount', () => {
+    it('is called when portal closes', () => {
+      const onUnmount = jest.fn()
+      mountPortal({ open: true, onUnmount })
+      wrapper.setProps({ open: false })
+
+      expect(onUnmount).toHaveBeenCalledTimes(1)
+    })
+
+    it('is called only once when portal closes and then is unmounted', () => {
+      const onUnmount = jest.fn()
+      mountPortal({ open: true, onUnmount })
+      wrapper.setProps({ open: false })
+      wrapper.unmount()
+
+      expect(onUnmount).toHaveBeenCalledTimes(1)
+    })
+
+    it('is called only once when directly unmounting', () => {
+      const onUnmount = jest.fn()
+      mountPortal({ open: true, onUnmount })
+      wrapper.unmount()
+
+      expect(onUnmount).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('triggerRef', () => {
+    it('maintains ref on the trigger', () => {
+      const triggerRef = jest.fn()
+      const mountNode = document.createElement('div')
+      document.body.appendChild(mountNode)
+
+      mountPortal({ trigger: <button id="trigger" />, triggerRef }, { attachTo: mountNode })
+
+      const triggerElem = document.querySelector('#trigger')
+
+      expect(triggerRef).toHaveBeenCalledTimes(1)
+      expect(triggerRef).toHaveBeenCalledWith(triggerElem)
+
+      wrapper.detach()
+      document.body.removeChild(mountNode)
+    })
+  })
+
+  describe('trigger', () => {
+    it('renders null when not set', () => {
+      mountPortal()
+
+      expect(wrapper.html()).toEqual(null)
+    })
+
+    it('renders the trigger when set', () => {
+      const text = 'open by click on me'
+      const trigger = <button>{text}</button>
+      mountPortal({ trigger })
+
+      expect(wrapper.find('button').length).toBe(1)
+      expect(wrapper.text()).toEqual(text)
+    })
+  })
+})

--- a/test/specs/components/PortalInner/PortalInner-test.tsx
+++ b/test/specs/components/PortalInner/PortalInner-test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import PortalInner, { IPortalInnerProps } from 'src/components/Portal/PortalInner'
+
+const mountPortalInner = (props: IPortalInnerProps) =>
+  mount(
+    <PortalInner {...props}>
+      <p />
+    </PortalInner>,
+  )
+
+describe('PortalInner', () => {
+  describe('render', () => {
+    it('calls react createPortal', () => {
+      const context = document.createElement('div')
+      const comp = mountPortalInner({ context })
+
+      expect(context.contains(comp.getDOMNode())).toBeTruthy()
+    })
+  })
+
+  describe('onMount', () => {
+    it('called when mounting', () => {
+      const handlerSpy = jest.fn()
+      mountPortalInner({ onMount: handlerSpy })
+
+      expect(handlerSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('onUnmount', () => {
+    it('is called only once when unmounting', () => {
+      const handlerSpy = jest.fn()
+      const wrapper = mountPortalInner({ onUnmount: handlerSpy })
+      wrapper.unmount()
+
+      expect(handlerSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/specs/components/Ref/Ref-test.tsx
+++ b/test/specs/components/Ref/Ref-test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { shallow, mount } from 'enzyme'
+
+import { CompositeClass, CompositeFunction, DOMClass, DOMFunction } from './fixtures'
+import Ref from 'src/components/Ref'
+
+const testInnerRef = Component => {
+  const innerRef = jest.fn()
+  const node = mount(
+    <Ref innerRef={innerRef}>
+      <Component />
+    </Ref>,
+  ).getDOMNode()
+
+  expect(innerRef).toHaveBeenCalledTimes(1)
+  expect(innerRef).toHaveBeenCalledWith(node)
+}
+
+describe('Ref', () => {
+  describe('children', () => {
+    it('renders single child', () => {
+      const child = <div data-child="whatever" />
+      const component = shallow(<Ref>{child}</Ref>)
+
+      expect(component.contains(child)).toBeTruthy()
+    })
+  })
+
+  describe('innerRef', () => {
+    it('returns node from a functional component with DOM node', () => {
+      testInnerRef(DOMFunction)
+    })
+
+    it('returns node from a functional component', () => {
+      testInnerRef(CompositeFunction)
+    })
+
+    it('returns node from a class component with DOM node', () => {
+      testInnerRef(DOMClass)
+    })
+
+    it('returns node from a class component', () => {
+      testInnerRef(CompositeClass)
+    })
+  })
+})

--- a/test/specs/components/Ref/fixtures.tsx
+++ b/test/specs/components/Ref/fixtures.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import Component = React.Component
+
+export const DOMFunction = props => <div {...props} id="node" />
+
+export const CompositeFunction = props => <DOMFunction {...props} />
+
+export class DOMClass extends Component {
+  render() {
+    return <div {...this.props} id="node" />
+  }
+}
+
+export class CompositeClass extends Component {
+  render() {
+    return <DOMClass {...this.props} />
+  }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Portal

This PR will introduce **Portal** component, a component that allows you to render children outside their parent (for now all portals are rendered at the end of the `body` DOM element); a **Portal** comes with the following props: 
- `onMount?: (props: IPortalProps) => void`: Called when the portal is mounted on the DOM
- `onUnmount?: (props: IPortalProps) => void`: Called when the portal is unmounted from the DOM
- `open?: boolean`: Controls whether or not the portal is displayed
- `trigger?: JSX.Element`: Element to be rendered in-place where the portal is defined
- `triggerRef?: (node: HTMLElement) => void`: Called with a ref to the trigger node

and the following helper components used by **Portal**:
- **PortalInner** with props:
  - `onMount?: (props: IPortalProps) => void`: Called when the portal is mounted on the DOM
  - `onUnmount?: (props: IPortalProps) => void`: Called when the portal is unmounted from the DOM

- **Ref** with props:
  - `innerRef?: (ref: HTMLElement) => void`: Called with `componentDidMount`

### TODO

- [ ] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [x] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# Proposal

## Basic portal

![screen shot 2018-08-27 at 17 27 10](https://user-images.githubusercontent.com/5442794/44674449-d2b30d00-aa2d-11e8-981c-8f8ae3334a82.png)

Renders a portal that is:
- opened when clicking on the `trigger`, a component sent to the portal as a prop;
- closed when clicking away or on the `trigger` (since it acts like a toggle)

```jsx
<Portal
  content={<div>This is a basic portal</div>}
  trigger={<Button content={'Toggle portal'} onClick={this.handleClick} />}
/>
```
generates
```html
<button>Toggle portal</button>
```
and at the end of `body` DOM element:
```html
<body>
  ...
  <div>This is a basic portal</div>
</body>
```

## Controlled portal

![screen shot 2018-08-27 at 17 26 25](https://user-images.githubusercontent.com/5442794/44674941-56212e00-aa2f-11e8-8745-197efa259104.png)

Renders a portal that is rendered or not depending on the value of `open` property

```jsx
<Portal
  content={<div>This is a controlled portal</div>}
  open={true}
/>
```
generates
```html
<body>
  ...
  <div>This is a controlled portal</div>
</body>
```
<button>Toggle portal</button>
at the end of `body` DOM element.
