### PR TITLE
docs: fix component examples route match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix component variables when merging themes @levithomason ([#128](https://github.com/stardust-ui/react/pull/128))
 - Fix docs *Maximize* for shorthand examples @miroslavstastny ([#122](https://github.com/stardust-ui/react/pull/122))
 - Fix Button styles when rendered as an anchor @levithomason ([#145](https://github.com/stardust-ui/react/pull/145))
+- Fix Layout doc page showing ItemLayout examples @levithomason ([#160](https://github.com/stardust-ui/react/pull/160))
 
 ### Features
 - Add basic `Radio` component @alinais ([#100](https://github.com/stardust-ui/react/pull/100))

--- a/docs/src/components/ComponentDoc/ComponentExamples.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExamples.tsx
@@ -34,7 +34,7 @@ export default class ComponentExamples extends React.Component<IComponentExample
 
     // rule #1
     const indexPath = _.find(allPaths, path =>
-      new RegExp(`(\/|^)${displayName}\/index\.tsx$`).test(path),
+      new RegExp(`\/${displayName}\/index\.tsx$`).test(path),
     )
     if (!indexPath) {
       return null


### PR DESCRIPTION
The currently published doc site shows the ItemLayout examples on the Layout doc page.  This is because the RegExp for matching examples to route names only required the example name to include the component displayName.  It has been updated to require an exact match.