### PR TITLE
feat(renderComponent): merged state and props for styles and accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Correct Teams theme site variables @sergiorv ([#110](https://github.com/stardust-ui/react/pull/110))
 
+### Features
+- Add `state` to `props` in component styling functions @Bugaa92 ([#173](https://github.com/stardust-ui/react/pull/173))
+
 <!--------------------------------[ v0.5.0 ]------------------------------- -->
 ## [v0.5.0](https://github.com/stardust-ui/react/tree/v0.5.0) (2018-08-30)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.4.0...v0.5.0)

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -10,12 +10,12 @@ import getUnhandledProps from './getUnhandledProps'
 
 import {
   ComponentStyleFunctionParam,
-  ComponentVariablesInput,
   ComponentVariablesObject,
   IComponentPartClasses,
-  IComponentPartStylesInput,
   IComponentPartStylesPrepared,
   IProps,
+  IPropsWithVarsAndStyles,
+  IState,
   IThemeInput,
   IThemePrepared,
 } from '../../types/theme'
@@ -34,27 +34,18 @@ export interface IRenderResultConfig<P> {
 
 export type RenderComponentCallback<P> = (config: IRenderResultConfig<P>) => any
 
-type IRenderConfigProps = {
-  [key: string]: any
-  variables?: ComponentVariablesInput
-  styles?: IComponentPartStylesInput
-}
-
 export interface IRenderConfig {
   className?: string
   defaultProps?: { [key: string]: any }
   displayName: string
   handledProps: string[]
-  props: IRenderConfigProps
-  state: { [key: string]: any }
+  props: IPropsWithVarsAndStyles
+  state: IState
 }
 
-const getAccessibility = <P extends {}>(props, state) => {
+const getAccessibility = (props: IState & IPropsWithVarsAndStyles) => {
   const { accessibility: customAccessibility, defaultAccessibility } = props
-  return callable(customAccessibility || defaultAccessibility || DefaultBehavior)({
-    ...props,
-    ...state,
-  })
+  return callable(customAccessibility || defaultAccessibility || DefaultBehavior)(props)
 }
 
 const renderComponent = <P extends {}>(
@@ -83,7 +74,11 @@ const renderComponent = <P extends {}>(
 
         // Resolve styles using resolved variables, merge results, allow props.styles to override
         const mergedStyles = mergeComponentStyles(componentStyles[displayName], props.styles)
-        const styleParam: ComponentStyleFunctionParam = { props, variables: resolvedVariables }
+        const stateAndProps = { ...state, ...props }
+        const styleParam: ComponentStyleFunctionParam = {
+          props: stateAndProps,
+          variables: resolvedVariables,
+        }
         const resolvedStyles = Object.keys(mergedStyles).reduce(
           (acc, next) => ({ ...acc, [next]: callable(mergedStyles[next])(styleParam) }),
           {},
@@ -92,7 +87,7 @@ const renderComponent = <P extends {}>(
         const classes: IComponentPartClasses = getClasses(renderer, mergedStyles, styleParam)
         classes.root = cx(className, classes.root, props.className)
 
-        const accessibility = getAccessibility(props, state)
+        const accessibility = getAccessibility(stateAndProps)
 
         const config: IRenderResultConfig<P> = {
           ElementType,

--- a/test/specs/commonTests/stylesFunction-test.tsx
+++ b/test/specs/commonTests/stylesFunction-test.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react'
+import * as _ from 'lodash'
+import { UIComponent } from 'src/lib'
+import { Extendable } from 'types/utils'
+import { ICSSInJSStyle } from 'types/theme'
+import { getTestingRenderedComponent } from 'test/utils'
+
+type AttrValue = 'props' | 'state'
+
+interface IProps {
+  propsAttr?: AttrValue
+  commonAttr?: AttrValue
+}
+
+interface IState {
+  commonAttr?: AttrValue
+  stateAttr?: AttrValue
+}
+
+type IPropsAndState = IProps & IState
+
+const testClassName = 'ui-test-component'
+
+const testStylesForComponent = ({
+  props,
+  state,
+  expected,
+}: { props?: IProps; state?: IState; expected?: IPropsAndState } = {}) => {
+  class TestComponent extends UIComponent<Extendable<IProps>, IState> {
+    public static className = testClassName
+    public static handledProps = ['propsAttr', 'commonAttr', 'styles']
+
+    public state = state
+
+    public renderComponent({ ElementType, classes, rest }): React.ReactNode {
+      return <ElementType {...rest} className={classes.root} />
+    }
+  }
+
+  const TestStylesComponent = (props: Extendable<IProps>) => (
+    <TestComponent
+      {...props}
+      styles={{
+        root: ({ props }: { props: IPropsAndState }): ICSSInJSStyle => {
+          expect(_.mapValues(expected, (val, key) => props[key])).toEqual(expected)
+          return {}
+        },
+      }}
+    />
+  )
+
+  getTestingRenderedComponent(TestStylesComponent, <TestStylesComponent {...props} />)
+}
+
+describe('styles function', () => {
+  it('receives as argument only props object if state is not set', () => {
+    testStylesForComponent({ expected: {} })
+
+    testStylesForComponent({
+      props: { propsAttr: 'props' },
+      expected: { propsAttr: 'props' },
+    })
+
+    testStylesForComponent({
+      props: { propsAttr: 'props', commonAttr: 'props' },
+      expected: { propsAttr: 'props', commonAttr: 'props' },
+    })
+  })
+
+  it('receives as argument a simple merge of props and state objects if both are set but there are no overlapping properties', () => {
+    testStylesForComponent({
+      props: { propsAttr: 'props' },
+      state: { stateAttr: 'state' },
+      expected: { propsAttr: 'props', stateAttr: 'state' },
+    })
+
+    testStylesForComponent({
+      props: { propsAttr: 'props' },
+      state: { commonAttr: 'state', stateAttr: 'state' },
+      expected: { propsAttr: 'props', commonAttr: 'state', stateAttr: 'state' },
+    })
+
+    testStylesForComponent({
+      props: { propsAttr: 'props', commonAttr: 'props' },
+      state: { stateAttr: 'state' },
+      expected: { propsAttr: 'props', commonAttr: 'props', stateAttr: 'state' },
+    })
+  })
+
+  it('receives as argument a merge of props and state objects where props have priority over state when we have overlapping properties', () => {
+    testStylesForComponent({
+      props: { commonAttr: 'props' },
+      state: { commonAttr: 'state' },
+      expected: { commonAttr: 'props' },
+    })
+
+    testStylesForComponent({
+      props: { propsAttr: 'props', commonAttr: 'props' },
+      state: { commonAttr: 'state' },
+      expected: { propsAttr: 'props', commonAttr: 'props' },
+    })
+
+    testStylesForComponent({
+      props: { commonAttr: 'props' },
+      state: { commonAttr: 'state', stateAttr: 'state' },
+      expected: { commonAttr: 'props', stateAttr: 'state' },
+    })
+
+    testStylesForComponent({
+      props: { propsAttr: 'props', commonAttr: 'props' },
+      state: { commonAttr: 'state', stateAttr: 'state' },
+      expected: { propsAttr: 'props', commonAttr: 'props', stateAttr: 'state' },
+    })
+  })
+})

--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -1,6 +1,7 @@
 import * as CSSType from 'csstype'
 import { IRenderer as IFelaRenderer } from 'fela'
 import * as React from 'react'
+import { Extendable } from './utils'
 
 // Themes go through 3 phases.
 // 1. Input - (from the user), variable and style objects/functions, some values optional
@@ -21,6 +22,17 @@ type ObjectOf<T> = { [key: string]: T }
 // ========================================================
 
 export type IProps = ObjectOf<any>
+
+export type IPropsWithVarsAndStyles = Extendable<{
+  variables?: ComponentVariablesInput
+  styles?: IComponentPartStylesInput
+}>
+
+// ========================================================
+// State
+// ========================================================
+
+export type IState = ObjectOf<any>
 
 // ========================================================
 // Variables
@@ -77,7 +89,7 @@ export interface ICSSInJSStyle extends React.CSSProperties {
 }
 
 export interface ComponentStyleFunctionParam {
-  props: IProps
+  props: IState & IPropsWithVarsAndStyles
   variables: ComponentVariablesObject
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Component style function

This PR adds the ability to receive a unified (merged) object of `props` and `state` as argument to component's style functions, as well as to the accessibility behaviors.

More details in the dedicated issue: #161 

### TODO

- [x] Conformance test
- [ ] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# API Proposal

## Before

```typescript
const buttonStyles: IComponentPartStylesInput = {
  root: ({
    props,
    variables
  }: { props: IButtonProps; variables: IButtonVars }): ICSSInJSStyle => {
    // props contains all props properties of the button
    return {}
  },
}
```

## After

```typescript
const buttonStyles: IComponentPartStylesInput = {
  root: ({
    props,
    variables
  }: { props: IButtonProps & IButtonState; variables: IButtonVars }): ICSSInJSStyle => {
    // props contains props and state properties merged, with props taking priority
    // in case of overlapping properties
    return {}
  },
}
```