### PR TITLE
docs: add guide for debugging unit tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -471,6 +471,30 @@ yarn test
 yarn test:watch
 ```
 
+#### Debugging tests
+
+1. Open `Chrome DevTools` and drag & drop the whole `react/` repo directory there, then click allow
+
+[]
+
+2. Go to project sources and in `config.ts` replace `cheap-source-map` string with `eval-source-map`
+
+3. Go to console and run:
+```bash
+node --inspect-brk node_modules/.bin/jest --runInBand [PATTERN_FOR_TEST_FILENAME]
+```
+
+e.g.:
+```bash
+node --inspect-brk node_modules/.bin/jest --runInBand ChatList*
+```
+
+4. Go to `Chrome DevTools` and click on the green button to open `Dedicated DevTools for Node.js`
+
+[]
+
+5. Press `Ctrl+P` to navigate to your test files, add breakpoints and resume execution
+
 ## State
 
 Strive to use stateless functional components when possible:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Docs

Added guid for debugging UTs.

Screenshots I used:

1:
![screen shot 2018-09-03 at 17 19 15](https://user-images.githubusercontent.com/5442794/44994711-35615700-afa0-11e8-9120-a27ab52ec0db.png)

2:
![screen shot 2018-09-03 at 17 20 20](https://user-images.githubusercontent.com/5442794/44994715-3a260b00-afa0-11e8-9afb-169506780af3.png)

