### PR TITLE
feat(Button): add iconOnly prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `state` to `props` in component styling functions @Bugaa92 ([#173](https://github.com/stardust-ui/react/pull/173))
 - Adding `behaviors` section to the menu, under the components @kolaps33 ([#119](https://github.com/stardust-ui/react/pull/119))
 - Add `avatar` prop to `Chat.Message` subcomponent @Bugaa92 ([#159](https://github.com/stardust-ui/react/pull/159))
+- add `iconOnly` prop to `Button` @mnajdova ([#182](https://github.com/stardust-ui/react/pull/182))
 
 <!--------------------------------[ v0.5.0 ]------------------------------- -->
 ## [v0.5.0](https://github.com/stardust-ui/react/tree/v0.5.0) (2018-08-30)

--- a/docs/src/examples/components/Button/Types/ButtonExampleIconOnly.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleIconOnly.shorthand.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Button } from '@stardust-ui/react'
+
+const ButtonExampleIconOnly = () => <Button type="primary" icon="book" iconOnly />
+
+export default ButtonExampleIconOnly

--- a/docs/src/examples/components/Button/Types/ButtonExampleIconOnly.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleIconOnly.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Button, Icon } from '@stardust-ui/react'
+
+const ButtonExampleIconOnly = () => (
+  <Button type="primary" icon iconOnly>
+    <Icon name="book" xSpacing="none" />
+  </Button>
+)
+
+export default ButtonExampleIconOnly

--- a/docs/src/examples/components/Button/Types/index.tsx
+++ b/docs/src/examples/components/Button/Types/index.tsx
@@ -20,6 +20,11 @@ const Types = () => (
       examplePath="components/Button/Types/ButtonExampleIcon"
     />
     <ComponentExample
+      title="Icon Only"
+      description="A button can be formatted differently if it indicate that it contains only an icon."
+      examplePath="components/Button/Types/ButtonExampleIconOnly"
+    />
+    <ComponentExample
       title="Content and Icon"
       description="A button can have an icon in addition to content."
       examplePath="components/Button/Types/ButtonExampleContentAndIcon"

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -22,6 +22,7 @@ export interface IButtonProps {
   content?: React.ReactNode
   fluid?: boolean
   icon?: ItemShorthand
+  iconOnly?: boolean
   iconPosition?: 'before' | 'after'
   onClick?: ComponentEventHandler<IButtonProps>
   type?: 'primary' | 'secondary'
@@ -71,6 +72,9 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
     /** Button can have an icon. */
     icon: customPropTypes.itemShorthand,
 
+    /** A button may indicate that it has only icon. */
+    iconOnly: PropTypes.bool,
+
     /** An icon button can format an Icon to appear before or after the button */
     iconPosition: PropTypes.oneOf(['before', 'after']),
 
@@ -104,6 +108,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
     'disabled',
     'fluid',
     'icon',
+    'iconOnly',
     'iconPosition',
     'onClick',
     'styles',
@@ -143,7 +148,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
   }
 
   public renderIcon = variables => {
-    const { disabled, icon, iconPosition, content, type } = this.props
+    const { icon, iconPosition, content, type } = this.props
 
     return Icon.create(icon, {
       defaultProps: {

--- a/src/themes/teams/components/Button/buttonStyles.ts
+++ b/src/themes/teams/components/Button/buttonStyles.ts
@@ -4,7 +4,7 @@ import { disabledStyle, truncateStyle } from '../../../../styles/customCSS'
 
 const buttonStyles: IComponentPartStylesInput = {
   root: ({ props, variables }: { props: any; variables: any }): ICSSInJSStyle => {
-    const { circular, disabled, fluid, type } = props
+    const { circular, disabled, fluid, type, iconOnly } = props
     const primary = type === 'primary'
     const secondary = type === 'secondary'
 
@@ -86,6 +86,11 @@ const buttonStyles: IComponentPartStylesInput = {
           borderColor: undefined,
           backgroundColor: undefined,
         },
+      }),
+
+      ...(iconOnly && {
+        minWidth: height,
+        padding: 0,
       }),
     }
   },


### PR DESCRIPTION
# Button

Added `iconOnly` prop to format the button in a more fitted way if it indicates that contains only an icon.

### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# API Proposal

## iconOnly: boolean

![image](https://user-images.githubusercontent.com/4512430/45037548-8d12c780-b05f-11e8-9e26-4db529cfcb41.png)

```jsx
<Button type="primary" icon="book" iconOnly />
```

```html
<button class="ui-button ..." aria-disabled="false">
  <span class="ui-icon ..." aria-hidden="true"></span>
</button>
```

# Question
The doubt I have regarding this is, whether this should be the default look when the Button contains only an icon, and how would we be aware if it contains only an icon when using the children API in order to have a consistent look in the shorthand and children API. As I didn't have a clear vision how this should work, I introduced explicit prop that would indicate this. I am open to any alternative proposals on this.
