### PR TITLE
fix(Divider, Menu): replacing the gray12 from variables to gray08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Correct Teams theme site variables @sergiorv ([#110](https://github.com/stardust-ui/react/pull/110))
+- Fixed missing colors from the siteVariables @mnajdova ([#200](https://github.com/stardust-ui/react/pull/200))
 
 ### Features
 - Add `state` to `props` in component styling functions @Bugaa92 ([#173](https://github.com/stardust-ui/react/pull/173))

--- a/src/themes/teams/components/Divider/dividerVariables.ts
+++ b/src/themes/teams/components/Divider/dividerVariables.ts
@@ -1,7 +1,7 @@
 export default (siteVars: any) => {
   return {
     defaultColor: siteVars.gray04,
-    defaultBackgroundColor: siteVars.gray12,
+    defaultBackgroundColor: siteVars.gray08,
     typePrimaryColor: siteVars.brand,
     typePrimaryBackgroundColor: siteVars.brand,
     typeSecondaryColor: siteVars.gray02,

--- a/src/themes/teams/components/Menu/menuVariables.ts
+++ b/src/themes/teams/components/Menu/menuVariables.ts
@@ -31,7 +31,7 @@ export default (siteVars: any): IMenuVariables => {
     typePrimaryBackgroundColorHover: siteVars.brand16,
     typePrimaryBorderColor: siteVars.brand08,
     typePrimaryActiveBorderColor: siteVars.brand12,
-    typePrimaryUnderlinedBorderColor: siteVars.gray12,
+    typePrimaryUnderlinedBorderColor: siteVars.gray08,
 
     iconsMenuItemSize: undefined,
     iconsMenuItemSpacing: 0,


### PR DESCRIPTION
# Fix
The gray12 was deleted from the siteVariables which broke the look of the components using this color, as it was undefined. This was now replaced with gray08.

The components affected by this were the `Divider` (the border color for the default Divider) and the `Menu` (the bottom border color of the underined Menu).
