### PR TITLE
fix: teams theme font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Correct Teams theme site variables @sergiorv ([#110](https://github.com/stardust-ui/react/pull/110))
-- Fixed missing colors from the siteVariables @mnajdova ([#200](https://github.com/stardust-ui/react/pull/200))
+- Fixed missing colors in Teams' siteVariables @mnajdova ([#200](https://github.com/stardust-ui/react/pull/200))
+- Fixed Teams' siteVariables font sizes @levithomason ([#204](https://github.com/stardust-ui/react/pull/204))
 
 ### Features
 - Add `state` to `props` in component styling functions @Bugaa92 ([#173](https://github.com/stardust-ui/react/pull/173))

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -6,6 +6,7 @@ import { AppContainer } from 'react-hot-loader'
 import { Provider, themes } from '@stardust-ui/react'
 
 import Router from './routes'
+import { mergeThemes } from '../../src/lib'
 
 // ----------------------------------------
 // Rendering
@@ -17,7 +18,15 @@ document.body.appendChild(mountNode)
 const render = NewApp =>
   ReactDOM.render(
     <AppContainer>
-      <Provider theme={themes.teams}>
+      <Provider
+        theme={mergeThemes(themes.teams, {
+          // adjust Teams' theme to Semantic UI's font size scheme
+          siteVariables: {
+            htmlFontSize: '14px',
+            bodyFontSize: '1rem',
+          },
+        })}
+      >
         <NewApp />
       </Provider>
     </AppContainer>,

--- a/src/themes/teams/siteVariables.ts
+++ b/src/themes/teams/siteVariables.ts
@@ -3,7 +3,7 @@ import { pxToRem } from '../../lib'
 //
 // VARIABLES
 //
-export const htmlFontSize = '14px' // what 1rem represents
+export const htmlFontSize = '10px' // what 1rem represents
 
 //
 // COLORS
@@ -73,6 +73,6 @@ export const lineHeightExtraSmall = 1.2
 export const bodyPadding = 0
 export const bodyMargin = 0
 export const bodyFontFamily = '"Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif'
-export const bodyFontSize = '1rem'
+export const bodyFontSize = '1.4rem'
 export const bodyColor = black
 export const bodyLineHeight = lineHeightBase


### PR DESCRIPTION
The Teams theme uses an html font size of 10px and scales the body by `1.4rem` to achieve a 14px body size.

This PR updates the html and body font size values in Teams' theme.  It also scales the doc site Provider values to maintain Semantic UI's 14px html font size need.
