### PR TITLE
fix: text component docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correct Teams theme site variables @sergiorv ([#110](https://github.com/stardust-ui/react/pull/110))
 - Fixed missing colors in Teams' siteVariables @mnajdova ([#200](https://github.com/stardust-ui/react/pull/200))
 - Fixed Teams' siteVariables font sizes @levithomason ([#204](https://github.com/stardust-ui/react/pull/204))
+- Fixed docs examples of `Text` component @codepretty ([#205](https://github.com/stardust-ui/react/pull/205))
 
 ### Features
 - Add `state` to `props` in component styling functions @Bugaa92 ([#173](https://github.com/stardust-ui/react/pull/173))
@@ -31,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `ButtonGroup` component @mnajdova ([#179](https://github.com/stardust-ui/react/pull/179))
 - Add Button `text` prop @mnajdova ([#177](https://github.com/stardust-ui/react/pull/177))
 - Add accessibility keyboard action handlers @sophieH29 ([#121](https://github.com/stardust-ui/react/pull/121))
+- Add accessibility description for `Text` component @codepretty ([#205](https://github.com/stardust-ui/react/pull/205))
 
 <!--------------------------------[ v0.5.0 ]------------------------------- -->
 ## [v0.5.0](https://github.com/stardust-ui/react/tree/v0.5.0) (2018-08-30)

--- a/docs/src/examples/components/Text/States/TextExampleDisabled.shorthand.tsx
+++ b/docs/src/examples/components/Text/States/TextExampleDisabled.shorthand.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextExampleDisabledShorthand = () => (
+  <Text disabled content="This feature has been disabled." />
+)
+
+export default TextExampleDisabledShorthand

--- a/docs/src/examples/components/Text/States/TextExampleError.shorthand.tsx
+++ b/docs/src/examples/components/Text/States/TextExampleError.shorthand.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextExampleErrorShorthand = () => <Text error content="There has been an error." />
+
+export default TextExampleErrorShorthand

--- a/docs/src/examples/components/Text/States/TextExampleSuccess.shorthand.tsx
+++ b/docs/src/examples/components/Text/States/TextExampleSuccess.shorthand.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextExampleSuccessShorthand = () => (
+  <Text success content="Your action has completed successfully." />
+)
+
+export default TextExampleSuccessShorthand

--- a/docs/src/examples/components/Text/Types/TextSizesExample.shorthand.tsx
+++ b/docs/src/examples/components/Text/Types/TextSizesExample.shorthand.tsx
@@ -3,21 +3,21 @@ import { Text } from '@stardust-ui/react'
 
 const TextSizesExampleShorthand = () => (
   <div>
-    <Text size="xs">Dicta voluptatum dolorem.</Text>
+    <Text size="xs" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="sm">Dicta voluptatum dolorem.</Text>
+    <Text size="sm" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="md">Dicta voluptatum dolorem.</Text>
+    <Text size="md" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="lg">Dicta voluptatum dolorem.</Text>
+    <Text size="lg" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="xl">Dicta voluptatum dolorem.</Text>
+    <Text size="xl" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="2x">Dicta voluptatum dolorem.</Text>
+    <Text size="2x" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="3x">Dicta voluptatum dolorem.</Text>
+    <Text size="3x" content="Dicta voluptatum dolorem." />
     <br />
-    <Text size="4x">Dicta voluptatum dolorem.</Text>
+    <Text size="4x" content="Dicta voluptatum dolorem." />
   </div>
 )
 export default TextSizesExampleShorthand

--- a/docs/src/examples/components/Text/Types/TextSizesExample.tsx
+++ b/docs/src/examples/components/Text/Types/TextSizesExample.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextSizesExample = () => (
+  <div>
+    <Text size="xs">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="sm">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="md">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="lg">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="xl">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="2x">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="3x">Dicta voluptatum dolorem.</Text>
+    <br />
+    <Text size="4x">Dicta voluptatum dolorem.</Text>
+  </div>
+)
+export default TextSizesExample

--- a/docs/src/examples/components/Text/Types/TextWeightsExample.shorthand.tsx
+++ b/docs/src/examples/components/Text/Types/TextWeightsExample.shorthand.tsx
@@ -3,15 +3,15 @@ import { Text } from '@stardust-ui/react'
 
 const TextWeightsExampleShorthand = () => (
   <div>
-    <Text weight="light">This text is light.</Text>
+    <Text weight="light" content="This text is light." />
     <br />
-    <Text weight="semilight">This text is semilight.</Text>
+    <Text weight="semilight" content="This text is semilight." />
     <br />
-    <Text weight="regular">This text is regular.</Text>
+    <Text weight="regular" content="This text is regular." />
     <br />
-    <Text weight="semibold">This text is semibold.</Text>
+    <Text weight="semibold" content="This text is semibold." />
     <br />
-    <Text weight="bold">This text is bold.</Text>
+    <Text weight="bold" content="This text is bold." />
   </div>
 )
 export default TextWeightsExampleShorthand

--- a/docs/src/examples/components/Text/Types/TextWeightsExample.tsx
+++ b/docs/src/examples/components/Text/Types/TextWeightsExample.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextWeightsExample = () => (
+  <div>
+    <Text weight="light">This text is light.</Text>
+    <br />
+    <Text weight="semilight">This text is semilight.</Text>
+    <br />
+    <Text weight="regular">This text is regular.</Text>
+    <br />
+    <Text weight="semibold">This text is semibold.</Text>
+    <br />
+    <Text weight="bold">This text is bold.</Text>
+  </div>
+)
+export default TextWeightsExample

--- a/docs/src/examples/components/Text/Variations/TextExampleAtMention.shorthand.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleAtMention.shorthand.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextExampleAtMentionShorthand = () => <Text atMention content="@Russell Wilson" />
+
+export default TextExampleAtMentionShorthand

--- a/docs/src/examples/components/Text/Variations/TextExampleTimestamp.shorthand.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleTimestamp.shorthand.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Text } from '@stardust-ui/react'
+
+const TextExampleTimestampShorthand = () => (
+  <Text timestamp title="August 28, 2018 at 11:16PM" content="Yesterday 11:16PM" />
+)
+
+export default TextExampleTimestampShorthand

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -26,6 +26,9 @@ export interface ITextProps {
 
 /**
  * A component containing text
+ * @accessibility
+ * Text is how people read the content on your website.
+ * Ensure that a contrast ratio of at least 4.5:1 exists between text and the background behind the text.
  */
 class Text extends UIComponent<Extendable<ITextProps>, any> {
   static className = 'ui-text'


### PR DESCRIPTION
# Updating the text doc to have all examples & have accessibility info
- all text types, states, and variations now have shorthand & children examples
- fixed some cases where children/shorthand were reversed

**Before**
![image](https://user-images.githubusercontent.com/828692/45201175-0d385900-b229-11e8-842a-cd3c825abfdc.png)

**After**
![image](https://user-images.githubusercontent.com/828692/45201230-5ab4c600-b229-11e8-9e83-9a365d982e0e.png)

