### PR TITLE
fix(chore): add git tags verification logic

### DIFF
--- a/build/gulp/tasks/git/index.ts
+++ b/build/gulp/tasks/git/index.ts
@@ -1,0 +1,7 @@
+import { task } from 'gulp'
+import prepush from './prepush'
+
+task('git:prepush', cb => {
+  const errorMessage = prepush()
+  cb(errorMessage)
+})

--- a/build/gulp/tasks/git/prepush.ts
+++ b/build/gulp/tasks/git/prepush.ts
@@ -1,0 +1,30 @@
+import { execSync } from 'child_process'
+
+// naive check is implemented for now - this checks if Semantic UI tags are present
+const hasWrongTags = (gitTagsList): boolean => {
+  // this one is guaranteed being relevant to Semantic UI only
+  const SemanticUiVersionTag = 'v0.1.2'
+
+  return gitTagsList.includes(SemanticUiVersionTag)
+}
+
+type Error = string
+
+export default (): Error => {
+  const gitTagsList = `${execSync('git tag -l')}`
+  if (hasWrongTags(gitTagsList)) {
+    const errorMessage = [
+      '!! YOUR LOCAL REPO CONTAINS WRONG GIT TAGS !!',
+      '-----------------------------------------------',
+      'To prevent wrong git tags from being pushed, please, consider to do the following steps:',
+      ' - delete all local tags: git tag -l | xargs git tag -d',
+      ' - pull all remote tags: git fetch --tags',
+      ' - verify your tags ($ git tag -l) match NPM releases: https://www.npmjs.com/package/@stardust-ui/react?activeTab=versions',
+      '-----------------------------------------------',
+    ].join('\n')
+
+    return errorMessage
+  }
+
+  return undefined
+}

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -11,6 +11,7 @@ require('./build/gulp/tasks/dist')
 require('./build/gulp/tasks/docs')
 require('./build/gulp/tasks/generate')
 require('./build/gulp/tasks/screener')
+require('./build/gulp/tasks/git')
 
 // global tasks
 task('build', series('dll', parallel('dist', 'build:docs')))

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "prettier --list-different \"**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx}\"",
     "precommit": "lint-staged",
+    "prepush": "gulp git:prepush",
     "postcommit": "git update-index --again",
     "prerelease": "yarn ci && cross-env NODE_ENV=production yarn build",
     "postrelease": "yarn deploy:docs",


### PR DESCRIPTION
This change prevents wrong git tags (version labels) to be pushed from local repo. Provided logic is quite naive and extremely simple, but it should be quite robust in helping us to solve the git tags issues. 

One of the key principle of this changes is to not introduce any changes automatically on client machine, just inform about the fact that those should be considered (and recommend specific instructions). Once we will obtain evidence that these steps are safe and OS-agnostic, we could consider to make them automatic.

![image](https://user-images.githubusercontent.com/9024564/45293333-8cb37a00-b500-11e8-9668-0e53778abcc4.png)

----------

Note that git tags should be cleaned for remote repo before merging these changes - will take care of that.