### PR TITLE
feat(accessibility): add logic to differentiate mouse focus from keyboard focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "keyboard-key": "^1.0.1",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.1",
-    "react-fela": "^7.2.0"
+    "react-fela": "^7.2.0",
+    "what-input": "^5.1.2"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.4",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import whatInput from 'what-input'
+import * as _ from 'lodash'
 
 import { UIComponent, childrenExist, customPropTypes, createShorthandFactory } from '../../lib'
 import Icon from '../Icon'
@@ -27,7 +28,7 @@ export interface IButtonProps {
   iconOnly?: boolean
   iconPosition?: 'before' | 'after'
   onClick?: ComponentEventHandler<IButtonProps>
-  onFocus?: ComponentEventHandler<IButtonProps>
+  onFocus?: ComponentEventHandler<Extendable<IButtonProps>>
   text?: boolean
   type?: 'primary' | 'secondary'
   accessibility?: Accessibility
@@ -142,7 +143,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
   static Group = ButtonGroup
 
   public state = {
-    isLastFocusFromKeyboard: false,
+    isFromKeyboard: false,
   }
 
   public renderComponent({
@@ -196,11 +197,11 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
   }
 
   private handleFocus = (e: React.SyntheticEvent) => {
-    const { onFocus } = this.props
-    this.setState({ isLastFocusFromKeyboard: whatInput.ask() === 'keyboard' })
-    if (onFocus) {
-      onFocus(e, this.props)
-    }
+    const isFromKeyboard = whatInput.ask() === 'keyboard'
+
+    this.setState({ isFromKeyboard })
+
+    _.invoke(this.props, 'onFocus', e, { ...this.props, isFromKeyboard })
   }
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -28,7 +28,7 @@ export interface IButtonProps {
   iconOnly?: boolean
   iconPosition?: 'before' | 'after'
   onClick?: ComponentEventHandler<IButtonProps>
-  onFocus?: ComponentEventHandler<Extendable<IButtonProps>>
+  onFocus?: ComponentEventHandler<IButtonProps>
   text?: boolean
   type?: 'primary' | 'secondary'
   accessibility?: Accessibility
@@ -201,7 +201,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
 
     this.setState({ isFromKeyboard })
 
-    _.invoke(this.props, 'onFocus', e, { ...this.props, isFromKeyboard })
+    _.invoke(this.props, 'onFocus', e, this.props)
   }
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
+import whatInput from 'what-input'
 
 import { UIComponent, childrenExist, customPropTypes, createShorthandFactory } from '../../lib'
 import Icon from '../Icon'
@@ -26,6 +27,7 @@ export interface IButtonProps {
   iconOnly?: boolean
   iconPosition?: 'before' | 'after'
   onClick?: ComponentEventHandler<IButtonProps>
+  onFocus?: ComponentEventHandler<IButtonProps>
   text?: boolean
   type?: 'primary' | 'secondary'
   accessibility?: Accessibility
@@ -89,6 +91,13 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
      */
     onClick: PropTypes.func,
 
+    /**
+     * Called after user's focus.
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onFocus: PropTypes.func,
+
     /** A button can be formatted to show only text in order to indicate some less-pronounced actions. */
     text: PropTypes.bool,
 
@@ -118,6 +127,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
     'iconOnly',
     'iconPosition',
     'onClick',
+    'onFocus',
     'styles',
     'text',
     'type',
@@ -130,6 +140,10 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
   }
 
   static Group = ButtonGroup
+
+  public state = {
+    isLastFocusFromKeyboard: false,
+  }
 
   public renderComponent({
     ElementType,
@@ -146,6 +160,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
         className={classes.root}
         disabled={disabled}
         onClick={this.handleClick}
+        onFocus={this.handleFocus}
         {...accessibility.attributes.root}
         {...rest}
       >
@@ -177,6 +192,14 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
 
     if (onClick) {
       onClick(e, this.props)
+    }
+  }
+
+  private handleFocus = (e: React.SyntheticEvent) => {
+    const { onFocus } = this.props
+    this.setState({ isLastFocusFromKeyboard: whatInput.ask() === 'keyboard' })
+    if (onFocus) {
+      onFocus(e, this.props)
     }
   }
 }

--- a/src/themes/teams/components/Button/buttonStyles.ts
+++ b/src/themes/teams/components/Button/buttonStyles.ts
@@ -4,7 +4,7 @@ import { disabledStyle, truncateStyle } from '../../../../styles/customCSS'
 
 const buttonStyles: IComponentPartStylesInput = {
   root: ({ props, variables }: { props: any; variables: any }): ICSSInJSStyle => {
-    const { circular, disabled, fluid, type, text, iconOnly } = props
+    const { circular, disabled, fluid, type, text, iconOnly, isLastFocusFromKeyboard } = props
     const primary = type === 'primary'
     const secondary = type === 'secondary'
 
@@ -48,6 +48,13 @@ const buttonStyles: IComponentPartStylesInput = {
       margin: `0 ${pxToRem(8)} 0 0`,
       verticalAlign: 'middle',
       cursor: 'pointer',
+
+      ':focus': {
+        ...(isLastFocusFromKeyboard &&
+          {
+            // focus styles should be added like this, since they should be applied only on keyboard.
+          }),
+      },
 
       ...(!text && {
         borderWidth: `${secondary ? (circular ? 1 : 2) : 0}px`,

--- a/src/themes/teams/components/Button/buttonStyles.ts
+++ b/src/themes/teams/components/Button/buttonStyles.ts
@@ -4,7 +4,7 @@ import { disabledStyle, truncateStyle } from '../../../../styles/customCSS'
 
 const buttonStyles: IComponentPartStylesInput = {
   root: ({ props, variables }: { props: any; variables: any }): ICSSInJSStyle => {
-    const { circular, disabled, fluid, type, text, iconOnly, isLastFocusFromKeyboard } = props
+    const { circular, disabled, fluid, type, text, iconOnly, isFromKeyboard } = props
     const primary = type === 'primary'
     const secondary = type === 'secondary'
 
@@ -50,7 +50,7 @@ const buttonStyles: IComponentPartStylesInput = {
       cursor: 'pointer',
 
       ':focus': {
-        ...(isLastFocusFromKeyboard &&
+        ...(isFromKeyboard &&
           {
             // focus styles should be added like this, since they should be applied only on keyboard.
           }),

--- a/test/specs/components/Button/Button-test.tsx
+++ b/test/specs/components/Button/Button-test.tsx
@@ -17,6 +17,14 @@ import { MenuBehavior } from 'src/lib/accessibility'
 
 const buttonImplementsShorthandProp = implementsShorthandProp(Button)
 
+jest.mock('what-input', () => {
+  return {
+    default: {
+      ask: jest.fn(),
+    },
+  }
+})
+
 describe('Button', () => {
   isConformant(Button)
   buttonImplementsShorthandProp('icon', Icon, { mapsValueToProp: 'name' })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8262,6 +8262,10 @@ webpack@^3.5.4:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
+what-input@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.1.2.tgz#a27e8a86650a1089fd0fe3393dd74fcd141f85e6"
+
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"


### PR DESCRIPTION
Removing focus ring when the focus is applied by mouse. Only added it on Buttons for now.

Checking with the library what-input the source of the focus. If focus comes from keyboard, make the state property isLastFocusFromKeyboard true, which triggers the custom style from the buttonStyles.ts

This focus style should be added in a new PR, and I've added the boolean variable in styles file for reference. It should be used like that or in a similar way, so the focus styles apply only on keyboard focus.