### PR TITLE
fix: Teams zwj gender emoji in Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
+- Fixed fonts to support zwj gender emojis ([#215](https://github.com/stardust-ui/react/pull/215))
 - Correct Teams theme site variables @sergiorv ([#110](https://github.com/stardust-ui/react/pull/110))
 - Fixed missing colors in Teams' siteVariables @mnajdova ([#200](https://github.com/stardust-ui/react/pull/200))
 - Fixed Teams' siteVariables font sizes @levithomason ([#204](https://github.com/stardust-ui/react/pull/204))

--- a/src/themes/teams/siteVariables.ts
+++ b/src/themes/teams/siteVariables.ts
@@ -72,7 +72,8 @@ export const lineHeightExtraSmall = 1.2
 //
 export const bodyPadding = 0
 export const bodyMargin = 0
-export const bodyFontFamily = '"Segoe UI", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", Helvetica, Arial, sans-serif'
+export const bodyFontFamily =
+  '"Segoe UI", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", Helvetica, Arial, sans-serif'
 export const bodyFontSize = '1.4rem'
 export const bodyColor = black
 export const bodyLineHeight = lineHeightBase

--- a/src/themes/teams/siteVariables.ts
+++ b/src/themes/teams/siteVariables.ts
@@ -72,7 +72,7 @@ export const lineHeightExtraSmall = 1.2
 //
 export const bodyPadding = 0
 export const bodyMargin = 0
-export const bodyFontFamily = '"Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif'
+export const bodyFontFamily = '"Segoe UI", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", Helvetica, Arial, sans-serif'
 export const bodyFontSize = '1.4rem'
 export const bodyColor = black
 export const bodyLineHeight = lineHeightBase


### PR DESCRIPTION
Chrome incorrectly handles zwj (zero-width joiner) gender emoji's and renders them as two emoji instead of a single one.  
For an example, please see this emoji in both Chrome and Edge within stardust.
🤦‍♂️

Adding fonts that correctly support ZWJ's for Mac and Windows fixes the issue