### PR TITLE
fix(mergeThemes): preserve fonts and static styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed missing colors in Teams' siteVariables @mnajdova ([#200](https://github.com/stardust-ui/react/pull/200))
 - Fixed Teams' siteVariables font sizes @levithomason ([#204](https://github.com/stardust-ui/react/pull/204))
 - Fixed docs examples of `Text` component @codepretty ([#205](https://github.com/stardust-ui/react/pull/205))
+- Preserve fonts and static styles in mergeThemes @levithomason ([#205](https://github.com/stardust-ui/react/pull/205))
 
 ### Features
 - Add `state` to `props` in component styling functions @Bugaa92 ([#173](https://github.com/stardust-ui/react/pull/173))

--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -42,14 +42,9 @@ class Provider extends React.Component<IProviderProps, any> {
           }),
         }),
       ),
-      staticStyles: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object,
-        PropTypes.func,
-        PropTypes.arrayOf(
-          PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
-        ),
-      ]),
+      staticStyles: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
+      ),
     }),
     children: PropTypes.element.isRequired,
   }
@@ -72,9 +67,7 @@ class Provider extends React.Component<IProviderProps, any> {
       })
     }
 
-    const staticStylesArr = toCompactArray(staticStyles)
-
-    staticStylesArr.forEach((staticStyle: StaticStyle) => {
+    staticStyles.forEach((staticStyle: StaticStyle) => {
       if (typeof staticStyle === 'string') {
         felaLtrRenderer.renderStatic(staticStyle)
       } else if (_.isPlainObject(staticStyle)) {

--- a/src/lib/mergeThemes.ts
+++ b/src/lib/mergeThemes.ts
@@ -4,6 +4,7 @@ import {
   ComponentVariablesInput,
   IComponentPartStylesInput,
   IComponentPartStylesPrepared,
+  IFontFace,
   ISiteVariables,
   IThemeComponentStylesInput,
   IThemeComponentStylesPrepared,
@@ -11,9 +12,12 @@ import {
   IThemeComponentVariablesPrepared,
   IThemeInput,
   IThemePrepared,
+  StaticStyle,
+  StaticStyles,
 } from '../../types/theme'
 import callable from './callable'
 import { felaRenderer, felaRtlRenderer } from './felaRenderer'
+import toCompactArray from './toCompactArray'
 
 // ----------------------------------------
 // Component level merge functions
@@ -143,11 +147,21 @@ export const mergeRTL = (target, ...sources) => {
   }, target)
 }
 
+export const mergeFontFaces = (...sources: IFontFace[]) => {
+  return toCompactArray<IFontFace>(...sources)
+}
+
+export const mergeStaticStyles = (...sources: StaticStyle[]) => {
+  return toCompactArray<StaticStyle>(...sources)
+}
+
 const mergeThemes = (...themes: IThemeInput[]): IThemePrepared => {
   const emptyTheme = {
     siteVariables: {},
     componentVariables: {},
     componentStyles: {},
+    fontFaces: [],
+    staticStyles: [],
   } as IThemePrepared
 
   return themes.reduce<IThemePrepared>((acc: IThemePrepared, next: IThemeInput) => {
@@ -164,6 +178,10 @@ const mergeThemes = (...themes: IThemeInput[]): IThemePrepared => {
 
     // Use the correct renderer for RTL
     acc.renderer = acc.rtl ? felaRtlRenderer : felaRenderer
+
+    acc.fontFaces = mergeFontFaces(...acc.fontFaces, ...next.fontFaces)
+
+    acc.staticStyles = mergeStaticStyles(...acc.staticStyles, ...next.staticStyles)
 
     return acc
   }, emptyTheme)

--- a/test/specs/lib/mergeThemes/mergeFontFaces-test.ts
+++ b/test/specs/lib/mergeThemes/mergeFontFaces-test.ts
@@ -1,0 +1,43 @@
+import { mergeFontFaces } from '../../../../src/lib/mergeThemes'
+
+describe('mergeFontFaces', () => {
+  test('returns a compact array', () => {
+    expect(
+      mergeFontFaces(
+        undefined,
+        null,
+        {
+          name: 'Segoe UI',
+          paths: ['public/fonts/segoe-ui-regular.woff2'],
+          style: { fontWeight: 400 },
+        },
+        {
+          name: 'Segoe UI',
+          paths: ['public/fonts/segoe-ui-semibold.woff2'],
+          style: { fontWeight: 600 },
+        },
+        {
+          name: 'Segoe UI',
+          paths: ['public/fonts/segoe-ui-bold.woff2'],
+          style: { fontWeight: 700 },
+        },
+      ),
+    ).toEqual([
+      {
+        name: 'Segoe UI',
+        paths: ['public/fonts/segoe-ui-regular.woff2'],
+        style: { fontWeight: 400 },
+      },
+      {
+        name: 'Segoe UI',
+        paths: ['public/fonts/segoe-ui-semibold.woff2'],
+        style: { fontWeight: 600 },
+      },
+      {
+        name: 'Segoe UI',
+        paths: ['public/fonts/segoe-ui-bold.woff2'],
+        style: { fontWeight: 700 },
+      },
+    ])
+  })
+})

--- a/test/specs/lib/mergeThemes/mergeStaticStyles-test.ts
+++ b/test/specs/lib/mergeThemes/mergeStaticStyles-test.ts
@@ -1,0 +1,15 @@
+import { mergeStaticStyles } from '../../../../src/lib/mergeThemes'
+
+describe('mergeStaticStyles', () => {
+  test('returns a compact array', () => {
+    expect(
+      mergeStaticStyles(
+        undefined,
+        null,
+        '',
+        { body: { color: 'red' } },
+        '*{box-sizing:border-box;}',
+      ),
+    ).toEqual([{ body: { color: 'red' } }, '*{box-sizing:border-box;}'])
+  })
+})

--- a/test/specs/lib/mergeThemes/mergeThemes-test.ts
+++ b/test/specs/lib/mergeThemes/mergeThemes-test.ts
@@ -1,4 +1,4 @@
-import mergeThemes from '../../../../src/lib/mergeThemes'
+import mergeThemes, { mergeFontFaces } from '../../../../src/lib/mergeThemes'
 import { felaRenderer, felaRtlRenderer } from '../../../../src/lib'
 
 describe('mergeThemes', () => {
@@ -230,6 +230,78 @@ describe('mergeThemes', () => {
         source: true,
         target: true,
         ...styleParam,
+      })
+    })
+  })
+
+  describe('font faces', () => {
+    test('returns a compact array', () => {
+      expect(
+        mergeThemes(
+          { fontFaces: null },
+          { fontFaces: undefined },
+          {
+            fontFaces: [
+              {
+                name: 'Segoe UI',
+                paths: ['public/fonts/segoe-ui-regular.woff2'],
+                style: { fontWeight: 400 },
+              },
+            ],
+          },
+          {
+            fontFaces: [
+              {
+                name: 'Segoe UI',
+                paths: ['public/fonts/segoe-ui-semibold.woff2'],
+                style: { fontWeight: 600 },
+              },
+            ],
+          },
+          {
+            fontFaces: [
+              {
+                name: 'Segoe UI',
+                paths: ['public/fonts/segoe-ui-bold.woff2'],
+                style: { fontWeight: 700 },
+              },
+            ],
+          },
+        ),
+      ).toMatchObject({
+        fontFaces: [
+          {
+            name: 'Segoe UI',
+            paths: ['public/fonts/segoe-ui-regular.woff2'],
+            style: { fontWeight: 400 },
+          },
+          {
+            name: 'Segoe UI',
+            paths: ['public/fonts/segoe-ui-semibold.woff2'],
+            style: { fontWeight: 600 },
+          },
+          {
+            name: 'Segoe UI',
+            paths: ['public/fonts/segoe-ui-bold.woff2'],
+            style: { fontWeight: 700 },
+          },
+        ],
+      })
+    })
+  })
+
+  describe('static styles', () => {
+    test('returns a compact array', () => {
+      expect(
+        mergeThemes(
+          { staticStyles: null },
+          { staticStyles: undefined },
+          { staticStyles: [''] },
+          { staticStyles: [{ body: { color: 'red' } }] },
+          { staticStyles: ['*{box-sizing:border-box;}'] },
+        ),
+      ).toMatchObject({
+        staticStyles: [{ body: { color: 'red' } }, '*{box-sizing:border-box;}'],
       })
     })
   })

--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -94,7 +94,7 @@ export interface ComponentStyleFunctionParam {
 }
 
 export type ComponentPartStyleFunction = ((
-  styleParam: ComponentStyleFunctionParam,
+  styleParam?: ComponentStyleFunctionParam,
 ) => ICSSInJSStyle)
 
 export type ComponentPartStyle = ComponentPartStyleFunction | ICSSInJSStyle
@@ -117,7 +117,7 @@ export type StaticStyleFunction = (siteVariables?: ISiteVariables) => StaticStyl
 
 export type StaticStyle = StaticStyleRenderable | StaticStyleFunction
 
-export type StaticStyles = OneOrArray<StaticStyle>
+export type StaticStyles = StaticStyle[]
 
 // ========================================================
 // Theme
@@ -148,6 +148,8 @@ export interface IThemePrepared {
   componentStyles: { [key in keyof IThemeComponentStylesPrepared]: IComponentPartStylesPrepared }
   rtl: boolean
   renderer: IRenderer
+  fontFaces: FontFaces
+  staticStyles: StaticStyles
 }
 
 export interface IThemeComponentStylesInput {


### PR DESCRIPTION
Merge themes currently doesn't handle font faces and static styles.  When merging themes, this information is lost.  We started merging themes at the top of the doc site in #204.  Therefore, the doc site fonts and static styles are not correct.

This PR introduces font face and static style merging which resolves the regression introduced.