### PR TITLE
fix(Divider): misusage of the variables for the default and secondary type

### DIFF
--- a/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/src/themes/teams/components/Divider/dividerStyles.ts
@@ -54,21 +54,21 @@ const dividerStyles: IComponentPartStylesInput = {
               ...beforeAndAfter(size, type, variables),
               marginLeft: pxToRem(22 + size * 2),
             },
-            color: variables.typeSecondaryColor, // the default color
+            color: variables.color, // the default color
             ...(type === 'primary' && {
               color: variables.typePrimaryColor,
             }),
             ...(type === 'secondary' && {
-              color: variables.defaultColor,
+              color: variables.typeSecondaryColor,
             }),
           }
         : {
-            ...dividerBorderStyle(size, variables.typeSecondaryBackgroundColor), // the default border style
+            ...dividerBorderStyle(size, variables.backgroundColor), // the default border style
             ...(type === 'primary' && {
               ...dividerBorderStyle(size, variables.typePrimaryBackgroundColor),
             }),
             ...(type === 'secondary' && {
-              ...dividerBorderStyle(size, variables.defaultBackgroundColor),
+              ...dividerBorderStyle(size, variables.typeSecondaryBackgroundColor),
             }),
           }),
     }

--- a/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/src/themes/teams/components/Divider/dividerStyles.ts
@@ -14,7 +14,7 @@ const dividerBorderStyle = (size, color): ICSSInJSStyle => ({
 const beforeAndAfter = (size, type, variables): ICSSPseudoElementStyle => ({
   content: '""',
   flex: 1,
-  ...dividerBorderStyle(size, variables.defaultBackgroundColor), // the default border style
+  ...dividerBorderStyle(size, variables.backgroundColor), // the default border style
   ...(type === 'primary' && {
     ...dividerBorderStyle(size, variables.typePrimaryBackgroundColor),
   }),

--- a/src/themes/teams/components/Divider/dividerVariables.ts
+++ b/src/themes/teams/components/Divider/dividerVariables.ts
@@ -1,10 +1,10 @@
 export default (siteVars: any) => {
   return {
-    defaultColor: siteVars.gray04,
-    defaultBackgroundColor: siteVars.gray08,
+    color: siteVars.gray02,
+    backgroundColor: siteVars.gray10,
     typePrimaryColor: siteVars.brand,
     typePrimaryBackgroundColor: siteVars.brand,
-    typeSecondaryColor: siteVars.gray02,
-    typeSecondaryBackgroundColor: siteVars.gray10,
+    typeSecondaryColor: siteVars.gray04,
+    typeSecondaryBackgroundColor: siteVars.gray08,
   }
 }


### PR DESCRIPTION
# Divider

The usage of the typeSecondaryXXX and defaultXXX variables was wrong, which produces bug in the usage of the variables.

## Reproduce bug
Use the divider in the following manner:

```jsx
<Divider type='secondary' variables={typeSecondaryColor: 'black'} content='Some text' />
```

## Expected behavior
The color of the Divider should be changed to black

## Actual behavior
The color is not changed as this variables is used for the default type of the Divider, not the secondary.

## Addition
Also the defaultColor, and defaultBackgroundColor are changed to color and backgroundColor.