### PR TITLE
BREAKING: apply styles prop to the root element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Restrict the `styles` prop to styling the root element only @levithomason ([#238](https://github.com/stardust-ui/react/pull/238))
+
 <!--------------------------------[ v0.5.2 ]------------------------------- -->
 ## [v0.5.2](https://github.com/stardust-ui/react/tree/v0.5.2) (2018-09-14)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.5.1...v0.5.2)

--- a/build/gulp/tasks/generate/templates/src-components/$DisplayName/$DisplayName.tsx
+++ b/build/gulp/tasks/generate/templates/src-components/$DisplayName/$DisplayName.tsx
@@ -2,13 +2,13 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import { UIComponent, childrenExist, customPropTypes, createShorthandFactory } from '../../lib'
-import { IComponentPartStylesInput, ComponentVariablesInput } from '../../../types/theme'
+import { ComponentPartStyle, ComponentVariablesInput } from '../../../types/theme'
 
 export type $DisplayNameProps = {
   as?: any
   children?: React.ReactChildren
   content?: React.ReactNode
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/docs/src/components/Knobs/KnobsLabel.tsx
+++ b/docs/src/components/Knobs/KnobsLabel.tsx
@@ -5,7 +5,7 @@ interface IKnobsLabelProps {
   value: string
 }
 
-const KnobsLabel: React.ComponentType<IKnobsLabelProps> = ({ name, value }) => (
+const KnobsLabel: React.SFC<IKnobsLabelProps> = ({ name, value }) => (
   <span>
     {name}: {JSON.stringify(value, null, 2)},
   </span>

--- a/docs/src/examples/components/Popup/Variations/PopupExamplePosition.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Variations/PopupExamplePosition.shorthand.tsx
@@ -15,7 +15,7 @@ const triggers = [
   { icon: 'arrow circle right', padding: '5px 5px 5px 42px' },
   { icon: 'arrow circle right', padding: '18px 5px 5px 42px' },
 ].map(({ icon, padding }) => (
-  <Button icon={icon} styles={{ root: { padding, height: '38px', minWidth: '64px' } }} />
+  <Button icon={icon} styles={{ padding, height: '38px', minWidth: '64px' }} />
 ))
 
 const PopupExamplePosition = () => (

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -7,7 +7,7 @@ import AccordionTitle from './AccordionTitle'
 import AccordionContent from './AccordionContent'
 import { DefaultBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/interfaces'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import {
   Extendable,
   ItemShorthand,
@@ -28,7 +28,7 @@ export interface IAccordionProps {
     title: ItemShorthand
   }[]
   accessibility?: Accessibility
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Image, Label, Status } from '../../'
 
 import { customPropTypes, UIComponent, createShorthandFactory } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ItemShorthand } from '../../../types/utils'
 
 export interface IAvatarProps {
@@ -15,7 +15,7 @@ export interface IAvatarProps {
   src?: string
   status?: ItemShorthand
   getInitials?: (name: string) => string
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -106,17 +106,10 @@ class Avatar extends UIComponent<Extendable<IAvatarProps>, any> {
     return (
       <ElementType {...rest} className={classes.root}>
         {src ? (
-          <Image
-            styles={{ root: styles.imageAvatar }}
-            fluid
-            avatar
-            src={src}
-            alt={alt}
-            title={name}
-          />
+          <Image styles={styles.imageAvatar} fluid avatar src={src} alt={alt} title={name} />
         ) : (
           <Label
-            styles={{ root: styles.avatarNameContainer }}
+            styles={styles.avatarNameContainer}
             as="div"
             content={getInitials(name || '')}
             variables={{ padding: '0px' }}
@@ -126,7 +119,7 @@ class Avatar extends UIComponent<Extendable<IAvatarProps>, any> {
         )}
         {Status.create(status, {
           defaultProps: {
-            styles: { root: styles.status },
+            styles: styles.status,
             size: size * 0.3125,
             variables: {
               borderColor: variables.statusBorderColor,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,7 +7,7 @@ import { UIComponent, childrenExist, customPropTypes, createShorthandFactory } f
 import Icon from '../Icon'
 import { ButtonBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/interfaces'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import {
   Extendable,
   ItemShorthand,
@@ -32,7 +32,7 @@ export interface IButtonProps {
   text?: boolean
   type?: 'primary' | 'secondary'
   accessibility?: Accessibility
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -175,7 +175,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
 
     return Icon.create(icon, {
       defaultProps: {
-        styles: { root: styles.icon },
+        styles: styles.icon,
         xSpacing: !content ? 'none' : iconPosition === 'after' ? 'before' : 'after',
         variables: variables.icon,
       },

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as _ from 'lodash'
 
 import { UIComponent, childrenExist, customPropTypes } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ItemShorthand, ReactChildren } from '../../../types/utils'
 import Button from './Button'
 
@@ -14,7 +14,7 @@ export interface IButtonGroupProps {
   className?: string
   content?: React.ReactNode
   buttons?: ItemShorthand[]
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -90,9 +90,7 @@ class ButtonGroup extends UIComponent<Extendable<IButtonGroupProps>, any> {
           Button.create(button, {
             defaultProps: {
               circular,
-              styles: {
-                root: this.getStyleForButtonIndex(styles, idx === 0, idx === buttons.length - 1),
-              },
+              styles: this.getStyleForButtonIndex(styles, idx === 0, idx === buttons.length - 1),
             },
           }),
         )}

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 import ChatMessage from './ChatMessage'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren, ItemShorthand } from '../../../types/utils'
 
 export interface IChatProps {
@@ -12,7 +12,7 @@ export interface IChatProps {
   className?: string
   children?: ReactChildren
   messages?: ItemShorthand[]
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -3,7 +3,11 @@ import * as PropTypes from 'prop-types'
 import * as cx from 'classnames'
 
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import {
+  ComponentVariablesInput,
+  ComponentPartStyle,
+  IComponentPartStylesInput,
+} from '../../../types/theme'
 import { Extendable, ReactChildren, ItemShorthand } from '../../../types/utils'
 import Avatar from '../Avatar'
 
@@ -14,7 +18,7 @@ export interface IChatMessageProps {
   className?: string
   content?: any
   mine?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -89,7 +93,7 @@ class ChatMessage extends UIComponent<Extendable<IChatMessageProps>, any> {
     avatar &&
     Avatar.create(avatar, {
       defaultProps: {
-        styles: { root: styles.avatar },
+        styles: styles.avatar,
         variables: variables.avatar,
       },
     })

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren } from '../../../types/utils'
 
 export interface IDividerProps {
@@ -13,7 +13,7 @@ export interface IDividerProps {
   size?: number
   type?: 'primary' | 'secondary'
   important?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -2,7 +2,7 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import ReactNode = React.ReactNode
 import { UIComponent, childrenExist, customPropTypes, IRenderResultConfig } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ItemShorthand, ReactChildren } from '../../../types/utils'
 
 export interface IGridProps {
@@ -12,7 +12,7 @@ export interface IGridProps {
   columns?: string | number
   content?: ItemShorthand | ItemShorthand[]
   rows?: string | number
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 import HeaderDescription from './HeaderDescription'
 import { Extendable, ItemShorthand, ReactChildren } from '../../../types/utils'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 
 export interface IHeaderProps {
   as?: any
@@ -13,7 +13,7 @@ export interface IHeaderProps {
   content?: React.ReactNode
   description?: ItemShorthand
   textAlign?: 'left' | 'center' | 'right' | 'justified'
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -93,7 +93,6 @@ class Header extends UIComponent<Extendable<IHeaderProps>, any> {
           ...(v.descriptionColor && { color: v.descriptionColor }),
         },
       },
-      generateKey: false,
     })
 
     return (

--- a/src/components/Header/HeaderDescription.tsx
+++ b/src/components/Header/HeaderDescription.tsx
@@ -2,7 +2,7 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren } from '../../../types/utils'
 
 export interface IHeaderDescriptionProps {
@@ -10,7 +10,7 @@ export interface IHeaderDescriptionProps {
   children?: ReactChildren
   className?: string
   content?: React.ReactNode
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -4,7 +4,7 @@ import { customPropTypes, UIComponent, createShorthandFactory } from '../../lib'
 import { IconBehavior } from '../../lib/accessibility/'
 
 import svgIcons from './svgIcons'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable } from '../../../types/utils'
 import { Accessibility } from '../../lib/accessibility/interfaces'
 
@@ -32,7 +32,7 @@ export interface IIconProps {
   svg?: boolean
   xSpacing?: IconXSpacing
   accessibility?: Accessibility
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -5,7 +5,7 @@ import { createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
 import { ImageBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/interfaces'
 
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren } from '../../../types/utils'
 
 export interface IImageProps {
@@ -16,7 +16,7 @@ export interface IImageProps {
   circular?: boolean
   className?: string
   fluid?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -10,7 +10,7 @@ import {
   partitionHTMLProps,
 } from '../../lib'
 import Icon from '../Icon'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import {
   Extendable,
   ItemShorthand,
@@ -31,7 +31,7 @@ export interface IInputProps {
   onChange?: ComponentEventHandler<IInputProps>
   value?: string
   type?: string
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -205,7 +205,7 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
         {this.computeIcon() &&
           Icon.create(this.computeIcon(), {
             defaultProps: {
-              styles: { root: styles.icon },
+              styles: styles.icon,
               variables: variables.icon,
             },
             overrideProps: this.handleIconOverrides,

--- a/src/components/ItemLayout/ItemLayout.tsx
+++ b/src/components/ItemLayout/ItemLayout.tsx
@@ -7,7 +7,7 @@ import Layout from '../Layout'
 import {
   ComponentVariablesInput,
   IComponentPartClasses,
-  IComponentPartStylesInput,
+  ComponentPartStyle,
   ICSSInJSStyle,
 } from '../../../types/theme'
 import { Extendable } from '../../../types/utils'
@@ -46,7 +46,7 @@ export interface IItemLayoutProps {
   endMediaCSS?: ICSSInJSStyle
   truncateContent?: boolean
   truncateHeader?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -221,7 +221,7 @@ class ItemLayout extends UIComponent<Extendable<IItemLayoutProps>, any> {
       <Layout
         as={as}
         className={classes.root}
-        styles={{ root: styles.root }}
+        styles={styles.root}
         rootCSS={rootCSS}
         alignItems="center"
         gap={pxToRem(8)}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -12,7 +12,7 @@ import {
 import { Icon, Image, Layout } from '../..'
 import { Accessibility } from '../../lib/accessibility/interfaces'
 
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren, ItemShorthand } from '../../../types/utils'
 
 export interface ILabelProps {
@@ -27,7 +27,7 @@ export interface ILabelProps {
   iconPosition?: 'start' | 'end'
   image?: ItemShorthand
   imagePosition?: 'start' | 'end'
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -112,20 +112,18 @@ class Label extends UIComponent<Extendable<ILabelProps>, any> {
       image &&
       Image.create(image, {
         defaultProps: {
-          styles: { root: styles.image },
+          styles: styles.image,
           variables: variables.image,
         },
-        generateKey: false,
       })
 
     const iconElement =
       icon &&
       Icon.create(icon, {
         defaultProps: {
+          styles: styles.icon,
           variables: variables.icon,
-          styles: { root: styles.icon },
         },
-        generateKey: false,
         overrideProps: this.handleIconOverrides,
       })
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -4,11 +4,7 @@ import * as cx from 'classnames'
 
 import { customPropTypes, UIComponent } from '../../lib'
 import { Extendable } from '../../../types/utils'
-import {
-  ComponentVariablesInput,
-  IComponentPartStylesInput,
-  ICSSInJSStyle,
-} from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle, ICSSInJSStyle } from '../../../types/theme'
 
 export interface ILayoutProps {
   as?: any
@@ -37,7 +33,7 @@ export interface ILayoutProps {
   truncateMain?: boolean
   truncateEnd?: boolean
   vertical?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -7,7 +7,7 @@ import ListItem from './ListItem'
 import { ListBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/interfaces'
 
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren, ItemShorthand } from '../../../types/utils'
 
 export interface IListProps {
@@ -20,7 +20,7 @@ export interface IListProps {
   selection?: boolean
   truncateContent?: boolean
   truncateHeader?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -4,7 +4,7 @@ import { createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
 import ItemLayout from '../ItemLayout'
 import { ListItemBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/interfaces'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable } from '../../../types/utils'
 
 export interface IListItemProps {
@@ -22,7 +22,7 @@ export interface IListItemProps {
   selection?: boolean
   truncateContent?: boolean
   truncateHeader?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -10,7 +10,7 @@ import { Accessibility } from '../../lib/accessibility/interfaces'
 import {
   ComponentVariablesInput,
   ComponentVariablesObject,
-  IComponentPartStylesInput,
+  ComponentPartStyle,
 } from '../../../types/theme'
 import { Extendable, ItemShorthand, ReactChildren } from '../../../types/utils'
 
@@ -29,7 +29,7 @@ export interface IMenuProps {
   type?: 'primary' | 'secondary'
   underlined?: boolean
   vertical?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -8,7 +8,7 @@ import Icon from '../Icon'
 import { MenuItemBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/interfaces'
 
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import {
   ComponentEventHandler,
   Extendable,
@@ -33,7 +33,7 @@ export interface IMenuItemProps {
   type?: 'primary' | 'secondary'
   underlined?: boolean
   vertical?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -5,7 +5,7 @@ import rtlCSSJS from 'rtl-css-js'
 
 import { childrenExist, customPropTypes, UIComponent, IRenderResultConfig } from '../../lib'
 import { ItemShorthand, Extendable, ReactChildren } from '../../../types/utils'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import Portal from '../Portal'
 import PopupContent from './PopupContent'
 import computePopupPlacement, { Alignment, Position } from './positioningHelper'
@@ -22,7 +22,7 @@ export interface IPopupProps {
   content?: ItemShorthand | ItemShorthand[]
   position?: Position
   trigger?: JSX.Element
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 
@@ -141,12 +141,7 @@ export default class Popup extends UIComponent<Extendable<IPopupProps>, IPopupSt
     const computedStyle = rtl ? rtlCSSJS(style) : style
 
     return (
-      <Popup.Content
-        innerRef={ref}
-        basic={basic}
-        {...rtl && { dir: 'rtl' }}
-        styles={{ root: computedStyle }}
-      >
+      <Popup.Content innerRef={ref} basic={basic} {...rtl && { dir: 'rtl' }} styles={computedStyle}>
         {content}
       </Popup.Content>
     )

--- a/src/components/Popup/PopupContent.tsx
+++ b/src/components/Popup/PopupContent.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import { customPropTypes, UIComponent, IRenderResultConfig } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ReactChildren } from '../../../types/utils'
 
 export interface IPopupContentProps {
@@ -12,7 +12,7 @@ export interface IPopupContentProps {
   children?: ReactChildren
   className?: string
   innerRef?: (node: HTMLElement) => void
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -15,7 +15,7 @@ import {
   ItemShorthand,
   ReactChildren,
 } from '../../../types/utils'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import Icon from '../Icon/Icon'
 
 export interface IRadioProps {
@@ -30,7 +30,7 @@ export interface IRadioProps {
   name?: string
   onChange?: ComponentEventHandler<IRadioProps>
   type?: string
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   value?: string | number
   variables?: ComponentVariablesInput
 }
@@ -137,13 +137,13 @@ class Radio extends AutoControlledComponent<Extendable<IRadioProps>, any> {
 
     return (
       <ElementType {...rest} className={classes.root}>
-        <Label as="label" styles={{ root: styles.label }}>
+        <Label as="label" styles={styles.label}>
           {Icon.create(icon || '', {
             defaultProps: {
               circular: true,
               size: 'mini',
               variables: variables.icon,
-              styles: { root: styles.icon },
+              styles: styles.icon,
             },
           })}
           {createHTMLInput(type, {

--- a/src/components/Segment/Segment.tsx
+++ b/src/components/Segment/Segment.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import { customPropTypes, UIComponent, childrenExist } from '../../lib'
 import { Extendable } from '../../../types/utils'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 
 export interface ISegmentProps {
   as?: any
   className?: string
   content?: any
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Icon } from '../../'
 
 import { customPropTypes, UIComponent, createShorthandFactory } from '../../lib'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ItemShorthand } from '../../../types/utils'
 
 export interface IStatusProps {
@@ -13,7 +13,7 @@ export interface IStatusProps {
   icon?: ItemShorthand
   size?: number
   state?: 'success' | 'info' | 'warning' | 'error' | 'unknown'
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { childrenExist, customPropTypes, UIComponent } from '../../lib'
 
 import { Extendable } from '../../../types/utils'
-import { ComponentVariablesInput, IComponentPartStylesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 
 export interface ITextProps {
   as?: any
@@ -20,7 +20,7 @@ export interface ITextProps {
   temporary?: boolean
   timestamp?: boolean
   truncated?: boolean
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 

--- a/src/lib/getElementType.tsx
+++ b/src/lib/getElementType.tsx
@@ -1,3 +1,6 @@
+import { ReactType } from 'react'
+import { IProps } from '../../types/theme'
+
 /**
  * Returns a createElement() type based on the props of the Component.
  * Useful for calculating what type a component should render as.
@@ -7,7 +10,11 @@
  * @param {function} [getDefault] A function that returns a default element type.
  * @returns {string|function} A ReactElement type
  */
-function getElementType(Component, props, getDefault?: Function) {
+function getElementType(
+  Component: { defaultProps?: IProps },
+  props: IProps,
+  getDefault?: () => ReactType,
+): ReactType {
   const { defaultProps = {} } = Component
 
   // ----------------------------------------

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -23,6 +23,7 @@ import {
   IAccessibilityDefinition,
   AccessibilityActionHandlers,
   FocusZoneMode,
+  Accessibility,
 } from './accessibility/interfaces'
 import { DefaultBehavior } from './accessibility'
 import getKeyDownHandlers from './getKeyDownHandlers'
@@ -126,8 +127,13 @@ const renderComponent = <P extends {}>(
         )(siteVariables, stateAndProps)
 
         // Resolve styles using resolved variables, merge results, allow props.styles to override
-        const mergedStyles = mergeComponentStyles(componentStyles[displayName], props.styles)
-        const accessibility = getAccessibility(stateAndProps, actionHandlers)
+        const mergedStyles: IComponentPartStylesPrepared = mergeComponentStyles(
+          componentStyles[displayName],
+          {
+            root: props.styles,
+          },
+        )
+        const accessibility: Accessibility = getAccessibility(stateAndProps, actionHandlers)
         const rest = getUnhandledProps(
           { handledProps: [...handledProps, ...accessibility.handledProps] },
           props,
@@ -136,7 +142,7 @@ const renderComponent = <P extends {}>(
           props: stateAndProps,
           variables: resolvedVariables,
         }
-        const resolvedStyles = Object.keys(mergedStyles).reduce(
+        const resolvedStyles: IComponentPartStylesPrepared = Object.keys(mergedStyles).reduce(
           (acc, next) => ({ ...acc, [next]: callable(mergedStyles[next])(styleParam) }),
           {},
         )

--- a/test/specs/commonTests/implementsShorthandProp.tsx
+++ b/test/specs/commonTests/implementsShorthandProp.tsx
@@ -49,20 +49,6 @@ export default Component => {
         expect(allShorthandPropertiesArePassedToShorthandComponent).toBe(true)
       })
 
-      test(`shorthand's styles may be passed as '${shorthandPropertyName}' prop of ${
-        Component.displayName
-      }'s styles`, () => {
-        const props = { [shorthandPropertyName]: 'some value' }
-
-        const wrapper = mount(
-          <Component {...props} styles={{ [shorthandPropertyName]: { foo: 'bar' } }} />,
-        )
-        const shorthandComponentProps = wrapper.find(ShorthandComponent.displayName).props()
-
-        expect(shorthandComponentProps.styles).toBeDefined()
-        expect(shorthandComponentProps.styles.root).toEqual({ foo: 'bar' })
-      })
-
       test(`shorthand's variables may be passed as '${shorthandPropertyName}' prop of ${
         Component.displayName
       }'s variables`, () => {

--- a/test/specs/commonTests/isConformant.tsx
+++ b/test/specs/commonTests/isConformant.tsx
@@ -87,7 +87,7 @@ export default (Component, options: any = {}) => {
         ].join('\n'),
       )
     })
-    return
+    return null
   }
 
   // ----------------------------------------

--- a/test/specs/commonTests/stylesFunction-test.tsx
+++ b/test/specs/commonTests/stylesFunction-test.tsx
@@ -40,11 +40,9 @@ const testStylesForComponent = ({
   const TestStylesComponent = (props: Extendable<IProps>) => (
     <TestComponent
       {...props}
-      styles={{
-        root: ({ props }: { props: IPropsAndState }): ICSSInJSStyle => {
-          expect(_.mapValues(expected, (val, key) => props[key])).toEqual(expected)
-          return {}
-        },
+      styles={({ props }: { props: IPropsAndState }): ICSSInJSStyle => {
+        expect(_.mapValues(expected, (val, key) => props[key])).toEqual(expected)
+        return {}
       }}
     />
   )

--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -25,7 +25,7 @@ export type IProps = ObjectOf<any>
 
 export type IPropsWithVarsAndStyles = Extendable<{
   variables?: ComponentVariablesInput
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
 }>
 
 // ========================================================


### PR DESCRIPTION
# Before

The `styles` prop accepted a map of component slots to styles:

```jsx
<Button 
  styles={{ 
    root: { background: 'blue' },
    icon: { color: 'white' },
   }}
  icon='user'
/>
```

# After

The `styles` prop now styles the root element only.  Use shorthand props to style component slots:

```jsx
<Button
  styles={{ background: 'blue' }}
  icon={{ name: 'user', styles: { color: 'white' } }}
/>
```