### PR TITLE
CSS-based approach to reflect pseudo-state changes of parent component in child's styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "crypto": "^1.0.1",
     "fela": "^6.1.7",
     "fela-plugin-fallback-value": "^5.0.17",
     "fela-plugin-placeholder-prefixer": "^5.0.18",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import whatInput from 'what-input'
 import * as _ from 'lodash'
+import * as cx from 'classnames'
 
 import { UIComponent, childrenExist, customPropTypes, createShorthandFactory } from '../../lib'
 import Icon from '../Icon'
@@ -44,6 +45,12 @@ export interface IButtonProps {
  *  - if button includes icon only, textual representation needs to be provided by using 'title', 'aria-label', or 'aria-labelledby' attributes
  */
 class Button extends UIComponent<Extendable<IButtonProps>, any> {
+  constructor(props, context) {
+    super(props, context)
+
+    this.componentId = 'button-instance-id'
+  }
+
   static create: Function
 
   public static displayName = 'Button'
@@ -155,7 +162,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
 
     return (
       <ElementType
-        className={classes.root}
+        className={cx(classes.root, this.componentId)}
         disabled={disabled}
         onClick={this.handleClick}
         onFocus={this.handleFocus}
@@ -178,6 +185,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
         styles: { root: styles.icon },
         xSpacing: !content ? 'none' : iconPosition === 'after' ? 'before' : 'after',
         variables: variables.icon,
+        className: cx(`${this.componentId}`, 'slot-icon'),
       },
     })
   }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -45,12 +45,6 @@ export interface IButtonProps {
  *  - if button includes icon only, textual representation needs to be provided by using 'title', 'aria-label', or 'aria-labelledby' attributes
  */
 class Button extends UIComponent<Extendable<IButtonProps>, any> {
-  constructor(props, context) {
-    super(props, context)
-
-    this.componentId = 'button-instance-id'
-  }
-
   static create: Function
 
   public static displayName = 'Button'
@@ -162,7 +156,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
 
     return (
       <ElementType
-        className={cx(classes.root, this.componentId)}
+        className={classes.root}
         disabled={disabled}
         onClick={this.handleClick}
         onFocus={this.handleFocus}
@@ -170,14 +164,14 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
         {...rest}
       >
         {hasChildren && children}
-        {!hasChildren && iconPosition !== 'after' && this.renderIcon(variables, styles)}
+        {!hasChildren && iconPosition !== 'after' && this.renderIcon(variables, styles, classes)}
         {!hasChildren && content && <span className={classes.content}>{content}</span>}
-        {!hasChildren && iconPosition === 'after' && this.renderIcon(variables, styles)}
+        {!hasChildren && iconPosition === 'after' && this.renderIcon(variables, styles, classes)}
       </ElementType>
     )
   }
 
-  public renderIcon = (variables, styles) => {
+  public renderIcon = (variables, styles, classes) => {
     const { icon, iconPosition, content } = this.props
 
     return Icon.create(icon, {
@@ -185,7 +179,7 @@ class Button extends UIComponent<Extendable<IButtonProps>, any> {
         styles: { root: styles.icon },
         xSpacing: !content ? 'none' : iconPosition === 'after' ? 'before' : 'after',
         variables: variables.icon,
-        className: cx(`${this.componentId}`, 'slot-icon'),
+        className: classes.slots.icon,
       },
     })
   }

--- a/src/lib/UIComponent.tsx
+++ b/src/lib/UIComponent.tsx
@@ -10,6 +10,8 @@ class UIComponent<P, S> extends React.Component<P, S> {
   static handledProps: any
   protected actionHandlers: AccessibilityActionHandlers
 
+  protected componentId?: string
+
   constructor(props, context) {
     super(props, context)
     if (process.env.NODE_ENV !== 'production') {
@@ -38,6 +40,7 @@ class UIComponent<P, S> extends React.Component<P, S> {
         props: this.props,
         state: this.state,
         actionHandlers: this.actionHandlers,
+        componentId: this.componentId,
       },
       this.renderComponent,
     )

--- a/src/lib/UIComponent.tsx
+++ b/src/lib/UIComponent.tsx
@@ -10,8 +10,6 @@ class UIComponent<P, S> extends React.Component<P, S> {
   static handledProps: any
   protected actionHandlers: AccessibilityActionHandlers
 
-  protected componentId?: string
-
   constructor(props, context) {
     super(props, context)
     if (process.env.NODE_ENV !== 'production') {
@@ -40,7 +38,6 @@ class UIComponent<P, S> extends React.Component<P, S> {
         props: this.props,
         state: this.state,
         actionHandlers: this.actionHandlers,
-        componentId: this.componentId,
       },
       this.renderComponent,
     )

--- a/src/lib/getClasses.ts
+++ b/src/lib/getClasses.ts
@@ -14,11 +14,33 @@ const getClasses = (
   renderer: IRenderer,
   componentStyles: IComponentPartStylesInput,
   styleParam: ComponentStyleFunctionParam,
+  extra: any,
 ): IComponentPartClasses => {
   // root, icon, etc.
   const componentParts: string[] = Object.keys(componentStyles)
 
+  const { componentId, className: componentClassName } = extra
+
   return componentParts.reduce((classes, partName) => {
+    // handle state section differently
+    // DISCLAIMER: dirty code alert!
+    if (partName.startsWith('on')) {
+      const pseudoStateName = partName.substr(2).toLowerCase()
+
+      const slotStyles = (componentStyles[partName] as any)()
+
+      Object.keys(slotStyles).forEach(slotName => {
+        const slotClassName = `slot-${slotName}`
+
+        renderer.renderStatic(
+          callable(slotStyles[slotName])(styleParam),
+          `.${componentClassName}.${componentId}:${pseudoStateName} .${componentId}.${slotClassName}`,
+        )
+      })
+
+      return classes
+    }
+
     classes[partName] = renderer.renderRule(callable(componentStyles[partName]), styleParam)
 
     return classes

--- a/src/lib/getClasses.ts
+++ b/src/lib/getClasses.ts
@@ -6,6 +6,16 @@ import {
   IRenderer,
 } from '../../types/theme'
 
+import * as crypto from 'crypto'
+
+const getHashCode = (fromString: string): string => {
+  return crypto
+    .createHash('md5')
+    .update(fromString)
+    .digest('hex')
+    .substr(0, 5)
+}
+
 /**
  * Returns a string of HTML classes.
  * Renders one or many component styles (objects of component parts) to the DOM.
@@ -19,32 +29,40 @@ const getClasses = (
   // root, icon, etc.
   const componentParts: string[] = Object.keys(componentStyles)
 
-  const { componentId, className: componentClassName } = extra
+  const { className: componentClassName } = extra
 
-  return componentParts.reduce((classes, partName) => {
-    // handle state section differently
-    // DISCLAIMER: dirty code alert!
-    if (partName.startsWith('on')) {
-      const pseudoStateName = partName.substr(2).toLowerCase()
+  return componentParts.reduce(
+    (classes, partName) => {
+      // handle state section differently
+      // DISCLAIMER: dirty code alert!
+      if (partName.startsWith('on')) {
+        const pseudoStateName = partName.substr(2).toLowerCase()
 
-      const slotStyles = (componentStyles[partName] as any)()
+        const slotStyles = (componentStyles[partName] as any)()
 
-      Object.keys(slotStyles).forEach(slotName => {
-        const slotClassName = `slot-${slotName}`
+        Object.keys(slotStyles).forEach(slotName => {
+          const slotStyle = callable(slotStyles[slotName])(styleParam)
+          const slotStyleHash = getHashCode(JSON.stringify(slotStyle))
 
-        renderer.renderStatic(
-          callable(slotStyles[slotName])(styleParam),
-          `.${componentClassName}.${componentId}:${pseudoStateName} .${componentId}.${slotClassName}`,
-        )
-      })
+          const slotClassName = `${slotName}-slot-of-${componentClassName}--${slotStyleHash}`
+
+          renderer.renderStatic(
+            slotStyle,
+            `.${componentClassName}:${pseudoStateName} .${slotClassName}`,
+          )
+
+          classes.slots[slotName] = slotClassName
+        })
+
+        return classes
+      }
+
+      classes[partName] = renderer.renderRule(callable(componentStyles[partName]), styleParam)
 
       return classes
-    }
-
-    classes[partName] = renderer.renderRule(callable(componentStyles[partName]), styleParam)
-
-    return classes
-  }, {})
+    },
+    { slots: {} } as any,
+  )
 }
 
 export default getClasses

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -1,4 +1,5 @@
 import * as cx from 'classnames'
+import _ from 'lodash'
 import * as React from 'react'
 import { FelaTheme } from 'react-fela'
 
@@ -53,6 +54,7 @@ export interface IRenderConfig {
   props: IPropsWithVarsAndStyles
   state: IState
   actionHandlers: AccessibilityActionHandlers
+  componentId?: string
 }
 
 const getAccessibility = (
@@ -104,6 +106,7 @@ const renderComponent = <P extends {}>(
     props,
     state,
     actionHandlers,
+    componentId,
   } = config
 
   return (
@@ -141,7 +144,11 @@ const renderComponent = <P extends {}>(
           {},
         )
 
-        const classes: IComponentPartClasses = getClasses(renderer, mergedStyles, styleParam)
+        const classes: IComponentPartClasses = getClasses(renderer, mergedStyles, styleParam, {
+          className,
+          componentId,
+        })
+
         classes.root = cx(className, classes.root, props.className)
 
         const config: IRenderResultConfig<P> = {

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -54,7 +54,6 @@ export interface IRenderConfig {
   props: IPropsWithVarsAndStyles
   state: IState
   actionHandlers: AccessibilityActionHandlers
-  componentId?: string
 }
 
 const getAccessibility = (
@@ -106,7 +105,6 @@ const renderComponent = <P extends {}>(
     props,
     state,
     actionHandlers,
-    componentId,
   } = config
 
   return (
@@ -146,7 +144,6 @@ const renderComponent = <P extends {}>(
 
         const classes: IComponentPartClasses = getClasses(renderer, mergedStyles, styleParam, {
           className,
-          componentId,
         })
 
         classes.root = cx(className, classes.root, props.className)

--- a/src/themes/teams/components/Button/buttonStyles.ts
+++ b/src/themes/teams/components/Button/buttonStyles.ts
@@ -140,6 +140,13 @@ const buttonStyles: IComponentPartStylesInput = {
     overflow: 'hidden',
     ...(typeof props.content === 'string' && truncateStyle),
   }),
+
+  onHover: {
+    icon: ({ props }) => ({
+      color: 'red',
+      ...(props.primary && { backgroundColor: 'yellow' }),
+    }),
+  } as any,
 }
 
 export default buttonStyles

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,6 +1650,10 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+
 css-in-js-utils@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"


### PR DESCRIPTION
This prototype is provided to test the CSS-based approach for the problem of tweaking styles of child component on parent's pseudo state changes (like `:hover`) - see #231.

**DISCLAIMER: PROTOTYPE ALERT! This PR is just a prototype, so please, dig into the implementation by accepting the fact  that code could be dirty.**

## API suggested

Is provided in the `buttonStyles.js`. Just to frame an idea, this is a proposed way of providing `Icon` styles on `Button` hover:

```js
// buttonStyles
const styles = {
  ...
  onHover: {
    icon: ({ props }) => ({ props.primary ? 'red' : 'blue' }),
    ...  // styles for other slots could be specified here
    }
 },
 on<another_pseudo_state>: {
   ...
 }
}
```

And for the `Button`'s logic the following changes should be applied - please, note that those are generic:

```jsx
const icon = Icon.create(icon, {
      ... 
      className: classes.slots.icon, // all pseudo-state style slots are aggregated into 'slots' property of 'classes' (we should, probably, better name it)
   }
}
```

## How it works

Essentially, provided logic results in the following CSS being added to the page:

```css
.${componentClassName}:${pseudoStateName} .${slotClassName} {
  ...
}

// specifically, simplified version looks like this
.ui-button:hover .slot-icon-76ae8 {
   ...
}
```

and the following HTML being rendered:

```html
<button class='ui-button .. '>
  <span class='... slot-icon-76ae8 ...' >...</span>
</button>
```

Please, note that `76ae8` is added to the class name of slot - this value is a hash that is calculated based on the props applied to the slot. This trick allow us to solve the following problems:
- address the problem of CSS styles scoping - even for the case of nested theme providers
- establish functional correspondence between parent component's state and calculates styles for child, so that each change of the parent's state (JS) or pseudo-state (CSS) will be properly reflected by styles of child
- limit the number of CSS classes necessary