### PR TITLE
fix: allow string or number as Input value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed `Divider` wrong usage of the `typeSecondary{color, backgroundColor}` and `default{color, backgroundColor}` variables; renamed `default{color, backgroundColor}` variables to `color` and `backgroundColor` @mnajdova ([#234](https://github.com/stardust-ui/react/pull/234))
 - Restrict the `styles` prop to styling the root element only @levithomason ([#238](https://github.com/stardust-ui/react/pull/238))
 
+### Fixes
+- Allow string or number as Input value @levithomason ([#250](https://github.com/stardust-ui/react/pull/250))
+
 ### Features
 - Add `author` and `timestamp` props for `Chat.Message` component @Bugaa92 ([#242](https://github.com/stardust-ui/react/pull/242))
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -23,13 +23,13 @@ export interface IInputProps {
   children?: ReactChildren
   className?: string
   clearable?: boolean
-  defaultValue?: string
+  defaultValue?: string | number
   fluid?: boolean
   icon?: ItemShorthand
   inline?: boolean
   input?: ItemShorthand
   onChange?: ComponentEventHandler<IInputProps>
-  value?: string
+  value?: string | number
   type?: string
   styles?: ComponentPartStyle
   variables?: ComponentVariablesInput


### PR DESCRIPTION
The Input typings currently only allow strings as value and defaultValue.  This PR also allows numbers.