### PR TITLE
fix(Icon): do not throw on missing font name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Allow string or number as Input value @levithomason ([#250](https://github.com/stardust-ui/react/pull/250))
+- Do not throw on missing Icon names @levithomason ([#251](https://github.com/stardust-ui/react/pull/251))
 
 ### Features
 - Add `author` and `timestamp` props for `Chat.Message` component @Bugaa92 ([#242](https://github.com/stardust-ui/react/pull/242))

--- a/src/themes/teams/components/Icon/fontAwesomeIconStyles.ts
+++ b/src/themes/teams/components/Icon/fontAwesomeIconStyles.ts
@@ -1297,12 +1297,7 @@ const fontAwesomeIcons = new Map([
   ['star empty', 'f089'],
 ])
 
-export default name => {
-  if (!fontAwesomeIcons.has(name)) {
-    throw new Error(`Could not find ${name} in FontAwesome`)
-  }
-  return fontAwesomeIcons.get(name)
-}
+export default name => fontAwesomeIcons.get(name)
 
 /**
  * TODO We should probably declare a @fontface rule here


### PR DESCRIPTION
We currently throw an error on missing icon names.  This is overkill.  We have typings and propTypes where we can more appropriately handle this.