### PR TITLE
fix: Generate correct paths in es/../Provider.d.ts

### DIFF
--- a/build/tsconfig.es.json
+++ b/build/tsconfig.es.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
     "module": "esnext",
-    "target": "es5",
-    "outDir": "../dist/es"
+    "target": "es5"
   }
 }

--- a/build/tsconfig.es.json
+++ b/build/tsconfig.es.json
@@ -2,6 +2,5 @@
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
     "module": "esnext",
-    "target": "es5"
   }
 }


### PR DESCRIPTION
Wrong path in v0.6.0:
dist/es/components/Provider/Provider.d.ts:
```jsx
import("../../../../src/components/Provider/ProviderConsumer")
```

Fixed by this PR:
dist/es/components/Provider/Provider.d.ts:
```jsx
import("./ProviderConsumer")
```