### PR TITLE
fix(test): disable skipLibCheck in test app

### DIFF
--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -50,17 +50,6 @@ const createReactApp = async (atTempDirectory: string, appName: string): Promise
   return appProjectPath
 }
 
-const enableTsCompilerFlagSync = (tsconfigPath: string, flag: string) => {
-  const tsConfigAsJson = JSON.parse(`${fs.readFileSync(tsconfigPath)}`)
-  if (!tsConfigAsJson.compilerOptions) {
-    tsConfigAsJson.compilerOptions = {}
-  }
-
-  tsConfigAsJson.compilerOptions[flag] = true
-
-  fs.writeFileSync(tsconfigPath, JSON.stringify(tsConfigAsJson))
-}
-
 // Tests the following scenario
 //  - Create a new react test app
 //  - Add Stardust as a app's dependency

--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -119,18 +119,12 @@ export default App;
     await runInTestApp(`yarn add ${paths.base(stardustPackageFilename)}`)
     log("Stardust is successfully added as test project's dependency.")
 
-    //////// ENABLE SKIP LIB CHECK FLAG ///////
-    log("STEP 3. Enable 'skipLibCheck' flag for test project's TS compiler")
-
-    const tsconfigPath = testAppPath('tsconfig.json')
-    enableTsCompilerFlagSync(tsconfigPath, 'skipLibCheck')
-
     //////// REFERENCE STARDUST COMPONENTS IN TEST APP's MAIN FILE ///////
-    log("STEP 4. Reference Stardust components in test project's App.tsx")
+    log("STEP 3. Reference Stardust components in test project's App.tsx")
     fs.writeFileSync(testAppPath('src', 'App.tsx'), appTSX)
 
     //////// BUILD TEST PROJECT ///////
-    log('STEP 5. Build test project..')
+    log('STEP 4. Build test project..')
     await runInTestApp(`yarn build`)
 
     log('Test project is built successfully!')


### PR DESCRIPTION
We've agreed to remove `skipLibCheck` flag from `tsconfig` that is used for Stardust test app - in that case we will be able to precisely follow the following plan of consuming Stardust on the client side:
- create app by `create-react-app` util
- add Stardust as a dependency
- use some Stardust components in the app
- try to build the app