### PR TITLE
feat(Text): add "me" option to `atMention` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - Add `Attachment` component @levithomason ([#220](https://github.com/stardust-ui/react/pull/220))
+- Add `atMention="me"` value to Text API @codepretty ([#277](https://github.com/stardust-ui/react/pull/277))
 
 ### Documentation
 - Add `Theming` guide @almedint, @levithomason ([#152](https://github.com/stardust-ui/react/pull/152))

--- a/docs/src/examples/components/Text/Variations/TextExampleAtMention.shorthand.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleAtMention.shorthand.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { Text } from '@stardust-ui/react'
 
-const TextExampleAtMentionShorthand = () => <Text atMention content="@Russell Wilson" />
+const TextExampleAtMentionShorthand = () => (
+  <div>
+    <Text atMention="me" content="@Mention Me" />
+    <br />
+    <Text atMention="other" content="@Mention Another" />
+  </div>
+)
 
 export default TextExampleAtMentionShorthand

--- a/docs/src/examples/components/Text/Variations/TextExampleAtMention.shorthand.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleAtMention.shorthand.tsx
@@ -3,9 +3,9 @@ import { Text } from '@stardust-ui/react'
 
 const TextExampleAtMentionShorthand = () => (
   <div>
-    <Text atMention="me" content="@Mention Me" />
+    <Text atMention content="@someone" />
     <br />
-    <Text atMention="other" content="@Mention Another" />
+    <Text atMention="me" content="@me" />
   </div>
 )
 

--- a/docs/src/examples/components/Text/Variations/TextExampleAtMention.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleAtMention.tsx
@@ -3,9 +3,9 @@ import { Text } from '@stardust-ui/react'
 
 const TextExampleAtMention = () => (
   <div>
-    <Text atMention="me">@Mention Me</Text>
+    <Text atMention>@someone</Text>
     <br />
-    <Text atMention="other">@Mention Another</Text>
+    <Text atMention="me">@me</Text>
   </div>
 )
 

--- a/docs/src/examples/components/Text/Variations/TextExampleAtMention.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleAtMention.tsx
@@ -3,9 +3,9 @@ import { Text } from '@stardust-ui/react'
 
 const TextExampleAtMention = () => (
   <div>
-    <Text atMention="me">@mention Me</Text>
+    <Text atMention="me">@Mention Me</Text>
     <br />
-    <Text atMention="other">@mention another</Text>
+    <Text atMention="other">@Mention Another</Text>
   </div>
 )
 

--- a/docs/src/examples/components/Text/Variations/TextExampleAtMention.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleAtMention.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { Text } from '@stardust-ui/react'
 
-const TextExampleAtMention = () => <Text atMention>@Russell Wilson</Text>
+const TextExampleAtMention = () => (
+  <div>
+    <Text atMention="me">@mention Me</Text>
+    <br />
+    <Text atMention="other">@mention another</Text>
+  </div>
+)
 
 export default TextExampleAtMention

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -42,7 +42,7 @@ class Text extends UIComponent<Extendable<ITextProps>, any> {
     as: customPropTypes.as,
 
     /** At mentions can be formatted to draw users' attention. Mentions for "me" can be formatted to appear differently. */
-    atMention: PropTypes.oneOfType([PropTypes.bool, 'me']),
+    atMention: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
     /** Additional CSS class name(s) to apply.  */
     className: PropTypes.string,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -8,7 +8,7 @@ import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/them
 
 export interface ITextProps {
   as?: any
-  atMention?: boolean
+  atMention?: 'me' | 'other'
   className?: string
   content?: any
   disabled?: boolean
@@ -41,8 +41,8 @@ class Text extends UIComponent<Extendable<ITextProps>, any> {
     /** Change the default element type of the Text component */
     as: customPropTypes.as,
 
-    /** Set as @mention Text component */
-    atMention: PropTypes.bool,
+    /** An @mention Text component can be formatted for myself mentioned or an other person mentioned */
+    atMention: PropTypes.oneOf(['me', 'other']),
 
     /** Additional CSS class name(s) to apply.  */
     className: PropTypes.string,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -41,8 +41,8 @@ class Text extends UIComponent<Extendable<ITextProps>, any> {
     /** Change the default element type of the Text component */
     as: customPropTypes.as,
 
-    /** An @mention Text component can be formatted for myself mentioned or an other person mentioned */
-    atMention: PropTypes.oneOfType(['me', PropTypes.bool]),
+    /** At mentions can be formatted to draw users' attention. Mentions for "me" can be formatted to appear differently. */
+    atMention: PropTypes.oneOfType([PropTypes.bool, 'me']),
 
     /** Additional CSS class name(s) to apply.  */
     className: PropTypes.string,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -8,7 +8,7 @@ import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/them
 
 export interface ITextProps {
   as?: any
-  atMention?: 'me' | 'other'
+  atMention?: boolean | 'me'
   className?: string
   content?: any
   disabled?: boolean
@@ -42,7 +42,7 @@ class Text extends UIComponent<Extendable<ITextProps>, any> {
     as: customPropTypes.as,
 
     /** An @mention Text component can be formatted for myself mentioned or an other person mentioned */
-    atMention: PropTypes.oneOf(['me', 'other']),
+    atMention: PropTypes.oneOfType(['me', PropTypes.bool]),
 
     /** Additional CSS class name(s) to apply.  */
     className: PropTypes.string,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -42,7 +42,7 @@ class Text extends UIComponent<Extendable<ITextProps>, any> {
     as: customPropTypes.as,
 
     /** At mentions can be formatted to draw users' attention. Mentions for "me" can be formatted to appear differently. */
-    atMention: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    atMention: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['me'])]),
 
     /** Additional CSS class name(s) to apply.  */
     className: PropTypes.string,

--- a/src/themes/teams/components/Text/textStyles.ts
+++ b/src/themes/teams/components/Text/textStyles.ts
@@ -27,7 +27,15 @@ export default {
   }: TextStylesParams): ICSSInJSStyle => {
     return {
       ...(truncated && truncateStyle),
-      ...(atMention && { color: v.atMentionTextColor }),
+      ...(atMention &&
+        atMention === 'other' && {
+          color: v.atMentionOtherTextColor,
+        }),
+      ...(atMention &&
+        atMention === 'me' && {
+          color: v.atMentionMeTextColor,
+          fontWeight: v.atMentionMeFontWeight,
+        }),
       ...(disabled && { color: v.disabledTextColor }),
       ...(error && { color: v.errorTextColor }),
       ...(success && { color: v.successTextColor }),

--- a/src/themes/teams/components/Text/textStyles.ts
+++ b/src/themes/teams/components/Text/textStyles.ts
@@ -27,15 +27,13 @@ export default {
   }: TextStylesParams): ICSSInJSStyle => {
     return {
       ...(truncated && truncateStyle),
-      ...(atMention &&
-        atMention === 'other' && {
-          color: v.atMentionOtherTextColor,
-        }),
-      ...(atMention &&
-        atMention === 'me' && {
-          color: v.atMentionMeTextColor,
-          fontWeight: v.atMentionMeFontWeight,
-        }),
+      ...(atMention === true && {
+        color: v.atMentionOtherTextColor,
+      }),
+      ...(atMention === 'me' && {
+        color: v.atMentionMeTextColor,
+        fontWeight: v.atMentionMeFontWeight,
+      }),
       ...(disabled && { color: v.disabledTextColor }),
       ...(error && { color: v.errorTextColor }),
       ...(success && { color: v.successTextColor }),

--- a/src/themes/teams/components/Text/textVariables.ts
+++ b/src/themes/teams/components/Text/textVariables.ts
@@ -6,7 +6,9 @@ export interface ITextVariables {
   textWeightRegular: number
   textWeightSemibold: number
   textWeightBold: number
-  atMentionTextColor: string
+  atMentionMeFontWeight: number
+  atMentionMeTextColor: string
+  atMentionOtherTextColor: string
   disabledTextColor: string
   errorTextColor: string
   successTextColor: string
@@ -32,7 +34,10 @@ export interface ITextVariables {
 
 export default (siteVariables): ITextVariables => {
   return {
-    atMentionTextColor: siteVariables.orange04,
+    atMentionOtherTextColor: siteVariables.orange04,
+    atMentionMeTextColor: siteVariables.brand06,
+    atMentionMeFontWeight: siteVariables.fontWeightBold,
+
     disabledTextColor: siteVariables.gray06,
     errorTextColor: siteVariables.red,
     successTextColor: siteVariables.green04,

--- a/src/themes/teams/components/Text/textVariables.ts
+++ b/src/themes/teams/components/Text/textVariables.ts
@@ -34,8 +34,8 @@ export interface ITextVariables {
 
 export default (siteVariables): ITextVariables => {
   return {
-    atMentionOtherTextColor: siteVariables.orange04,
-    atMentionMeTextColor: siteVariables.brand06,
+    atMentionOtherTextColor: siteVariables.brand06,
+    atMentionMeTextColor: siteVariables.orange04,
     atMentionMeFontWeight: siteVariables.fontWeightBold,
 
     disabledTextColor: siteVariables.gray06,


### PR DESCRIPTION
atMention text can be of 2 types, myself or another person

**Example**
![image](https://user-images.githubusercontent.com/828692/46038519-257cf480-c0c0-11e8-883c-f40006510f4e.png)

**Usage**
```jsx
<Text atMention="me">@Mention Me</Text>
<Text atMention="other">@Mention Another</Text>
```