### PR TITLE
fix: make tmp to be a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "prop-types": "^15.6.1",
     "react-fela": "^7.2.0",
     "react-popper": "^1.0.2",
-    "tmp": "^0.0.33",
     "what-input": "^5.1.2"
   },
   "devDependencies": {
@@ -157,6 +156,7 @@
     "simulant": "^0.2.2",
     "ta-scripts": "^2.5.2",
     "through2": "^2.0.3",
+    "tmp": "^0.0.33",
     "ts-jest": "^22.4.6",
     "ts-node": "^6.1.0",
     "tslint": "^5.10.0",


### PR DESCRIPTION
This move is necessary due to `tmp` package is not used by any of the consumer's scenarios.