### PR TITLE
feat(menu): add menu item focus styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add embed mode for `FocusZone` and use it in newly added Chat behaviors @tomasiser ([#233](https://github.com/stardust-ui/react/pull/233))
 - Add default accessibility behavior to `Popup` @sophieH29 ([#218](https://github.com/stardust-ui/react/pull/218))
+- Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))
 
 ### Documentation
 - Improve `Contributing` documentation @alinais, @levithomason ([#189](https://github.com/stardust-ui/react/pull/189))

--- a/docs/src/examples/components/Menu/Variations/MenuExampleIconOnlyPrimary.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Variations/MenuExampleIconOnlyPrimary.shorthand.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Menu } from '@stardust-ui/react'
+
+const items = [
+  { key: 'home', icon: 'home' },
+  { key: 'users', icon: 'users' },
+  { key: 'search', icon: 'search' },
+]
+
+const MenuExampleIconOnlyPrimary = () => (
+  <Menu iconOnly defaultActiveIndex={0} items={items} type="primary" />
+)
+
+export default MenuExampleIconOnlyPrimary

--- a/docs/src/examples/components/Menu/Variations/MenuExampleIconOnlyPrimaryInverted.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Variations/MenuExampleIconOnlyPrimaryInverted.shorthand.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Menu } from '@stardust-ui/react'
+
+const items = [
+  { key: 'home', icon: 'home' },
+  { key: 'users', icon: 'users' },
+  { key: 'search', icon: 'search' },
+]
+
+const MenuExampleIconOnlyPrimaryInverted = () => (
+  <Menu
+    iconOnly
+    defaultActiveIndex={0}
+    items={items}
+    type="primary"
+    variables={siteVars => ({
+      defaultColor: siteVars.gray06,
+      defaultBackgroundColor: siteVars.brand,
+      typePrimaryActiveBorderColor: siteVars.white,
+    })}
+  />
+)
+
+export default MenuExampleIconOnlyPrimaryInverted

--- a/docs/src/examples/components/Menu/Variations/MenuExampleIconOnlyVerticalPrimary.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Variations/MenuExampleIconOnlyVerticalPrimary.shorthand.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Menu } from '@stardust-ui/react'
+
+const items = [
+  { key: 'home', icon: 'home' },
+  { key: 'users', icon: 'users' },
+  { key: 'search', icon: 'search' },
+]
+
+const MenuExampleIconOnlyVertical = () => (
+  <Menu vertical iconOnly defaultActiveIndex={0} items={items} type="primary" />
+)
+
+export default MenuExampleIconOnlyVertical

--- a/docs/src/examples/components/Menu/Variations/MenuExampleToolbar.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Variations/MenuExampleToolbar.shorthand.tsx
@@ -7,7 +7,6 @@ const items = [
     icon: {
       name: 'cloud',
       circular: true,
-      xSpacing: 'both',
       size: 'small',
     },
     accessibility: ToolbarButtonBehavior,
@@ -18,7 +17,6 @@ const items = [
     icon: {
       name: 'clock',
       circular: true,
-      xSpacing: 'both',
       size: 'small',
     },
     accessibility: ToolbarButtonBehavior,
@@ -29,7 +27,6 @@ const items = [
     icon: {
       name: 'book',
       circular: true,
-      xSpacing: 'both',
       size: 'small',
     },
     accessibility: ToolbarButtonBehavior,

--- a/docs/src/examples/components/Menu/Variations/index.tsx
+++ b/docs/src/examples/components/Menu/Variations/index.tsx
@@ -60,7 +60,7 @@ const Variations = () => (
       examplePath="components/Menu/Variations/MenuExampleUnderlined"
     />
     <ComponentExample
-      title="Underlined primary"
+      title="Underlined Primary"
       description="A menu can underline the active element."
       examplePath="components/Menu/Variations/MenuExampleUnderlinedPrimary"
     />
@@ -85,9 +85,24 @@ const Variations = () => (
       examplePath="components/Menu/Variations/MenuExampleIconOnly"
     />
     <ComponentExample
+      title="Icon Only Primary"
+      description="Menu can contain only icons."
+      examplePath="components/Menu/Variations/MenuExampleIconOnlyPrimary"
+    />
+    <ComponentExample
+      title="Icon Only Primary Inverted"
+      description="Menu can contain only icons."
+      examplePath="components/Menu/Variations/MenuExampleIconOnlyPrimaryInverted"
+    />
+    <ComponentExample
       title="Vertical Icon Only"
       description="Vertical menu can contain only icons."
       examplePath="components/Menu/Variations/MenuExampleIconOnlyVertical"
+    />
+    <ComponentExample
+      title="Vertical Icon Only Primary"
+      description="Vertical menu can contain only icons."
+      examplePath="components/Menu/Variations/MenuExampleIconOnlyVerticalPrimary"
     />
     <ComponentExample
       title="Menu as a Tab List"

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -36,6 +36,10 @@ export interface IButtonProps {
   variables?: ComponentVariablesInput
 }
 
+export interface IButtonState {
+  [isFromKeyboard.propertyName]: boolean
+}
+
 /**
  * A button.
  * @accessibility
@@ -43,7 +47,7 @@ export interface IButtonProps {
  *  - for disabled buttons, add 'disabled' attribute so that the state is properly recognized by the screen reader
  *  - if button includes icon only, textual representation needs to be provided by using 'title', 'aria-label', or 'aria-labelledby' attributes
  */
-class Button extends UIComponent<Extendable<IButtonProps>, any> {
+class Button extends UIComponent<Extendable<IButtonProps>, IButtonState> {
   static create: Function
 
   public static displayName = 'Button'

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -7,6 +7,7 @@ import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } f
 import Icon from '../Icon'
 import { MenuItemBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/interfaces'
+import IsFromKeyboard from '../../lib/isFromKeyboard'
 
 import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import {
@@ -37,7 +38,11 @@ export interface IMenuItemProps {
   variables?: ComponentVariablesInput
 }
 
-class MenuItem extends UIComponent<Extendable<IMenuItemProps>, any> {
+export interface IMenuItemState {
+  [IsFromKeyboard.propertyName]: boolean
+}
+
+class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   static displayName = 'MenuItem'
 
   static className = 'ui-menu__item'
@@ -114,13 +119,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, any> {
     accessibility: MenuItemBehavior as Accessibility,
   }
 
-  protected actionHandlers: AccessibilityActionHandlers = {
-    performClick: event => this.handleClick(event),
-  }
-
-  handleClick = e => {
-    _.invoke(this.props, 'onClick', e, this.props)
-  }
+  state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
     const { children, content, icon } = this.props
@@ -138,6 +137,8 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, any> {
           <a
             className={cx('ui-menu__item__anchor', classes.anchor)}
             onClick={this.handleClick}
+            onBlur={this.handleBlur}
+            onFocus={this.handleFocus}
             {...accessibility.attributes.anchor}
             {...accessibility.keyHandlers.anchor}
           >
@@ -150,6 +151,26 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, any> {
         )}
       </ElementType>
     )
+  }
+
+  protected actionHandlers: AccessibilityActionHandlers = {
+    performClick: event => this.handleClick(event),
+  }
+
+  private handleClick = e => {
+    _.invoke(this.props, 'onClick', e, this.props)
+  }
+
+  private handleBlur = (e: React.SyntheticEvent) => {
+    this.setState(IsFromKeyboard.initial)
+
+    _.invoke(this.props, 'onBlur', e, this.props)
+  }
+
+  private handleFocus = (e: React.SyntheticEvent) => {
+    this.setState(IsFromKeyboard.state())
+
+    _.invoke(this.props, 'onFocus', e, this.props)
   }
 }
 

--- a/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/src/components/RadioGroup/RadioGroupItem.tsx
@@ -32,15 +32,23 @@ export interface IRadioGroupItemProps {
   styles?: ComponentPartStyle
   value?: string | number
   variables?: ComponentVariablesInput
-  isFromKeyboard?: boolean
+  [isFromKeyboard.propertyName]?: boolean
   vertical?: boolean
+}
+
+export interface IRadioGroupItemState {
+  checked: boolean
+  [isFromKeyboard.propertyName]: boolean
 }
 
 /**
  * @accessibility
  * Radio items need to be grouped in RadioGroup component to correctly handle accessibility.
  */
-class RadioGroupItem extends AutoControlledComponent<Extendable<IRadioGroupItemProps>, any> {
+class RadioGroupItem extends AutoControlledComponent<
+  Extendable<IRadioGroupItemProps>,
+  IRadioGroupItemState
+> {
   static create: Function
 
   static displayName = 'RadioGroupItem'
@@ -131,7 +139,7 @@ class RadioGroupItem extends AutoControlledComponent<Extendable<IRadioGroupItemP
 
   static autoControlledProps = ['checked', isFromKeyboard.propertyName]
 
-  elementRef: HTMLElement
+  private elementRef: HTMLElement
 
   componentDidMount() {
     this.elementRef = ReactDOM.findDOMNode(this) as HTMLElement
@@ -155,7 +163,7 @@ class RadioGroupItem extends AutoControlledComponent<Extendable<IRadioGroupItemP
     _.invoke(this.props, 'onBlur', e, this.props)
   }
 
-  handleClick = e => {
+  private handleClick = e => {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,6 +33,7 @@ export {
 } from './htmlPropsUtils'
 
 export { default as isBrowser } from './isBrowser'
+export { default as typescriptUtils } from './typescriptUtils'
 export { default as doesNodeContainClick } from './doesNodeContainClick'
 export { default as leven } from './leven'
 

--- a/src/lib/isFromKeyboard.ts
+++ b/src/lib/isFromKeyboard.ts
@@ -1,12 +1,17 @@
 import whatInput from 'what-input'
+import tsUtils from './typescriptUtils'
+export interface IState {
+  isFromKeyboard: boolean
+}
 
 export default class IsFromKeyboard {
-  static state = () => {
-    const isFromKeyboard = whatInput.ask() === 'keyboard'
-    return { isFromKeyboard }
+  static readonly propertyName = tsUtils.nameof<IState>('isFromKeyboard')
+
+  static initial: IState = IsFromKeyboard.getObjectWithPropValue(false)
+
+  static state = (): IState => IsFromKeyboard.getObjectWithPropValue(whatInput.ask() === 'keyboard')
+
+  private static getObjectWithPropValue(value: boolean): IState {
+    return { [IsFromKeyboard.propertyName]: value }
   }
-
-  static initial = { isFromKeyboard: false }
-
-  static propertyName = 'isFromKeyboard'
 }

--- a/src/lib/typescriptUtils.ts
+++ b/src/lib/typescriptUtils.ts
@@ -1,0 +1,5 @@
+const nameof = <T>(name: keyof T) => name
+
+export default {
+  nameof,
+}

--- a/src/themes/teams/components/Button/buttonStyles.ts
+++ b/src/themes/teams/components/Button/buttonStyles.ts
@@ -1,9 +1,9 @@
 import { pxToRem } from '../../../../lib'
 import { IComponentPartStylesInput, ICSSInJSStyle } from '../../../../../types/theme'
-import { IButtonProps } from '../../../../components/Button/Button'
+import { IButtonProps, IButtonState } from '../../../../components/Button/Button'
 import { truncateStyle } from '../../../../styles/customCSS'
 
-const buttonStyles: IComponentPartStylesInput<IButtonProps, any> = {
+const buttonStyles: IComponentPartStylesInput<IButtonProps & IButtonState, any> = {
   root: ({ props, variables }): ICSSInJSStyle => {
     const { circular, disabled, fluid, type, text, iconOnly, isFromKeyboard } = props
     const primary = type === 'primary'

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -5,48 +5,76 @@ import {
   ICSSInJSStyle,
 } from '../../../../../types/theme'
 import { IMenuVariables } from './menuVariables'
-import { IMenuItemProps } from '../../../../components/Menu/MenuItem'
+import { IMenuItemProps, IMenuItemState } from '../../../../components/Menu/MenuItem'
 
-const underlinedItem = (color): ICSSInJSStyle => ({
+type MenuItemProps = IMenuItemProps & IMenuItemState
+
+const underlinedItem = (color: string): ICSSInJSStyle => ({
+  paddingBottom: 0,
   borderBottom: `solid ${pxToRem(4)} ${color}`,
   transition: 'color .1s ease',
 })
 
+const getActionStyles = ({
+  props: { type, underlined, iconOnly, isFromKeyboard },
+  variables: v,
+  color,
+}: {
+  props: MenuItemProps
+  variables: IMenuVariables
+  color: string
+}): ICSSInJSStyle =>
+  (underlined && !isFromKeyboard) || iconOnly
+    ? {
+        color,
+        background: v.defaultBackgroundColor,
+      }
+    : type === 'primary'
+      ? {
+          color: v.typePrimaryActiveColor,
+          background: v.typePrimaryActiveBackgroundColor,
+        }
+      : {
+          color,
+          background: v.defaultActiveBackgroundColor,
+        }
+
 const itemSeparator: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
   props,
-  variables,
+  variables: v,
 }): ICSSInJSStyle => {
   const { iconOnly, pointing, pills, type, underlined, vertical } = props
-  return {
-    ...(!pills &&
-      !underlined &&
-      !(pointing && vertical) &&
-      !iconOnly && {
-        '::before': {
-          position: 'absolute',
-          content: '""',
-          top: 0,
-          right: 0,
-          ...(vertical ? { width: '100%', height: '1px' } : { width: '1px', height: '100%' }),
-          background: variables.defaultBorderColor,
-          ...(type === 'primary' && {
-            background: variables.typePrimaryBorderColor,
-          }),
-        },
-        ...(vertical && {
-          ':first-child': {
-            '::before': {
-              display: 'none',
-            },
+
+  return (
+    !pills &&
+    !underlined &&
+    !(pointing && vertical) &&
+    !iconOnly && {
+      '::before': {
+        position: 'absolute',
+        content: '""',
+        top: 0,
+        right: 0,
+        ...(vertical ? { width: '100%', height: '1px' } : { width: '1px', height: '100%' }),
+        ...(type === 'primary'
+          ? { background: v.typePrimaryBorderColor }
+          : { background: v.defaultBorderColor }),
+      },
+
+      ...(vertical && {
+        ':first-child': {
+          '::before': {
+            display: 'none',
           },
-        }),
+        },
       }),
-  }
+    }
+  )
 }
 
 const pointingBeak: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
   props,
-  variables,
+  variables: v,
 }): ICSSInJSStyle => {
   const { pointing, type } = props
 
@@ -56,11 +84,11 @@ const pointingBeak: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
   let borders: ICSSInJSStyle
 
   if (type === 'primary') {
-    backgroundColor = variables.typePrimaryActiveBackgroundColor
-    borderColor = variables.typePrimaryBorderColor
+    backgroundColor = v.typePrimaryActiveBackgroundColor
+    borderColor = v.typePrimaryBorderColor
   } else {
-    backgroundColor = variables.defaultActiveBackgroundColor
-    borderColor = variables.defaultBorderColor
+    backgroundColor = v.defaultActiveBackgroundColor
+    borderColor = v.defaultBorderColor
   }
 
   if (pointing === 'start') {
@@ -97,38 +125,36 @@ const pointingBeak: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
   }
 }
 
-const menuItemStyles: IComponentPartStylesInput<IMenuItemProps, IMenuVariables> = {
-  root: ({ props, variables, theme }): ICSSInJSStyle => {
-    const { active, iconOnly, pills, pointing, type, underlined, vertical } = props
-    const { iconsMenuItemSpacing } = variables
+const menuItemStyles: IComponentPartStylesInput<MenuItemProps, IMenuVariables> = {
+  root: ({ props, variables: v, theme }): ICSSInJSStyle => {
+    const { active, isFromKeyboard, pills, pointing, underlined, vertical } = props
+
     return {
-      color: variables.defaultColor,
+      color: v.defaultColor,
+      background: v.defaultBackgroundColor,
       lineHeight: 1,
       position: 'relative',
       verticalAlign: 'middle',
       display: 'block',
-      ...(iconOnly && {
-        ':nth-child(n+2)': {
-          ...(vertical
-            ? { marginTop: iconsMenuItemSpacing }
-            : { marginLeft: iconsMenuItemSpacing }),
-        },
-      }),
+
       ...(pills && {
         ...(vertical ? { margin: `0 0 ${pxToRem(5)} 0` } : { margin: `0 ${pxToRem(8)} 0 0` }),
         borderRadius: pxToRem(5),
       }),
+
       ...(underlined && {
-        padding: '0',
-        margin: `0 ${pxToRem(10)} 0 0`,
+        display: 'flex',
+        alignItems: 'center',
+        height: pxToRem(29),
+        lineHeight: v.lineHeightBase,
+        padding: `0 ${pxToRem(4)}`,
+        margin: `0 ${pxToRem(4)} 0 0`,
         ':nth-child(n+2)': {
-          marginLeft: `${pxToRem(10)}`,
+          marginLeft: `${pxToRem(4)}`,
         },
-        background: 'transparent',
         boxShadow: 'none',
-        color: variables.defaultColor,
       }),
-      ...itemSeparator({ props, variables, theme }),
+
       ...(pointing &&
         vertical && {
           border: '1px solid transparent',
@@ -140,94 +166,108 @@ const menuItemStyles: IComponentPartStylesInput<IMenuItemProps, IMenuVariables> 
           marginBottom: `${pxToRem(12)}`,
         }),
 
-      ':hover': {
-        color: variables.defaultActiveColor,
-        // all menus should have gray background on hover except the underlined menu
-        ...(!underlined && {
-          background: variables.defaultActiveBackgroundColor,
-          ...(type === 'primary' && {
-            background: variables.typePrimaryActiveBackgroundColor,
-          }),
-        }),
-      },
+      ...itemSeparator({ props, variables: v, theme }),
 
+      // active styles
       ...(active && {
-        ...(!underlined && {
-          background: variables.defaultActiveBackgroundColor,
-          ...(type === 'primary' && {
-            background: variables.typePrimaryActiveBackgroundColor,
-          }),
-        }),
-        color: variables.defaultColor,
-        ':hover': {
-          ...(!underlined && {
-            color: variables.defaultActiveColor,
-            background: variables.defaultActiveBackgroundColor,
-            ...(type === 'primary' && {
-              background: variables.typePrimaryActiveBackgroundColor,
-            }),
-          }),
-        },
-        ...(pointing && !vertical && pointingBeak({ props, variables, theme })),
+        ...getActionStyles({ props, variables: v, color: v.defaultColor }),
+
         ...(pointing &&
-          vertical && {
-            ...(pointing === 'end'
-              ? { borderRight: `${pxToRem(3)} solid ${variables.typePrimaryActiveColor}` }
-              : { borderLeft: `${pxToRem(3)} solid ${variables.typePrimaryActiveColor}` }),
-          }),
+          (vertical
+            ? pointing === 'end'
+              ? { borderRight: `${pxToRem(3)} solid ${v.typePrimaryActiveBorderColor}` }
+              : { borderLeft: `${pxToRem(3)} solid ${v.typePrimaryActiveBorderColor}` }
+            : pointingBeak({ props, variables: v, theme }))),
       }),
+
+      // focus styles
+      ...(isFromKeyboard && getActionStyles({ props, variables: v, color: v.defaultActiveColor })),
+
+      // hover styles
+      ':hover': getActionStyles({ props, variables: v, color: v.defaultActiveColor }),
     }
   },
 
-  anchor: ({ props, variables }): ICSSInJSStyle => {
-    const { active, iconOnly, pointing, type, underlined, vertical } = props
-    const { iconsMenuItemSize } = variables
+  anchor: ({ props, variables: v }): ICSSInJSStyle => {
+    const { active, iconOnly, isFromKeyboard, pointing, type, underlined, vertical } = props
 
     return {
       color: 'inherit',
       display: 'block',
+      cursor: 'pointer',
+
       ...(underlined
-        ? { padding: `0 0 ${pxToRem(8)} 0` }
+        ? { padding: `${pxToRem(4)} 0` }
         : pointing && vertical
           ? { padding: `${pxToRem(8)} ${pxToRem(18)}` }
           : { padding: `${pxToRem(14)} ${pxToRem(18)}` }),
-      cursor: 'pointer',
 
       ...(iconOnly && {
-        width: iconsMenuItemSize,
-        height: iconsMenuItemSize || '100%',
+        width: v.iconsMenuItemSize,
+        height: v.iconsMenuItemSize || '100%',
         padding: 0,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
       }),
 
-      ':hover': {
-        color: 'inherit',
-        ...(underlined && {
-          paddingBottom: `${pxToRem(4)}`,
-          ...underlinedItem(variables.defaultActiveBackgroundColor),
-          ...(type === 'primary' && {
-            ...underlinedItem(variables.typePrimaryActiveBorderColor),
-          }),
-        }),
+      // active styles
+      ...(active &&
+        (type === 'primary'
+          ? {
+              ...(iconOnly && { color: v.typePrimaryActiveBorderColor }),
+
+              ...(underlined && {
+                color: v.typePrimaryActiveBorderColor,
+                ...underlinedItem(v.typePrimaryActiveBorderColor),
+              }),
+            }
+          : underlined && {
+              fontWeight: 700,
+              ...underlinedItem(v.defaultActiveColor),
+            })),
+
+      // focus styles
+      ...(isFromKeyboard && {
+        ...(type === 'primary'
+          ? {
+              ...(iconOnly && {
+                color: v.typePrimaryActiveBorderColor,
+                border: `1px solid ${v.typePrimaryActiveBorderColor}`,
+                borderRadius: v.circularRadius,
+              }),
+
+              ...(underlined && { color: v.typePrimaryActiveColor }),
+
+              ...(underlined && active && underlinedItem(v.typePrimaryActiveColor)),
+            }
+          : {
+              ...(iconOnly && {
+                border: `1px solid ${v.defaultActiveColor}`,
+                borderRadius: v.circularRadius,
+              }),
+
+              ...(underlined && { fontWeight: 700 }),
+
+              ...(underlined && active && underlinedItem(v.defaultActiveColor)),
+            }),
+      }),
+
+      ':focus': {
+        outline: 0,
       },
 
-      ...(active &&
-        underlined && {
-          color: variables.defaultColor,
-          paddingBottom: `${pxToRem(4)}`,
-          ':hover': {},
-          ...underlinedItem(variables.defaultActiveColor),
-          ...(type === 'primary'
-            ? {
-                color: variables.typePrimaryActiveColor,
-                ...underlinedItem(variables.typePrimaryActiveColor),
-              }
-            : {
-                fontWeight: 700,
-              }),
-        }),
+      // hover styles
+      ':hover': {
+        color: 'inherit',
+
+        ...(type === 'primary'
+          ? {
+              ...(iconOnly && { color: v.typePrimaryActiveBorderColor }),
+              ...(!active && underlined && underlinedItem(v.typePrimaryHoverBorderColor)),
+            }
+          : !active && underlined && underlinedItem(v.defaultActiveBackgroundColor)),
+      },
     }
   },
 }

--- a/src/themes/teams/components/Menu/menuVariables.ts
+++ b/src/themes/teams/components/Menu/menuVariables.ts
@@ -1,39 +1,45 @@
-export interface IMenuVariables {
-  [key: string]: string | number | undefined
+import { pxToRem } from '../../../../lib'
 
+export interface IMenuVariables {
   defaultColor: string
+  defaultBackgroundColor: string
+
   defaultActiveColor: string
   defaultActiveBackgroundColor: string
   defaultBorderColor: string
 
-  typePrimaryColor: string
   typePrimaryActiveColor: string
   typePrimaryActiveBackgroundColor: string
-  typePrimaryBackgroundColorHover: string
-  typePrimaryBorderColor: string
   typePrimaryActiveBorderColor: string
+
+  typePrimaryBorderColor: string
+  typePrimaryHoverBorderColor: string
   typePrimaryUnderlinedBorderColor: string
 
   iconsMenuItemSize?: string
-  iconsMenuItemSpacing: number | string
+  circularRadius: string
+  lineHeightBase: string
 }
 
 export default (siteVars: any): IMenuVariables => {
   return {
     defaultColor: siteVars.gray02,
+    defaultBackgroundColor: 'transparent',
+
     defaultActiveColor: siteVars.black,
     defaultActiveBackgroundColor: siteVars.gray10,
     defaultBorderColor: siteVars.gray08,
 
-    typePrimaryColor: siteVars.gray02,
-    typePrimaryActiveColor: siteVars.brand,
-    typePrimaryActiveBackgroundColor: siteVars.brand14,
-    typePrimaryBackgroundColorHover: siteVars.brand16,
+    typePrimaryActiveColor: siteVars.white,
+    typePrimaryActiveBackgroundColor: siteVars.brand08,
+    typePrimaryActiveBorderColor: siteVars.brand,
+
     typePrimaryBorderColor: siteVars.brand08,
-    typePrimaryActiveBorderColor: siteVars.brand12,
+    typePrimaryHoverBorderColor: siteVars.gray08,
     typePrimaryUnderlinedBorderColor: siteVars.gray08,
 
-    iconsMenuItemSize: undefined,
-    iconsMenuItemSpacing: 0,
+    iconsMenuItemSize: pxToRem(32),
+    circularRadius: pxToRem(999),
+    lineHeightBase: siteVars.lineHeightBase,
   }
 }

--- a/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -1,22 +1,19 @@
 import { IComponentPartStylesInput, ICSSInJSStyle } from 'theme'
-import { IRadioGroupItemProps } from '../../../../components/RadioGroup/RadioGroupItem'
+import {
+  IRadioGroupItemProps,
+  IRadioGroupItemState,
+} from '../../../../components/RadioGroup/RadioGroupItem'
 import { pxToRem } from '../../../../lib'
 
-const radioStyles: IComponentPartStylesInput = {
-  root: ({ variables, props }: { props: IRadioGroupItemProps; variables: any }): ICSSInJSStyle => ({
+const radioStyles: IComponentPartStylesInput<IRadioGroupItemProps & IRadioGroupItemState, any> = {
+  root: ({ props }): ICSSInJSStyle => ({
     outline: 0,
     ...(!props.vertical && {
       display: 'inline-block',
     }),
   }),
 
-  label: ({
-    variables,
-    props,
-  }: {
-    props: IRadioGroupItemProps
-    variables: any
-  }): ICSSInJSStyle => ({
+  label: ({ props, variables }): ICSSInJSStyle => ({
     cursor: 'pointer',
     display: 'inline-flex',
     alignItems: 'baseline',
@@ -28,7 +25,7 @@ const radioStyles: IComponentPartStylesInput = {
     }),
   }),
 
-  icon: ({ props, variables }: { props: IRadioGroupItemProps; variables: any }): ICSSInJSStyle => ({
+  icon: ({ props, variables }): ICSSInJSStyle => ({
     ...(props.isFromKeyboard && {
       // this creates both inset and outset box shadow that some readers (NVDA) show when radio is not checked but it is focused
       boxShadow:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Menu

This PR main purposes:
- adds keyboard focus styles by leveraging existing functionality;
- updates existing styles to adhere better to Teams theme;

### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [x] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# Description

## `type="primary"`

All primary (`type="primary"`) menus get updated background for `active`, `focus` and `hover` states.
![screen shot 2018-09-27 at 02 49 14](https://user-images.githubusercontent.com/5442794/46117676-db505c00-c202-11e8-904c-b634b85496a8.png)

## `underlined`

Underlined menus get new styles for `active`, `focus` and `hover` states.

![screen shot 2018-09-27 at 02 49 46](https://user-images.githubusercontent.com/5442794/46117426-7cd6ae00-c201-11e8-8a28-4636077be8ba.png)
![screen shot 2018-09-27 at 02 50 02](https://user-images.githubusercontent.com/5442794/46117482-bad3d200-c201-11e8-8acd-84ec9a6b73da.png)

## `iconOnly`

Menus with only icons as item get new styles for `active`, `focus` and `hover` states.

#### 1. regular:
![screen shot 2018-09-27 at 02 50 22](https://user-images.githubusercontent.com/5442794/46117580-3766b080-c202-11e8-9f58-243795140360.png)

#### 2. inverted (by tweeking variables):
![screen shot 2018-09-27 at 02 51 37](https://user-images.githubusercontent.com/5442794/46117608-6846e580-c202-11e8-84f9-c08cab98bfd0.png)

#### 3. vertical (with `vertical` prop):
![screen shot 2018-09-27 at 02 51 57](https://user-images.githubusercontent.com/5442794/46117661-c8d62280-c202-11e8-848f-7df5dc552afe.png)
