### PR TITLE
fix(radio-group): replaced label with content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix generation of `key` for the `Accordion.Content` @mnajdova ([#305](https://github.com/stardust-ui/react/pull/305))
 - Ensure `Popup` is rendered as direct child of `body` element in the DOM tree @kuzhelov ([#302](https://github.com/stardust-ui/react/pull/302))
 - Fix toggle logic of `Popup` as reaction on key press events @kuzhelov ([#304](https://github.com/stardust-ui/react/pull/304))
+- Fix for `RadioGroup`: made `label` accept react nodes as value and fixed keyboard navigation @Bugaa92 ([#287](https://github.com/stardust-ui/react/pull/287))
 
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))

--- a/docs/src/examples/components/RadioGroup/Item/RadioGroupItemExample.shorthand.tsx
+++ b/docs/src/examples/components/RadioGroup/Item/RadioGroupItemExample.shorthand.tsx
@@ -8,8 +8,8 @@ const handleChange = () => {
 const RadioGroupItemExample = () => (
   <RadioGroup
     items={[
-      <RadioGroup.Item label="Make your choice" value="1" checkedChanged={handleChange} />,
-      <RadioGroup.Item label="Another option" value="2" checkedChanged={handleChange} />,
+      <RadioGroup.Item key="1" label="Make your choice" value="1" checkedChanged={handleChange} />,
+      <RadioGroup.Item key="2" label="Another option" value="2" checkedChanged={handleChange} />,
     ]}
   />
 )

--- a/docs/src/examples/components/RadioGroup/Item/RadioGroupItemExampleChecked.shorthand.tsx
+++ b/docs/src/examples/components/RadioGroup/Item/RadioGroupItemExampleChecked.shorthand.tsx
@@ -4,7 +4,7 @@ import { RadioGroup } from '@stardust-ui/react'
 const RadioGroupItemExampleCheckedShorthand = () => (
   <RadioGroup
     defaultCheckedValue="1"
-    items={[<RadioGroup.Item label="This radio comes pre-checked" value="1" />]}
+    items={[<RadioGroup.Item key="1" label="This radio comes pre-checked" value="1" />]}
   />
 )
 

--- a/docs/src/examples/components/RadioGroup/Item/RadioGroupItemExampleDisabled.shorthand.tsx
+++ b/docs/src/examples/components/RadioGroup/Item/RadioGroupItemExampleDisabled.shorthand.tsx
@@ -4,8 +4,8 @@ import { RadioGroup } from '@stardust-ui/react'
 const RadioGroupItemExampleDisabledShorthand = () => (
   <RadioGroup
     items={[
-      <RadioGroup.Item label="Disabled" value="1" disabled />,
-      <RadioGroup.Item label="Enabled" value="2" />,
+      <RadioGroup.Item key="1" label="Disabled" value="1" disabled />,
+      <RadioGroup.Item key="2" label="Enabled" value="2" />,
     ]}
   />
 )

--- a/docs/src/examples/components/RadioGroup/Types/RadioGroupExample.shorthand.tsx
+++ b/docs/src/examples/components/RadioGroup/Types/RadioGroupExample.shorthand.tsx
@@ -1,26 +1,9 @@
 import React from 'react'
-import { Divider, RadioGroup } from '@stardust-ui/react'
-const props = [
-  { name: 'pizza', key: 'Capricciosa', label: 'Capricciosa', value: 'capricciosa' },
-  { name: 'pizza', key: 'Prosciutto', label: 'Prosciutto', value: 'prosciutto', disabled: true },
-  {
-    name: 'pizza',
-    key: 'Margherita',
-    label: 'Margherita',
-    value: 'margherita',
-  },
-]
-const items = [
-  <RadioGroup.Item {...props[0]} />,
-  <RadioGroup.Item {...props[1]} />,
-  <RadioGroup.Item {...props[2]} />,
-]
+import { Divider, RadioGroup, Input, Text } from '@stardust-ui/react'
 
-class RadioGroupExample extends React.Component {
-  state = { selectedValue: '' }
-  handleChange = (e, props) => {
-    this.setState({ selectedValue: props.value })
-  }
+class RadioGroupVerticalExample extends React.Component {
+  state = { selectedValue: '', inputTabIndex: '-1' }
+
   render() {
     const { selectedValue } = this.state
     return (
@@ -29,11 +12,42 @@ class RadioGroupExample extends React.Component {
         <Divider />
         <RadioGroup
           defaultCheckedValue="capricciosa"
-          items={items}
+          items={this.getItems()}
           checkedValueChanged={this.handleChange}
         />
       </div>
     )
   }
+
+  getItems() {
+    return [
+      { name: 'pizza', key: 'Capricciosa', label: 'Capricciosa', value: 'capricciosa' },
+      {
+        name: 'pizza',
+        key: 'Prosciutto',
+        label: 'Prosciutto',
+        value: 'prosciutto',
+        disabled: true,
+      },
+      {
+        name: 'pizza',
+        key: 'Custom',
+        label: (
+          <Text>
+            Choose your own <Input inline placeholder="flavour" />
+          </Text>
+        ),
+        value: 'custom',
+        checkedChanged: this.handleCustomCheckedChange,
+        'aria-label': 'Press Tab to change flavour',
+      },
+    ]
+  }
+
+  handleChange = (e, props) => this.setState({ selectedValue: props.value })
+
+  handleCustomCheckedChange = (e, props) =>
+    this.setState({ inputTabIndex: props.checked ? '0' : '-1' })
 }
-export default RadioGroupExample
+
+export default RadioGroupVerticalExample

--- a/docs/src/examples/components/RadioGroup/Types/RadioGroupVerticalExample.shorthand.tsx
+++ b/docs/src/examples/components/RadioGroup/Types/RadioGroupVerticalExample.shorthand.tsx
@@ -1,22 +1,9 @@
 import React from 'react'
-import { Divider, RadioGroup } from '@stardust-ui/react'
-
-const items = [
-  { name: 'pizza', key: 'Capricciosa', label: 'Capricciosa', value: 'capricciosa' },
-  { name: 'pizza', key: 'Prosciutto', label: 'Prosciutto', value: 'prosciutto', disabled: true },
-  {
-    name: 'pizza',
-    key: 'Margherita',
-    label: 'Margherita',
-    value: 'margherita',
-  },
-]
+import { Divider, RadioGroup, Input, Text } from '@stardust-ui/react'
 
 class RadioGroupVerticalExample extends React.Component {
-  state = { selectedValue: '' }
-  handleChange = (e, props) => {
-    this.setState({ selectedValue: props.value })
-  }
+  state = { selectedValue: '', inputTabIndex: '-1' }
+
   render() {
     const { selectedValue } = this.state
     return (
@@ -26,11 +13,42 @@ class RadioGroupVerticalExample extends React.Component {
         <RadioGroup
           vertical
           defaultCheckedValue="capricciosa"
-          items={items}
+          items={this.getItems()}
           checkedValueChanged={this.handleChange}
         />
       </div>
     )
   }
+
+  getItems() {
+    return [
+      { name: 'pizza', key: 'Capricciosa', label: 'Capricciosa', value: 'capricciosa' },
+      {
+        name: 'pizza',
+        key: 'Prosciutto',
+        label: 'Prosciutto',
+        value: 'prosciutto',
+        disabled: true,
+      },
+      {
+        name: 'pizza',
+        key: 'Custom',
+        label: (
+          <Text>
+            Choose your own <Input inline placeholder="flavour" />
+          </Text>
+        ),
+        value: 'custom',
+        checkedChanged: this.handleCustomCheckedChange,
+        'aria-label': 'Press Tab to change flavour',
+      },
+    ]
+  }
+
+  handleChange = (e, props) => this.setState({ selectedValue: props.value })
+
+  handleCustomCheckedChange = (e, props) =>
+    this.setState({ inputTabIndex: props.checked ? '0' : '-1' })
 }
+
 export default RadioGroupVerticalExample

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -9,11 +9,7 @@ import RadioGroupItem, { IRadioGroupItemProps } from './RadioGroupItem'
 import { RadioGroupBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/interfaces'
 
-import {
-  ComponentVariablesInput,
-  ComponentVariablesObject,
-  ComponentPartStyle,
-} from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import { Extendable, ItemShorthand, ReactChildren } from '../../../types/utils'
 
 export interface IRadioGroupProps {
@@ -87,34 +83,51 @@ class RadioGroup extends AutoControlledComponent<Extendable<IRadioGroupProps>, a
 
   static Item = RadioGroupItem
 
-  actionHandlers: AccessibilityActionHandlers = {
+  renderComponent({ ElementType, classes, accessibility, rest }) {
+    const { children, vertical } = this.props
+    return (
+      <ElementType
+        {...accessibility.attributes.root}
+        {...accessibility.keyHandlers.root}
+        {...rest}
+        className={classes.root}
+      >
+        {childrenExist(children) ? children : this.renderItems(vertical)}
+      </ElementType>
+    )
+  }
+
+  protected actionHandlers: AccessibilityActionHandlers = {
     nextItem: event => this.setCheckedItem(event, 1),
     prevItem: event => this.setCheckedItem(event, -1),
   }
 
-  getItemProps = item => {
+  private getItemProps = (item): IRadioGroupItemProps => {
     return (item as React.ReactElement<IRadioGroupItemProps>).props || item
   }
 
-  setCheckedItem = (event, direction) => {
+  private setCheckedItem = (event, direction) => {
     const nextItem = this.findNextEnabledCheckedItem(direction)
 
     if (nextItem) {
-      this.trySetState({ checkedValue: nextItem.value })
-      _.invoke(this.props, 'checkedValueChanged', event, nextItem)
+      this.setCheckedValue({
+        checkedValue: nextItem.value,
+        shouldFocus: true,
+        event,
+        props: nextItem,
+      })
     }
-
     event.preventDefault()
   }
 
-  findNextEnabledCheckedItem = (direction): IRadioGroupItemProps => {
+  private findNextEnabledCheckedItem = (direction): IRadioGroupItemProps => {
     if (!this.props.items || !this.props.items.length) {
       return undefined
     }
 
     const currentIndex = _.findIndex(
       this.props.items,
-      item => this.getItemProps(item as IRadioGroupItemProps).value === this.state.checkedValue,
+      item => this.getItemProps(item).value === this.state.checkedValue,
     )
 
     for (
@@ -132,7 +145,7 @@ class RadioGroup extends AutoControlledComponent<Extendable<IRadioGroupProps>, a
         return undefined
       }
 
-      const itemProps = this.getItemProps(this.props.items[newIndex] as IRadioGroupItemProps)
+      const itemProps = this.getItemProps(this.props.items[newIndex])
       if (!itemProps.disabled) {
         return itemProps
       }
@@ -140,45 +153,43 @@ class RadioGroup extends AutoControlledComponent<Extendable<IRadioGroupProps>, a
     return undefined
   }
 
-  handleItemOverrides = predefinedProps => ({
+  private handleItemOverrides = predefinedProps => ({
     checked:
       typeof this.state.checkedValue !== 'undefined' &&
       this.state.checkedValue === predefinedProps.value,
     onClick: (event, itemProps) => {
       const { value, disabled } = itemProps
       if (!disabled && value !== this.state.checkedValue) {
-        this.trySetState({ checkedValue: value })
-        _.invoke(this.props, 'checkedValueChanged', event, itemProps)
+        this.setCheckedValue({ checkedValue: value, shouldFocus: false, event, props: itemProps })
       }
       _.invoke(predefinedProps, 'onClick', event, itemProps)
     },
+    shouldFocus: this.state.shouldFocus,
   })
 
-  renderItems = (variables: ComponentVariablesObject, vertical: boolean) => {
-    const { items } = this.props
-
-    return _.map(items, (item, index) =>
+  private renderItems = (vertical: boolean) =>
+    _.map(this.props.items, item =>
       RadioGroupItem.create(item, {
-        defaultProps: {
-          vertical,
-        },
+        defaultProps: { vertical },
         overrideProps: this.handleItemOverrides,
       }),
     )
-  }
 
-  renderComponent({ ElementType, classes, accessibility, variables, rest }) {
-    const { children, vertical } = this.props
-    return (
-      <ElementType
-        {...accessibility.attributes.root}
-        {...accessibility.keyHandlers.root}
-        {...rest}
-        className={classes.root}
-      >
-        {childrenExist(children) ? children : this.renderItems(variables, vertical)}
-      </ElementType>
-    )
+  private setCheckedValue({
+    checkedValue,
+    shouldFocus,
+    event,
+    props,
+  }: {
+    checkedValue: number | string
+    shouldFocus: boolean
+    event: React.SyntheticEvent
+    props: IRadioGroupItemProps
+  }) {
+    this.trySetState({ checkedValue })
+    this.setState({ shouldFocus })
+
+    _.invoke(this.props, 'checkedValueChanged', event, props)
   }
 }
 

--- a/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/src/components/RadioGroup/RadioGroupItem.tsx
@@ -24,11 +24,12 @@ export interface IRadioGroupItemProps {
   checkedChanged?: ComponentEventHandler<IRadioGroupItemProps>
   children?: ReactChildren
   className?: string
+  label?: React.ReactNode
   defaultChecked?: boolean
   disabled?: boolean
   icon?: ItemShorthand
-  label?: string
   name?: string
+  shouldFocus?: boolean // TODO: RFC #306
   styles?: ComponentPartStyle
   value?: string | number
   variables?: ComponentVariablesInput
@@ -49,6 +50,8 @@ class RadioGroupItem extends AutoControlledComponent<
   Extendable<IRadioGroupItemProps>,
   IRadioGroupItemState
 > {
+  private elementRef: HTMLElement
+
   static create: Function
 
   static displayName = 'RadioGroupItem'
@@ -89,7 +92,7 @@ class RadioGroupItem extends AutoControlledComponent<
     isFromKeyboard: PropTypes.bool,
 
     /** The label of the radio item. */
-    label: PropTypes.string,
+    label: customPropTypes.contentShorthand,
 
     /** The HTML input name. */
     name: PropTypes.string,
@@ -122,6 +125,9 @@ class RadioGroupItem extends AutoControlledComponent<
      */
     checkedChanged: PropTypes.func,
 
+    /** Whether should focus when checked */
+    shouldFocus: PropTypes.bool,
+
     /** Additional CSS styles to apply to the component instance.  */
     styles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 
@@ -142,32 +148,16 @@ class RadioGroupItem extends AutoControlledComponent<
 
   static autoControlledProps = ['checked', isFromKeyboard.propertyName]
 
-  private elementRef: HTMLElement
-
-  componentDidMount() {
-    this.elementRef = ReactDOM.findDOMNode(this) as HTMLElement
-  }
-
   componentDidUpdate(prevProps, prevState) {
     const checked = this.state.checked
     if (checked !== prevState.checked) {
-      checked && this.elementRef.focus()
+      checked && this.props.shouldFocus && this.elementRef.focus()
       _.invoke(this.props, 'checkedChanged', undefined, { ...this.props, checked })
     }
   }
 
-  private handleFocus = (e: React.SyntheticEvent) => {
-    this.setState(isFromKeyboard.state())
-    _.invoke(this.props, 'onFocus', e, this.props)
-  }
-
-  private handleBlur = (e: React.SyntheticEvent) => {
-    this.setState(isFromKeyboard.initial)
-    _.invoke(this.props, 'onBlur', e, this.props)
-  }
-
-  private handleClick = e => {
-    _.invoke(this.props, 'onClick', e, this.props)
+  componentDidMount() {
+    this.elementRef = ReactDOM.findDOMNode(this) as HTMLElement
   }
 
   renderComponent({ ElementType, classes, rest, styles, variables, accessibility }) {
@@ -196,6 +186,20 @@ class RadioGroupItem extends AutoControlledComponent<
         </Label>
       </ElementType>
     )
+  }
+
+  private handleFocus = (e: React.SyntheticEvent) => {
+    this.setState(isFromKeyboard.state())
+    _.invoke(this.props, 'onFocus', e, this.props)
+  }
+
+  private handleBlur = (e: React.SyntheticEvent) => {
+    this.setState(isFromKeyboard.initial)
+    _.invoke(this.props, 'onBlur', e, this.props)
+  }
+
+  private handleClick = e => {
+    _.invoke(this.props, 'onClick', e, this.props)
   }
 }
 


### PR DESCRIPTION


<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Radio group

This PR contains:
- replacing `label` prop with `content`
- making `content` accept react nodes as value

### TODO

- [x] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [x] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md
