### PR TITLE
fix: make theme variables and styles extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Ensure `Popup` is rendered as direct child of `body` element in the DOM tree @kuzhelov ([#302](https://github.com/stardust-ui/react/pull/302))
 - Fix toggle logic of `Popup` as reaction on key press events @kuzhelov ([#304](https://github.com/stardust-ui/react/pull/304))
 - Fix for `RadioGroup`: made `label` accept react nodes as value and fixed keyboard navigation @Bugaa92 ([#287](https://github.com/stardust-ui/react/pull/287))
+- Make theme variables and styles types extensible @levithomason ([#292](https://github.com/stardust-ui/react/pull/292))
 
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -1,6 +1,6 @@
 import { pxToRem } from '../../../../lib'
 import {
-  ComponentPartStyle,
+  ComponentPartStyleFunction,
   IComponentPartStylesInput,
   ICSSInJSStyle,
 } from '../../../../../types/theme'
@@ -39,7 +39,7 @@ const getActionStyles = ({
           background: v.defaultActiveBackgroundColor,
         }
 
-const itemSeparator: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
+const itemSeparator: ComponentPartStyleFunction<IMenuItemProps, IMenuVariables> = ({
   props,
   variables: v,
 }): ICSSInJSStyle => {
@@ -72,7 +72,7 @@ const itemSeparator: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
   )
 }
 
-const pointingBeak: ComponentPartStyle<IMenuItemProps, IMenuVariables> = ({
+const pointingBeak: ComponentPartStyleFunction<IMenuItemProps, IMenuVariables> = ({
   props,
   variables: v,
 }): ICSSInJSStyle => {
@@ -264,7 +264,7 @@ const menuItemStyles: IComponentPartStylesInput<MenuItemProps, IMenuVariables> =
         ...(type === 'primary'
           ? {
               ...(iconOnly && { color: v.typePrimaryActiveBorderColor }),
-              ...(!active && underlined && underlinedItem(v.typePrimaryHoverBorderColor)),
+              ...(!active && underlined && underlinedItem(v.typePrimaryHoverBorderColor as string)),
             }
           : !active && underlined && underlinedItem(v.defaultActiveBackgroundColor)),
       },

--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -60,6 +60,9 @@ export interface ICSSPseudoElementStyle extends ICSSInJSStyle {
 }
 
 export interface ICSSInJSStyle extends React.CSSProperties {
+  // TODO Questionable: how else would users target their own children?
+  [key: string]: any
+
   // missing React.CSSProperties
   speak?: CSSType.Globals | 'none' | 'normal' | 'spell-out'
 
@@ -163,7 +166,7 @@ export interface IThemePrepared {
 }
 
 export interface IThemeComponentStylesInput {
-  [key: string]: any
+  [key: string]: IComponentPartStylesInput
 
   Accordion?: IComponentPartStylesInput
   Attachment?: IComponentPartStylesInput
@@ -198,7 +201,7 @@ export interface IThemeComponentStylesInput {
 }
 
 export interface IThemeComponentStylesPrepared {
-  [key: string]: any
+  [key: string]: IComponentPartStylesPrepared
 
   Accordion?: IComponentPartStylesPrepared
   Attachment?: IComponentPartStylesPrepared

--- a/types/theme.d.ts
+++ b/types/theme.d.ts
@@ -163,72 +163,142 @@ export interface IThemePrepared {
 }
 
 export interface IThemeComponentStylesInput {
+  [key: string]: any
+
   Accordion?: IComponentPartStylesInput
+  Attachment?: IComponentPartStylesInput
   Avatar?: IComponentPartStylesInput
   Button?: IComponentPartStylesInput
+  ButtonGroup?: IComponentPartStylesInput
   Chat?: IComponentPartStylesInput
+  ChatItem?: IComponentPartStylesInput
+  ChatMessage?: IComponentPartStylesInput
   Divider?: IComponentPartStylesInput
+  Grid?: IComponentPartStylesInput
   Header?: IComponentPartStylesInput
+  HeaderDescription?: IComponentPartStylesInput
   Icon?: IComponentPartStylesInput
   Image?: IComponentPartStylesInput
   Input?: IComponentPartStylesInput
+  ItemLayout?: IComponentPartStylesInput
   Label?: IComponentPartStylesInput
   Layout?: IComponentPartStylesInput
   List?: IComponentPartStylesInput
   ListItem?: IComponentPartStylesInput
   Menu?: IComponentPartStylesInput
+  MenuItem?: IComponentPartStylesInput
+  Portal?: IComponentPartStylesInput
+  Popup?: IComponentPartStylesInput
+  PopupContent?: IComponentPartStylesInput
+  RadioGroup?: IComponentPartStylesInput
+  RadioGroupItem?: IComponentPartStylesInput
+  Segment?: IComponentPartStylesInput
+  Status?: IComponentPartStylesInput
   Text?: IComponentPartStylesInput
 }
 
 export interface IThemeComponentStylesPrepared {
+  [key: string]: any
+
   Accordion?: IComponentPartStylesPrepared
+  Attachment?: IComponentPartStylesPrepared
   Avatar?: IComponentPartStylesPrepared
   Button?: IComponentPartStylesPrepared
+  ButtonGroup?: IComponentPartStylesPrepared
   Chat?: IComponentPartStylesPrepared
+  ChatItem?: IComponentPartStylesPrepared
+  ChatMessage?: IComponentPartStylesPrepared
   Divider?: IComponentPartStylesPrepared
+  Grid?: IComponentPartStylesPrepared
   Header?: IComponentPartStylesPrepared
+  HeaderDescription?: IComponentPartStylesPrepared
   Icon?: IComponentPartStylesPrepared
   Image?: IComponentPartStylesPrepared
   Input?: IComponentPartStylesPrepared
+  ItemLayout?: IComponentPartStylesPrepared
   Label?: IComponentPartStylesPrepared
   Layout?: IComponentPartStylesPrepared
   List?: IComponentPartStylesPrepared
   ListItem?: IComponentPartStylesPrepared
   Menu?: IComponentPartStylesPrepared
+  MenuItem?: IComponentPartStylesPrepared
+  Portal?: IComponentPartStylesPrepared
+  Popup?: IComponentPartStylesPrepared
+  PopupContent?: IComponentPartStylesPrepared
+  RadioGroup?: IComponentPartStylesPrepared
+  RadioGroupItem?: IComponentPartStylesPrepared
+  Segment?: IComponentPartStylesPrepared
+  Status?: IComponentPartStylesPrepared
   Text?: IComponentPartStylesPrepared
 }
 
 export interface IThemeComponentVariablesInput {
+  [key: string]: any
+
   Accordion?: ComponentVariablesInput
+  Attachment?: ComponentVariablesInput
   Avatar?: ComponentVariablesInput
   Button?: ComponentVariablesInput
+  ButtonGroup?: ComponentVariablesInput
   Chat?: ComponentVariablesInput
+  ChatItem?: ComponentVariablesInput
+  ChatMessage?: ComponentVariablesInput
   Divider?: ComponentVariablesInput
+  Grid?: ComponentVariablesInput
   Header?: ComponentVariablesInput
+  HeaderDescription?: ComponentVariablesInput
   Icon?: ComponentVariablesInput
   Image?: ComponentVariablesInput
   Input?: ComponentVariablesInput
+  ItemLayout?: ComponentVariablesInput
   Label?: ComponentVariablesInput
   Layout?: ComponentVariablesInput
+  List?: ComponentVariablesInput
   ListItem?: ComponentVariablesInput
   Menu?: ComponentVariablesInput
+  MenuItem?: ComponentVariablesInput
+  Portal?: ComponentVariablesInput
+  Popup?: ComponentVariablesInput
+  PopupContent?: ComponentVariablesInput
+  RadioGroup?: ComponentVariablesInput
+  RadioGroupItem?: ComponentVariablesInput
+  Segment?: ComponentVariablesInput
+  Status?: ComponentVariablesInput
   Text?: ComponentVariablesInput
 }
 
 export interface IThemeComponentVariablesPrepared {
+  [key: string]: any
+
   Accordion?: ComponentVariablesPrepared
+  Attachment?: ComponentVariablesPrepared
   Avatar?: ComponentVariablesPrepared
   Button?: ComponentVariablesPrepared
+  ButtonGroup?: ComponentVariablesPrepared
   Chat?: ComponentVariablesPrepared
+  ChatItem?: ComponentVariablesPrepared
+  ChatMessage?: ComponentVariablesPrepared
   Divider?: ComponentVariablesPrepared
+  Grid?: ComponentVariablesPrepared
   Header?: ComponentVariablesPrepared
+  HeaderDescription?: ComponentVariablesPrepared
   Icon?: ComponentVariablesPrepared
   Image?: ComponentVariablesPrepared
   Input?: ComponentVariablesPrepared
+  ItemLayout?: ComponentVariablesPrepared
   Label?: ComponentVariablesPrepared
   Layout?: ComponentVariablesPrepared
+  List?: ComponentVariablesPrepared
   ListItem?: ComponentVariablesPrepared
   Menu?: ComponentVariablesPrepared
+  MenuItem?: ComponentVariablesPrepared
+  Portal?: ComponentVariablesPrepared
+  Popup?: ComponentVariablesPrepared
+  PopupContent?: ComponentVariablesPrepared
+  RadioGroup?: ComponentVariablesPrepared
+  RadioGroupItem?: ComponentVariablesPrepared
+  Segment?: ComponentVariablesPrepared
+  Status?: ComponentVariablesPrepared
   Text?: ComponentVariablesPrepared
 }
 


### PR DESCRIPTION
Currently, consumers cannot add custom component display names to a theme's `componentVariables` and `componentStyles`.  This is a problem as they will need to add their component's to the theme as well.

I've also added the unlisted component display names the theme.
