### PR TITLE
chore: Enable noUnusedLocals in tsconfig

### DIFF
--- a/build/tsconfig.common.json
+++ b/build/tsconfig.common.json
@@ -24,5 +24,6 @@
     "noImplicitThis": false,
     "noImplicitAny": false,
     "strictNullChecks": false,
+    "noUnusedLocals": true,
   }
 }


### PR DESCRIPTION
## Summary

This PR enables `noUnusedLocals`. No code changes were necessary as everything has already been fixed in #228.

## Details

`no-unused-variables` tslint rule was enabled in #228.

The rule is deprecated in favour of `noUnusedLocals` TypeScript compiler option (see https://github.com/palantir/tslint/blob/master/CHANGELOG.md#warning-deprecations).

Related to #184,` noUnusedLocal` matches ProjectB configuration. 