### PR TITLE
fix(Attachment): styles prop typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix Attachment `styles` prop typing @levithomason ([#299](https://github.com/stardust-ui/react/pull/299))
+
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))
 

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 import { UIComponent, customPropTypes, createShorthandFactory } from '../../lib'
 import { Extendable, ItemShorthand } from '../../../types/utils'
-import { IComponentPartStylesInput, ComponentVariablesInput } from '../../../types/theme'
+import { ComponentVariablesInput, ComponentPartStyle } from '../../../types/theme'
 import Icon from '../Icon/Icon'
 import Button from '../Button/Button'
 import Text from '../Text/Text'
@@ -18,7 +18,7 @@ export type AttachmentProps = {
   header?: ItemShorthand
   icon?: ItemShorthand
   progress?: string | number
-  styles?: IComponentPartStylesInput
+  styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
 


### PR DESCRIPTION
The Attachment component `styles` typing currently requires component part styles mapping (root, icon, etc) opposed to a component part style for the root only.

This PR fixes that.