### PR TITLE
fix(Accordion): generate key for the Accordion.Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix Attachment `styles` prop typing @levithomason ([#299](https://github.com/stardust-ui/react/pull/299))
-- Fix generation of key for the Accordion.Content @mnajdova ([#305](https://github.com/stardust-ui/react/pull/305))
+- Fix generation of `key` for the `Accordion.Content` @mnajdova ([#305](https://github.com/stardust-ui/react/pull/305))
 
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix Attachment `styles` prop typing @levithomason ([#299](https://github.com/stardust-ui/react/pull/299))
+- Fix generation of key for the Accordion.Content @mnajdova ([#305](https://github.com/stardust-ui/react/pull/305))
 
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))

--- a/docs/src/examples/components/Accordion/Variations/AccordionExampleList.shorthand.tsx
+++ b/docs/src/examples/components/Accordion/Variations/AccordionExampleList.shorthand.tsx
@@ -6,18 +6,21 @@ class AccordionExampleList extends React.Component {
     const panels = [
       {
         title: 'Pets',
-        content: (
-          <div>
-            <List
-              items={[
-                { key: 'a', media: <Image avatar src="//placehold.it/100" />, header: 'cat' },
-                { key: 'b', media: <Image avatar src="//placehold.it/100" />, header: 'dog' },
-                { key: 'c', media: <Image avatar src="//placehold.it/100" />, header: 'mouse' },
-              ]}
-            />
-            <Button>Add pet</Button>
-          </div>
-        ),
+        content: {
+          key: 'animals',
+          content: (
+            <div>
+              <List
+                items={[
+                  { key: 'a', media: <Image avatar src="//placehold.it/100" />, header: 'cat' },
+                  { key: 'b', media: <Image avatar src="//placehold.it/100" />, header: 'dog' },
+                  { key: 'c', media: <Image avatar src="//placehold.it/100" />, header: 'mouse' },
+                ]}
+              />
+              <Button>Add pet</Button>
+            </div>
+          ),
+        },
       },
     ]
 

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -152,19 +152,14 @@ class Accordion extends AutoControlledComponent<Extendable<IAccordionProps>, any
 
       children.push(
         AccordionTitle.create(title, {
-          generateKey: true,
           defaultProps: { active, index },
           overrideProps: this.handleTitleOverrides,
         }),
       )
       children.push(
-        AccordionContent.create(
-          { content },
-          {
-            generateKey: true,
-            defaultProps: { active },
-          },
-        ),
+        AccordionContent.create(content, {
+          defaultProps: { active },
+        }),
       )
     })
 


### PR DESCRIPTION
# Fix

This PR fixes https://github.com/stardust-ui/react/issues/291 

### TODO

- [x] Conformance test
- [x] Update the CHANGELOG.md

There was a bug in the creation of the Content which prevented generation of keys, and a small bug where the complex content for the Accordion.Content was created. Those two are fixed now. 
## Important note
We support generation of keys, for the component that as content has some primitive value (string, number etc). If the content is something more complex (as in the last example of the docs), that the user is responsible for creating the key.