### PR TITLE
fix(docs): fix className to receive string

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -402,7 +402,7 @@ class ComponentExample extends React.Component<IComponentExampleProps, IComponen
         key: codeType,
         onClick: this.setApiCodeType.bind(this, codeType),
         content: codeTypeApiButtonLabels[codeType],
-        className: disabled && 'crossout',
+        ...(disabled && { className: 'crossout' }),
       }
     })
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Docsite

### Description

This PR contains a one line fix for the doc site. Whenever we open the code editor there is a console error coming from the API code menu (`Shorthand API | Children API`) items.

We are sending  boolean values instead of string values to `className` prop for menu items, hence the error:
![docsite_error](https://user-images.githubusercontent.com/5442794/46465883-243b7e00-c7ca-11e8-94ce-042c6d7f070c.gif)

### Fix:

Always send string as `className` prop value.