### PR TITLE
fix(Input): remove duplcated 'onChange' handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Ensure `Popup` is rendered as direct child of `body` element in the DOM tree @kuzhelov ([#302](https://github.com/stardust-ui/react/pull/302))
 - Fix toggle logic of `Popup` as reaction on key press events @kuzhelov ([#304](https://github.com/stardust-ui/react/pull/304))
 - Fix for `RadioGroup`: made `label` accept react nodes as value and fixed keyboard navigation @Bugaa92 ([#287](https://github.com/stardust-ui/react/pull/287))
+- Fix duplicated handling of 'change' event by `Input` @kuzhelov ([#310](https://github.com/stardust-ui/react/pull/310))
 
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -174,12 +174,10 @@ class Input extends AutoControlledComponent<Extendable<IInputProps>, any> {
     const { type } = this.props
     const [htmlInputProps, restProps] = this.partitionProps()
 
-    const { onChange } = htmlInputProps as any
-
     const inputClasses = classes.input
 
     return (
-      <ElementType className={classes.root} {...restProps} onChange={onChange}>
+      <ElementType className={classes.root} {...restProps}>
         {createHTMLInput(type, {
           defaultProps: htmlInputProps,
           overrideProps: {


### PR DESCRIPTION
Currently for each change of the input value we have `onChange` handler logic being called twice. This is happening due to the same event handling function is provided both for `<input>` DOM element, as well as for the wrapping component (`default is <div>`):

```jsx
renderComponent({ ElementType, classes, styles, variables }) {
   ...

    return (
      <ElementType className={classes.root} {...restProps} onChange={onChange}>  // <----- HERE
        {createHTMLInput(type, {
          defaultProps: htmlInputProps, // <------ AND HERE, as htmlInputProps contain 'onChange' one
          overrideProps: {
            className: inputClasses,
            ref: this.handleInputRef,
          },
        })}
```

![image](https://user-images.githubusercontent.com/9024564/46474503-b56f1c80-c7eb-11e8-99f8-464ea9e1e25d.png)


