### PR TITLE
fix(Popup): rename 'onOpenChange' -> 'onChange'

### DIFF
--- a/docs/src/examples/components/Popup/Types/PopupExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupExample.shorthand.tsx
@@ -12,7 +12,7 @@ class PopupExample extends React.Component<any, any> {
     return (
       <Popup
         open={this.state.popupOpen}
-        onOpenChange={(e, newProps) => {
+        onChange={(e, newProps) => {
           alert(`Popup is requested to change its open state to "${newProps.open}".`)
           this.setState({ popupOpen: newProps.open })
         }}

--- a/docs/src/examples/components/Popup/Types/PopupExample.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupExample.tsx
@@ -12,7 +12,7 @@ class PopupExample extends React.Component<any, any> {
     return (
       <Popup
         open={this.state.popupOpen}
-        onOpenChange={(e, newProps) => {
+        onChange={(e, newProps) => {
           alert(`Popup is requested to change its open state to "${newProps.open}".`)
           this.setState({ popupOpen: newProps.open })
         }}

--- a/docs/src/examples/components/Popup/Types/index.tsx
+++ b/docs/src/examples/components/Popup/Types/index.tsx
@@ -7,7 +7,7 @@ const Types = () => (
   <ExampleSection title="Types">
     <ComponentExample
       title="Default"
-      description="A default popup. Note that Popup is a controlled component, and its 'open' prop value could be changed either by parent component, or by user actions (e.g. key press) - thus it is necessary to handle 'onOpenChanged' event. Try to type some text into popup's input field and press ESC to see the effect."
+      description="A default popup. Note that Popup is a controlled component, and its 'open' prop value could be changed either by parent component, or by user actions (e.g. key press) - thus it is necessary to handle 'onChange' event. Try to type some text into popup's input field and press ESC to see the effect."
       examplePath="components/Popup/Types/PopupExample"
     />
   </ExampleSection>

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -35,7 +35,7 @@ export interface IPopupProps {
   content?: ItemShorthand | ItemShorthand[]
   defaultOpen?: boolean
   open?: boolean
-  onOpenChange?: ComponentEventHandler<IPopupProps>
+  onChange?: ComponentEventHandler<IPopupProps>
   position?: Position
   trigger?: JSX.Element
 }
@@ -86,7 +86,7 @@ export default class Popup extends AutoControlledComponent<Extendable<IPopupProp
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props and proposed value.
      */
-    onOpenChange: PropTypes.func,
+    onChange: PropTypes.func,
 
     /**
      * Position for the popup. Position has higher priority than align. If position is vertical ('above' | 'below')
@@ -112,10 +112,10 @@ export default class Popup extends AutoControlledComponent<Extendable<IPopupProp
 
   protected actionHandlers: AccessibilityActionHandlers = {
     toggle: e =>
-      _.invoke(this.props, 'onOpenChange', e, { ...this.props, ...{ open: !this.props.open } }),
+      _.invoke(this.props, 'onChange', e, { ...this.props, ...{ open: !this.props.open } }),
     closeAndFocusTrigger: e => {
-      if (this.props.onOpenChange) {
-        _.invoke(this.props, 'onOpenChange', e, { ...this.props, ...{ open: false } })
+      if (this.props.onChange) {
+        _.invoke(this.props, 'onChange', e, { ...this.props, ...{ open: false } })
         _.invoke(this.state.triggerRef, 'focus')
       }
     },


### PR DESCRIPTION
### TODO 
- [ ] update CHANGELOG

-----------

This BREAKING change is necessary to ensure the naming is consistent with other components (such as Input). Although it is a breaking one, it is better to introduce it sooner than later.