### PR TITLE
fix(debug): make `debug` a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Ensure `Popup` is rendered as direct child of `body` element in the DOM tree @kuzhelov ([#302](https://github.com/stardust-ui/react/pull/302))
 - Fix toggle logic of `Popup` as reaction on key press events @kuzhelov ([#304](https://github.com/stardust-ui/react/pull/304))
 - Fix for `RadioGroup`: made `label` accept react nodes as value and fixed keyboard navigation @Bugaa92 ([#287](https://github.com/stardust-ui/react/pull/287))
+- Make `debug` a runtime dependency ([#301](https://github.com/stardust-ui/react/issues/301))
 
 ### Features
 - Add focus styles for `Menu.Item` component @Bugaa92 ([#286](https://github.com/stardust-ui/react/pull/286))

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "debug": "^3.0.1",
     "faker": "^4.1.0",
     "fela": "^6.1.7",
     "fela-plugin-fallback-value": "^5.0.17",
@@ -110,7 +111,6 @@
     "copy-to-clipboard": "^3.0.8",
     "copy-webpack-plugin": "^4.5.2",
     "cross-env": "^5.1.4",
-    "debug": "^3.0.1",
     "doctoc": "^1.3.0",
     "doctrine": "^2.0.0",
     "enzyme": "^3.1.0",


### PR DESCRIPTION
Fixes https://github.com/stardust-ui/react/issues/301. Ideally we could get rid of this dependency if in production environments, but this seems to be a fine solution in the meantime.