### PR TITLE
docs(ComponentExample): remove cruft prop `suiVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Improve `Contributing` documentation for accessibility @jurokapsiar ([#303](https://github.com/stardust-ui/react/pull/303))
 - Add theme switcher for exploring different themes on the docs (only available in development mode) @mnajdova ([#280](https://github.com/stardust-ui/react/pull/280))
 - Add `Prototypes` section and `Chat Pane` prototype (only available in development mode) @Bugaa92 ([#235](https://github.com/stardust-ui/react/pull/235))
+- Remove cruft prop `suiVersion` from the `ComponentExample` component @layershifter ([#329](https://github.com/stardust-ui/react/pull/329))
 
 <!--------------------------------[ v0.8.0 ]------------------------------- -->
 ## [v0.8.0](https://github.com/stardust-ui/react/tree/v0.8.0) (2018-10-01)

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -30,7 +30,6 @@ export interface IComponentExampleProps extends RouteComponentProps<any, any> {
   title: string
   description: string
   examplePath: string
-  suiVersion?: string
   themeName?: string
 }
 
@@ -98,7 +97,6 @@ class ComponentExample extends React.Component<IComponentExampleProps, IComponen
     history: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     match: PropTypes.object.isRequired,
-    suiVersion: PropTypes.string,
     title: PropTypes.node,
     themeName: PropTypes.string,
   }
@@ -606,7 +604,7 @@ class ComponentExample extends React.Component<IComponentExampleProps, IComponen
   }
 
   public render() {
-    const { children, description, suiVersion, title } = this.props
+    const { children, description, title } = this.props
     const {
       handleMouseLeave,
       handleMouseMove,
@@ -659,7 +657,6 @@ class ComponentExample extends React.Component<IComponentExampleProps, IComponen
                 <ComponentExampleTitle
                   description={description}
                   title={title}
-                  suiVersion={suiVersion}
                 />
               </div>
               <div style={{ flex: '0 0 auto' }}>

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -654,10 +654,7 @@ class ComponentExample extends React.Component<IComponentExampleProps, IComponen
           <Grid.Column width={16} style={{ borderBottom: '1px solid #ddd' }}>
             <div style={{ display: 'flex' }}>
               <div style={{ flex: '1' }}>
-                <ComponentExampleTitle
-                  description={description}
-                  title={title}
-                />
+                <ComponentExampleTitle description={description} title={title} />
               </div>
               <div style={{ flex: '0 0 auto' }}>
                 <ComponentControls

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleTitle.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleTitle.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import * as React from 'react'
-import { Header, Label } from 'semantic-ui-react'
+import { Header } from 'semantic-ui-react'
 
 const titleStyle = {
   margin: 0,
@@ -10,25 +10,15 @@ export default class ComponentExampleTitle extends React.PureComponent<any, any>
   static propTypes = {
     description: PropTypes.node,
     title: PropTypes.node,
-    suiVersion: PropTypes.string,
   }
 
   render() {
-    const { description, title, suiVersion } = this.props
+    const { description, title } = this.props
     return (
       <div>
         {title && (
           <Header as="h3" className="no-anchor" style={titleStyle}>
             {title}
-            {suiVersion && (
-              <Label
-                as="a"
-                color="teal"
-                content={suiVersion}
-                size="tiny"
-                title={`Available from Semantic UI ${suiVersion}`}
-              />
-            )}
           </Header>
         )}
         {description && <p>{description}</p>}


### PR DESCRIPTION
`ComponentExampleTitle` and `ComponentExample` have cruft variables that are useless for Stardust UI.
