### PR TITLE
fix(Button): renderIcon prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix Button's `renderIcon` prop @levithomason ([#347](https://github.com/stardust-ui/react/pull/347))
+
 ### Features
 - Make `content` to be a shorthand prop for `Popup` @kuzhelov ([#322](https://github.com/stardust-ui/react/pull/322))
 - Add generic `Slot` component (used internally) and use it as shorthand for `Button` `content` prop @Bugaa92 ([#335](https://github.com/stardust-ui/react/pull/335))

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -177,8 +177,8 @@ class Button extends UIComponent<Extendable<IButtonProps>, IButtonState> {
         styles: styles.icon,
         xSpacing: !content ? 'none' : iconPosition === 'after' ? 'before' : 'after',
         variables: variables.icon,
-        render: renderIcon,
       },
+      render: renderIcon,
     })
   }
 


### PR DESCRIPTION
Currently, the `renderIcon` prop is passed to the Icon's defaultProps by mistake.  This should be passed as an option to the factory.  This PR fixes this issue.