### PR TITLE
feat(Chat): add content and renderContent props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Make `content` to be a shorthand prop for `Popup` @kuzhelov ([#322](https://github.com/stardust-ui/react/pull/322))
 - Add generic `Slot` component (used internally) and use it as shorthand for `Button` `content` prop @Bugaa92 ([#335](https://github.com/stardust-ui/react/pull/335))
 - Add `fitted` prop to `Divider` @gopalgoel19 ([#333](https://github.com/stardust-ui/react/pull/333))
+- Add `content` and `renderContent` to Chat API @levithomason ([#348](https://github.com/stardust-ui/react/pull/348))
 
 <!--------------------------------[ v0.9.0 ]------------------------------- -->
 ## [v0.9.0](https://github.com/stardust-ui/react/tree/v0.9.0) (2018-10-07)

--- a/src/components/Chat/ChatItem.tsx
+++ b/src/components/Chat/ChatItem.tsx
@@ -2,20 +2,22 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 
 import {
+  childrenExist,
   createShorthandFactory,
   customPropTypes,
   IRenderResultConfig,
   UIComponent,
 } from '../../lib'
+import Slot from '../Slot/Slot'
 import { ComponentPartStyle, ComponentVariablesInput } from '../../../types/theme'
-import { Extendable, ReactChildren } from '../../../types/utils'
-import childrenExist from '../../lib/childrenExist'
+import { Extendable, ReactChildren, ShorthandRenderFunction } from '../../../types/utils'
 
 export interface IChatItemProps {
   as?: any
   content?: React.ReactNode
   children?: ReactChildren
   className?: string
+  renderContent?: ShorthandRenderFunction
   styles?: ComponentPartStyle
   variables?: ComponentVariablesInput
 }
@@ -37,6 +39,18 @@ class ChatItem extends UIComponent<Extendable<IChatItemProps>, any> {
     /** Additional CSS class name(s) to apply. */
     className: PropTypes.string,
 
+    /** Shorthand for the primary content. */
+    content: PropTypes.node,
+
+    /**
+     * A custom render function the content slot.
+     *
+     * @param {React.ReactType} Component - The computed component for this slot.
+     * @param {object} props - The computed props for this slot.
+     * @param {ReactNode|ReactNodeArray} children - The computed children for this slot.
+     */
+    renderContent: PropTypes.func,
+
     /** Custom styles to be applied for component. */
     styles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 
@@ -48,12 +62,24 @@ class ChatItem extends UIComponent<Extendable<IChatItemProps>, any> {
     as: 'li',
   }
 
-  renderComponent({ ElementType, classes, rest }: IRenderResultConfig<IChatItemProps>) {
-    const { children, content } = this.props
+  renderComponent({
+    ElementType,
+    classes,
+    styles,
+    variables,
+    rest,
+  }: IRenderResultConfig<IChatItemProps>) {
+    const { children, content, renderContent } = this.props
 
     return (
       <ElementType {...rest} className={classes.root}>
-        {childrenExist(children) ? children : content}
+        {childrenExist(children)
+          ? children
+          : Slot.create(content, {
+              styles: styles.content,
+              variables: variables.content,
+              render: renderContent,
+            })}
       </ElementType>
     )
   }

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -26,6 +26,7 @@ import { chatMessageBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/interfaces'
 import Layout from '../Layout'
 import Text from '../Text'
+import Slot from '../Slot/Slot'
 
 export interface IChatMessageProps {
   accessibility?: Accessibility
@@ -38,6 +39,7 @@ export interface IChatMessageProps {
   mine?: boolean
   renderAuthor?: ShorthandRenderFunction
   renderAvatar?: ShorthandRenderFunction
+  renderContent?: ShorthandRenderFunction
   renderTimestamp?: ShorthandRenderFunction
   styles?: ComponentPartStyle
   timestamp?: ShorthandValue
@@ -96,6 +98,15 @@ class ChatMessage extends UIComponent<Extendable<IChatMessageProps>, any> {
      * @param {ReactNode|ReactNodeArray} children - The computed children for this slot.
      */
     renderAvatar: PropTypes.func,
+
+    /**
+     * A custom render function the content slot.
+     *
+     * @param {React.ReactType} Component - The computed component for this slot.
+     * @param {object} props - The computed props for this slot.
+     * @param {ReactNode|ReactNodeArray} children - The computed children for this slot.
+     */
+    renderContent: PropTypes.func,
 
     /**
      * A custom render function the timestamp slot.
@@ -166,6 +177,7 @@ class ChatMessage extends UIComponent<Extendable<IChatMessageProps>, any> {
       renderAuthor,
       renderAvatar,
       renderTimestamp,
+      renderContent,
       timestamp,
     } = this.props
 
@@ -196,6 +208,12 @@ class ChatMessage extends UIComponent<Extendable<IChatMessageProps>, any> {
       render: renderTimestamp,
     })
 
+    const contentElement = Slot.create(content, {
+      styles: styles.content,
+      variables: variables.content,
+      render: renderContent,
+    })
+
     return (
       <Layout
         start={!mine && avatarElement}
@@ -209,7 +227,7 @@ class ChatMessage extends UIComponent<Extendable<IChatMessageProps>, any> {
                 {timestampElement}
               </>
             }
-            main={content}
+            main={contentElement}
           />
         }
         end={mine && avatarElement}

--- a/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -19,6 +19,7 @@ const chatMessageStyles: IComponentPartStylesInput<IChatMessageProps, IChatMessa
   }),
 
   avatar: ({ props: p }: { props: IChatMessageProps }): ICSSInJSStyle => ({
+    display: p.mine ? 'none' : undefined,
     marginTop: px10asRem,
     marginBottom: px10asRem,
     marginLeft: p.mine ? px10asRem : 0,
@@ -32,9 +33,10 @@ const chatMessageStyles: IComponentPartStylesInput<IChatMessageProps, IChatMessa
     borderRadius: '0.3rem',
   }),
 
-  author: {
+  author: ({ props: p }): ICSSInJSStyle => ({
+    display: p.mine ? 'none' : undefined,
     marginRight: px10asRem,
-  },
+  }),
 }
 
 export default chatMessageStyles


### PR DESCRIPTION
This PR adds the `content` prop and `renderContent` callback prop to all Chat components.

Also, the ChatMessage was hardcoded to show/hide certain slots based on if the message is `mine`.  This logic has been moved to the Teams theme styles instead.