### PR TITLE
feat(menuItem): add endIcon prop

### DIFF
--- a/docs/src/examples/components/Menu/Variations/MenuExampleWithEndIconsVertical.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Variations/MenuExampleWithEndIconsVertical.shorthand.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Menu } from '@stardust-ui/react'
+
+const items = [
+  { key: 'home', content: 'Home', endIcon: 'home' },
+  { key: 'users', content: 'Users', endIcon: 'users' },
+  { key: 'search', content: 'Search', endIcon: 'search' },
+]
+
+const MenuExampleWithEndIconsVertical = () => <Menu vertical defaultActiveIndex={0} items={items} />
+
+export default MenuExampleWithEndIconsVertical

--- a/docs/src/examples/components/Menu/Variations/index.tsx
+++ b/docs/src/examples/components/Menu/Variations/index.tsx
@@ -80,6 +80,11 @@ const Variations = () => (
       examplePath="components/Menu/Variations/MenuExampleWithIconsVertical"
     />
     <ComponentExample
+      title="Vertical End Icon"
+      description="Menu items can contain end icons."
+      examplePath="components/Menu/Variations/MenuExampleWithEndIconsVertical"
+    />
+    <ComponentExample
       title="Icon Only"
       description="Menu can contain only icons."
       examplePath="components/Menu/Variations/MenuExampleIconOnly"

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -26,6 +26,7 @@ export interface IMenuItemProps {
   className?: string
   content?: any
   disabled?: boolean
+  endIcon?: boolean
   icon?: ShorthandValue
   iconOnly?: boolean
   index?: number
@@ -72,6 +73,9 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
 
     /** A menu item can show it is currently unable to be interacted with. */
     disabled: PropTypes.bool,
+
+    /** Name or shorthand for Menu Item End Icon. */
+    endIcon: customPropTypes.itemShorthand,
 
     /** Name or shorthand for Menu Item Icon */
     icon: customPropTypes.itemShorthand,
@@ -136,7 +140,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
-    const { children, content, icon, renderIcon } = this.props
+    const { children, content, endIcon, icon, renderIcon } = this.props
 
     return (
       <ElementType
@@ -162,6 +166,16 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
                 render: renderIcon,
               })}
             {content}
+            {endIcon &&
+              Icon.create(this.props.endIcon, {
+                defaultProps: {
+                  xSpacing: !!content ? 'before' : 'none',
+                  style: {
+                    float: 'right',
+                  },
+                },
+                render: renderIcon,
+              })}
           </a>
         )}
       </ElementType>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# ```MenuItem```

Add an ```endIcon``` prop which renders an ```Icon``` component at the end of the ```MenuItem```.

### TODO

- [ ] Conformance test
- [ ] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [ ] Update the CHANGELOG.md

# API Proposal

## ```endIcon```
![menu stardust](https://user-images.githubusercontent.com/11490517/46795157-14daa880-cd67-11e8-8ec5-f56831baaa09.png)
