### PR TITLE
feat(menuItem: add menu prop)

### DIFF
--- a/docs/src/examples/components/Menu/Types/MenuExampleVerticalWithSubmenu.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Types/MenuExampleVerticalWithSubmenu.shorthand.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Menu } from '@stardust-ui/react'
+
+const items = [
+  {
+    key: 'editorials',
+    content: 'Editorials',
+    menu: {
+      items: [
+        { key: '1', content: 'item1' },
+        {
+          key: '2',
+          content: 'item2',
+          menu: { items: [{ key: '1', content: 'item1' }, { key: '2', content: 'item2' }] },
+        },
+      ],
+    },
+  },
+  { key: 'review', content: 'Reviews' },
+  { key: 'events', content: 'Upcoming Events' },
+]
+
+const MenuExampleVerticalWithSubmenu = () => <Menu defaultActiveIndex={0} items={items} vertical />
+
+export default MenuExampleVerticalWithSubmenu

--- a/docs/src/examples/components/Menu/Types/MenuExampleVerticalWithSubmenu.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Types/MenuExampleVerticalWithSubmenu.shorthand.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Menu } from '@stardust-ui/react'
+import { Menu, Provider } from '@stardust-ui/react'
 
 const items = [
   {
@@ -20,6 +20,20 @@ const items = [
   { key: 'events', content: 'Upcoming Events' },
 ]
 
-const MenuExampleVerticalWithSubmenu = () => <Menu defaultActiveIndex={0} items={items} vertical />
+const MenuExampleVerticalWithSubmenu = () => (
+  <Provider
+    theme={{
+      componentStyles: {
+        Menu: {
+          root: {
+            zIndex: 1000,
+          },
+        },
+      },
+    }}
+  >
+    <Menu defaultActiveIndex={0} vertical items={items} />
+  </Provider>
+)
 
 export default MenuExampleVerticalWithSubmenu

--- a/docs/src/examples/components/Menu/Types/MenuExampleWithSubmenu.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Types/MenuExampleWithSubmenu.shorthand.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Menu } from '@stardust-ui/react'
+import { Menu, Provider } from '@stardust-ui/react'
 
 const items = [
   {
@@ -38,6 +38,20 @@ const items = [
   { key: 'events', content: 'Upcoming Events' },
 ]
 
-const MenuExampleWithSubMenu = () => <Menu defaultActiveIndex={0} items={items} />
+const MenuExampleWithSubMenu = () => (
+  <Provider
+    theme={{
+      componentStyles: {
+        Menu: {
+          root: {
+            zIndex: 1000,
+          },
+        },
+      },
+    }}
+  >
+    <Menu defaultActiveIndex={0} items={items} />
+  </Provider>
+)
 
 export default MenuExampleWithSubMenu

--- a/docs/src/examples/components/Menu/Types/MenuExampleWithSubmenu.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Types/MenuExampleWithSubmenu.shorthand.tsx
@@ -13,10 +13,28 @@ const items = [
           content: 'item2',
           menu: { items: [{ key: '1', content: 'item1' }, { key: '2', content: 'item2' }] },
         },
+        {
+          key: '3',
+          content: 'item3',
+          menu: { items: [{ key: '1', content: 'item1' }, { key: '2', content: 'item2' }] },
+        },
       ],
     },
   },
-  { key: 'review', content: 'Reviews' },
+  {
+    key: 'review',
+    content: 'Reviews',
+    menu: {
+      items: [
+        { key: '1', content: 'item1' },
+        {
+          key: '2',
+          content: 'item2',
+          menu: { items: [{ key: '1', content: 'item1' }, { key: '2', content: 'item2' }] },
+        },
+      ],
+    },
+  },
   { key: 'events', content: 'Upcoming Events' },
 ]
 

--- a/docs/src/examples/components/Menu/Types/MenuExampleWithSubmenu.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Types/MenuExampleWithSubmenu.shorthand.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Menu } from '@stardust-ui/react'
+
+const items = [
+  {
+    key: 'editorials',
+    content: 'Editorials',
+    menu: {
+      items: [
+        { key: '1', content: 'item1' },
+        {
+          key: '2',
+          content: 'item2',
+          menu: { items: [{ key: '1', content: 'item1' }, { key: '2', content: 'item2' }] },
+        },
+      ],
+    },
+  },
+  { key: 'review', content: 'Reviews' },
+  { key: 'events', content: 'Upcoming Events' },
+]
+
+const MenuExampleWithSubMenu = () => <Menu defaultActiveIndex={0} items={items} />
+
+export default MenuExampleWithSubMenu

--- a/docs/src/examples/components/Menu/Types/index.tsx
+++ b/docs/src/examples/components/Menu/Types/index.tsx
@@ -19,6 +19,16 @@ const Types = () => (
       description="A vertical menu displays elements vertically."
       examplePath="components/Menu/Types/MenuExampleVertical"
     />
+    <ComponentExample
+      title="Menu with Submenus"
+      description="A menu can have submenus."
+      examplePath="components/Menu/Types/MenuExampleWithSubmenu"
+    />
+    <ComponentExample
+      title="Vertical submenus"
+      description="A vertical menu can have submenu."
+      examplePath="components/Menu/Types/MenuExampleVerticalWithSubmenu"
+    />
   </ExampleSection>
 )
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -133,14 +133,12 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
 
       this.trySetState({ activeIndex: index })
 
-      if (menu) {
-        this.setState(prev => {
-          if (prev.menuItemOpenKey === index) {
-            return { popupOpen: !prev.popupOpen }
-          }
-          return { menuItemOpenKey: index, popupOpen: true }
-        })
-      }
+      this.setState(prev => {
+        if (prev.menuItemOpenKey === index) {
+          return { popupOpen: !prev.popupOpen }
+        }
+        return { menuItemOpenKey: index, popupOpen: true }
+      })
 
       _.invoke(predefinedProps, 'onClick', e, itemProps)
     },

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -121,11 +121,26 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
 
   static Item = MenuItem
 
+  state = {
+    menuItemOpenKey: 0,
+    popupOpen: false,
+    activeIndex: '0',
+  }
+
   handleItemOverrides = predefinedProps => ({
     onClick: (e, itemProps) => {
-      const { index } = itemProps
+      const { index, menu } = itemProps
 
       this.trySetState({ activeIndex: index })
+
+      if (menu) {
+        this.setState(prev => {
+          if (prev.menuItemOpenKey === index) {
+            return { popupOpen: !prev.popupOpen }
+          }
+          return { menuItemOpenKey: index, popupOpen: true }
+        })
+      }
 
       _.invoke(predefinedProps, 'onClick', e, itemProps)
     },
@@ -147,6 +162,9 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
           vertical,
           index,
           active: parseInt(activeIndex, 10) === index,
+          popupOpen: this.state.popupOpen,
+          menuItemOpenKey: this.state.menuItemOpenKey,
+          // togglePopup: this.togglePopup,
         },
         overrideProps: this.handleItemOverrides,
         render: renderItem,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -122,24 +122,22 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
   static Item = MenuItem
 
   state = {
-    popupOpen: false,
+    submenuOpen: false,
     activeIndex: '',
   }
 
   handleItemOverrides = predefinedProps => ({
-    popupOpen: this.state.popupOpen,
-    activeIndex: this.state.activeIndex,
     onClick: (e, itemProps) => {
       const { index } = itemProps
 
-      // this.trySetState({ activeIndex: index })
-
       this.setState(prev => {
         if (prev.activeIndex === index) {
-          return { popupOpen: !prev.popupOpen }
+          return { submenuOpen: !prev.submenuOpen }
         }
-        return { activeIndex: index, popupOpen: true }
+        return { submenuOpen: true }
       })
+
+      this.trySetState({ activeIndex: index })
 
       _.invoke(predefinedProps, 'onClick', e, itemProps)
     },
@@ -161,6 +159,7 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
           vertical,
           index,
           active: parseInt(activeIndex, 10) === index,
+          submenuOpen: this.state.activeIndex === index ? this.state.submenuOpen : false,
         },
         overrideProps: this.handleItemOverrides,
         render: renderItem,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -122,22 +122,23 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
   static Item = MenuItem
 
   state = {
-    menuItemOpenKey: 0,
     popupOpen: false,
-    activeIndex: '0',
+    activeIndex: '',
   }
 
   handleItemOverrides = predefinedProps => ({
+    popupOpen: this.state.popupOpen,
+    activeIndex: this.state.activeIndex,
     onClick: (e, itemProps) => {
-      const { index, menu } = itemProps
+      const { index } = itemProps
 
-      this.trySetState({ activeIndex: index })
+      // this.trySetState({ activeIndex: index })
 
       this.setState(prev => {
-        if (prev.menuItemOpenKey === index) {
+        if (prev.activeIndex === index) {
           return { popupOpen: !prev.popupOpen }
         }
-        return { menuItemOpenKey: index, popupOpen: true }
+        return { activeIndex: index, popupOpen: true }
       })
 
       _.invoke(predefinedProps, 'onClick', e, itemProps)
@@ -160,9 +161,6 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
           vertical,
           index,
           active: parseInt(activeIndex, 10) === index,
-          popupOpen: this.state.popupOpen,
-          menuItemOpenKey: this.state.menuItemOpenKey,
-          // togglePopup: this.togglePopup,
         },
         overrideProps: this.handleItemOverrides,
         render: renderItem,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -145,7 +145,7 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
 
   renderItems = (variables: ComponentVariablesObject) => {
     const { iconOnly, items, pills, pointing, renderItem, type, underlined, vertical } = this.props
-    const { activeIndex } = this.state
+    const { activeIndex, submenuOpen } = this.state
 
     return _.map(items, (item, index) =>
       MenuItem.create(item, {
@@ -159,7 +159,10 @@ class Menu extends AutoControlledComponent<Extendable<IMenuProps>, any> {
           vertical,
           index,
           active: parseInt(activeIndex, 10) === index,
-          submenuOpen: this.state.activeIndex === index ? this.state.submenuOpen : false,
+          ...(activeIndex === index && { submenuOpen }),
+          ...(item.menu && {
+            styles: { position: 'relative' },
+          }),
         },
         overrideProps: this.handleItemOverrides,
         render: renderItem,

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -142,7 +142,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
-    const { children, index, menu, menuItemOpenKey, popupOpen, vertical, type } = this.props
+    const { activeIndex, children, index, menu, popupOpen, vertical, type } = this.props
 
     return (
       <ElementType
@@ -157,7 +157,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
           this.renderMenuItem(accessibility, classes)
         ) : (
           <Popup
-            open={index === menuItemOpenKey ? popupOpen : false}
+            open={index === activeIndex ? popupOpen : false}
             align={vertical ? 'top' : 'start'}
             position={vertical ? 'after' : 'below'}
             content={{

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
 import Icon from '../Icon'
 import Menu from '../Menu'
-import Popup from '../Popup'
+// import Provider from '../Provider'
 import { menuItemBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/interfaces'
 import IsFromKeyboard from '../../lib/isFromKeyboard'
@@ -146,7 +146,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
-    const { children, menu, submenuOpen, vertical, type } = this.props
+    const { children } = this.props
 
     return (
       <ElementType
@@ -155,48 +155,45 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
         {...accessibility.keyHandlers.root}
         {...rest}
       >
-        {childrenExist(children) ? (
-          children
-        ) : !menu ? (
-          this.renderMenuItem(accessibility, classes)
-        ) : (
-          <Popup
-            open={submenuOpen}
-            align={vertical ? 'top' : 'start'}
-            position={vertical ? 'after' : 'below'}
-            content={{
-              content: <Menu items={menu.items} vertical type={type} />,
-              styles: {
-                padding: '0px',
-                border: '',
-              },
-            }}
-            // content={<Menu items={menu.items} type={type} vertical/>}
-          >
-            {this.renderMenuItem(accessibility, classes)}
-          </Popup>
-        )}
+        {childrenExist(children) ? children : this.renderMenuItem(accessibility, classes)}
       </ElementType>
     )
   }
   private renderMenuItem = (accessibility, classes) => {
-    const { content, icon, renderIcon } = this.props
+    const { content, icon, renderIcon, menu, type, vertical, submenuOpen } = this.props
     return (
-      <a
-        className={cx('ui-menu__item__anchor', classes.anchor)}
-        onClick={this.handleClick}
-        onBlur={this.handleBlur}
-        onFocus={this.handleFocus}
-        {...accessibility.attributes.anchor}
-        {...accessibility.keyHandlers.anchor}
-      >
-        {icon &&
-          Icon.create(this.props.icon, {
-            defaultProps: { xSpacing: !!content ? 'after' : 'none' },
-            render: renderIcon,
-          })}
-        {content}
-      </a>
+      <>
+        <a
+          className={cx('ui-menu__item__anchor', classes.anchor)}
+          onClick={this.handleClick}
+          onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
+          {...accessibility.attributes.anchor}
+          {...accessibility.keyHandlers.anchor}
+        >
+          {icon &&
+            Icon.create(this.props.icon, {
+              defaultProps: { xSpacing: !!content ? 'after' : 'none' },
+              render: renderIcon,
+            })}
+          {content}
+        </a>
+        {menu && submenuOpen ? (
+          <Menu
+            accessibility={null}
+            items={menu.items}
+            vertical
+            type={type}
+            styles={{
+              // background: 'white',
+              // zIndex: '1000',
+              position: 'absolute',
+              top: vertical ? '0' : '100%',
+              left: vertical ? '100%' : '0',
+            }}
+          />
+        ) : null}
+      </>
     )
   }
   protected actionHandlers: AccessibilityActionHandlers = {

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -142,7 +142,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
-    const { children, menu, vertical, type } = this.props
+    const { children, index, menu, menuItemOpenKey, popupOpen, vertical, type } = this.props
 
     return (
       <ElementType
@@ -157,6 +157,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
           this.renderMenuItem(accessibility, classes)
         ) : (
           <Popup
+            open={index === menuItemOpenKey ? popupOpen : false}
             align={vertical ? 'top' : 'start'}
             position={vertical ? 'after' : 'below'}
             content={{
@@ -166,7 +167,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
                 border: '',
               },
             }}
-            // content={<Menu items={menu.items} vertical/>}
+            // content={<Menu items={menu.items} type={type} vertical/>}
           >
             {this.renderMenuItem(accessibility, classes)}
           </Popup>

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -36,6 +36,7 @@ export interface IMenuItemProps {
   pills?: boolean
   pointing?: boolean | 'start' | 'end'
   renderIcon?: ShorthandRenderFunction
+  submenuOpen?: boolean
   type?: 'primary' | 'secondary'
   underlined?: boolean
   vertical?: boolean
@@ -106,6 +107,9 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
      */
     pointing: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['start', 'end'])]),
 
+    /** */
+    submenuOpen: PropTypes.bool,
+
     /** The menu can have primary or secondary type */
     type: PropTypes.oneOf(['primary', 'secondary']),
 
@@ -142,7 +146,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
-    const { activeIndex, children, index, menu, popupOpen, vertical, type } = this.props
+    const { children, menu, submenuOpen, vertical, type } = this.props
 
     return (
       <ElementType
@@ -157,7 +161,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
           this.renderMenuItem(accessibility, classes)
         ) : (
           <Popup
-            open={index === activeIndex ? popupOpen : false}
+            open={submenuOpen}
             align={vertical ? 'top' : 'start'}
             position={vertical ? 'after' : 'below'}
             content={{

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -5,6 +5,8 @@ import * as React from 'react'
 
 import { childrenExist, createShorthandFactory, customPropTypes, UIComponent } from '../../lib'
 import Icon from '../Icon'
+import Menu from '../Menu'
+import Popup from '../Popup'
 import { menuItemBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/interfaces'
 import IsFromKeyboard from '../../lib/isFromKeyboard'
@@ -29,6 +31,7 @@ export interface IMenuItemProps {
   icon?: ShorthandValue
   iconOnly?: boolean
   index?: number
+  menu?: any
   onClick?: ComponentEventHandler<IMenuItemProps>
   pills?: boolean
   pointing?: boolean | 'start' | 'end'
@@ -81,6 +84,9 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
 
     /** MenuItem index inside Menu. */
     index: PropTypes.number,
+
+    /** MenuItem's submenu */
+    menu: PropTypes.any,
 
     /**
      * Called on click. When passed, the component will render as an `a`
@@ -136,7 +142,7 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
   state = IsFromKeyboard.initial
 
   renderComponent({ ElementType, classes, accessibility, rest }) {
-    const { children, content, icon, renderIcon } = this.props
+    const { children, menu, vertical, type } = this.props
 
     return (
       <ElementType
@@ -147,27 +153,47 @@ class MenuItem extends UIComponent<Extendable<IMenuItemProps>, IMenuItemState> {
       >
         {childrenExist(children) ? (
           children
+        ) : !menu ? (
+          this.renderMenuItem(accessibility, classes)
         ) : (
-          <a
-            className={cx('ui-menu__item__anchor', classes.anchor)}
-            onClick={this.handleClick}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-            {...accessibility.attributes.anchor}
-            {...accessibility.keyHandlers.anchor}
+          <Popup
+            align={vertical ? 'top' : 'start'}
+            position={vertical ? 'after' : 'below'}
+            content={{
+              content: <Menu items={menu.items} vertical type={type} />,
+              styles: {
+                padding: '0px',
+                border: '',
+              },
+            }}
+            // content={<Menu items={menu.items} vertical/>}
           >
-            {icon &&
-              Icon.create(this.props.icon, {
-                defaultProps: { xSpacing: !!content ? 'after' : 'none' },
-                render: renderIcon,
-              })}
-            {content}
-          </a>
+            {this.renderMenuItem(accessibility, classes)}
+          </Popup>
         )}
       </ElementType>
     )
   }
-
+  private renderMenuItem = (accessibility, classes) => {
+    const { content, icon, renderIcon } = this.props
+    return (
+      <a
+        className={cx('ui-menu__item__anchor', classes.anchor)}
+        onClick={this.handleClick}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
+        {...accessibility.attributes.anchor}
+        {...accessibility.keyHandlers.anchor}
+      >
+        {icon &&
+          Icon.create(this.props.icon, {
+            defaultProps: { xSpacing: !!content ? 'after' : 'none' },
+            render: renderIcon,
+          })}
+        {content}
+      </a>
+    )
+  }
   protected actionHandlers: AccessibilityActionHandlers = {
     performClick: event => this.handleClick(event),
   }

--- a/src/themes/teams/components/Menu/menuVariables.ts
+++ b/src/themes/teams/components/Menu/menuVariables.ts
@@ -24,7 +24,7 @@ export interface IMenuVariables {
 export default (siteVars: any): IMenuVariables => {
   return {
     defaultColor: siteVars.gray02,
-    defaultBackgroundColor: 'transparent',
+    defaultBackgroundColor: '#FFF',
 
     defaultActiveColor: siteVars.black,
     defaultActiveBackgroundColor: siteVars.gray10,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# menuItem ```menu``` prop

Add a menu prop which has the capability to render submenus.
![screenshot 58](https://user-images.githubusercontent.com/11490517/46872445-bf2efa80-ce51-11e8-9717-b383a7795a36.png)

### TODO

- [ ] Conformance test
- [ ] Minimal doc site example
- [ ] Stardust base theme
- [ ] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [ ] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [ ] Update the CHANGELOG.md


