### PR TITLE
fix(avatar): fix for status sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
-- fix for status sizes in `Avatar` component @Bugaa92 ([#358](https://github.com/stardust-ui/react/pull/358))
+- Remove hardcoded `status` size calculations in `Avatar` component @Bugaa92 ([#358](https://github.com/stardust-ui/react/pull/358))
 
 <!--------------------------------[ v0.9.1 ]------------------------------- -->
 ## [v0.9.1](https://github.com/stardust-ui/react/tree/v0.9.1) (2018-10-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- fix for status sizes in `Avatar` component @Bugaa92 ([#358](https://github.com/stardust-ui/react/pull/358))
+
 <!--------------------------------[ v0.9.1 ]------------------------------- -->
 ## [v0.9.1](https://github.com/stardust-ui/react/tree/v0.9.1) (2018-10-11)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.9.0...v0.9.1)

--- a/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
+++ b/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
@@ -2,11 +2,13 @@ import _ from 'lodash'
 import React from 'react'
 import { Avatar } from '@stardust-ui/react'
 
-const status = { icon: 'check', color: 'green', title: 'Available' }
+const statusProps = { icon: 'check', color: 'green', title: 'Available' }
 
 const AvatarExampleSizeShorthand = () =>
   _.times(7, i => {
     const size = 20 + i * 4
+    const status = { ...statusProps, size: size * 0.3125 }
+
     return (
       <p key={size}>
         <strong>{size}</strong>

--- a/docs/src/examples/components/Avatar/Variations/AvatarExampleStatusCustomization.shorthand.tsx
+++ b/docs/src/examples/components/Avatar/Variations/AvatarExampleStatusCustomization.shorthand.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Avatar } from '@stardust-ui/react'
+import { Avatar, Grid, Status, Text } from '@stardust-ui/react'
 
-const AvatarExampleStatusCustomizationShorthand = () => (
+const defaultAvatar = (
   <Avatar
     image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
     status={{
@@ -9,8 +9,60 @@ const AvatarExampleStatusCustomizationShorthand = () => (
       icon: 'check',
       title: 'Available',
     }}
-    variables={{ statusBorderColor: '#d3d3d3' }}
   />
+)
+
+const AvatarExampleStatusCustomizationShorthand = () => (
+  <Grid
+    columns="43% 50px 50px"
+    styles={{ justifyContent: 'start', justifyItems: 'start', gap: '10px', alignItems: 'center' }}
+  >
+    <Text content="Status can receive variables" />
+    {defaultAvatar}
+    <Avatar
+      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      status={{
+        color: 'green',
+        icon: 'check',
+        title: 'Available',
+      }}
+      variables={{ statusBorderColor: 'black' }}
+    />
+    <Text content="Status can have different size for the same avatar size" />
+    {defaultAvatar}
+    <Avatar
+      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      status={{
+        color: 'green',
+        icon: 'check',
+        title: 'Available',
+        size: 16,
+      }}
+    />
+    <Text content="Status can have same size for different avatar sizes" />
+    {defaultAvatar}
+    <Avatar
+      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      size={48}
+      status={{
+        color: 'green',
+        icon: 'check',
+        title: 'Available',
+      }}
+    />
+    <Text content="Status and avatar sizes can be proportionate" />
+    {defaultAvatar}
+    <Avatar
+      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      size={Avatar.defaultProps.size * 1.5}
+      status={{
+        color: 'green',
+        icon: 'check',
+        title: 'Available',
+        size: Status.defaultProps.size * 1.5,
+      }}
+    />
+  </Grid>
 )
 
 export default AvatarExampleStatusCustomizationShorthand

--- a/docs/src/examples/components/Avatar/Variations/AvatarExampleStatusCustomization.shorthand.tsx
+++ b/docs/src/examples/components/Avatar/Variations/AvatarExampleStatusCustomization.shorthand.tsx
@@ -14,7 +14,7 @@ const defaultAvatar = (
 
 const AvatarExampleStatusCustomizationShorthand = () => (
   <Grid
-    columns="43% 50px 50px"
+    columns="50% 50px 50px"
     styles={{ justifyContent: 'start', justifyItems: 'start', gap: '10px', alignItems: 'center' }}
   >
     <Text content="Status can receive variables" />

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -118,17 +118,8 @@ class Avatar extends UIComponent<Extendable<IAvatarProps>, any> {
   }
 
   renderComponent({ ElementType, classes, rest, styles, variables }) {
-    const {
-      name,
-      status,
-      image,
-      label,
-      getInitials,
-      renderImage,
-      renderLabel,
-      renderStatus,
-      size,
-    } = this.props as IAvatarPropsWithDefaults
+    const { name, status, image, label, getInitials, renderImage, renderLabel, renderStatus } = this
+      .props as IAvatarPropsWithDefaults
 
     return (
       <ElementType {...rest} className={classes.root}>
@@ -156,7 +147,6 @@ class Avatar extends UIComponent<Extendable<IAvatarProps>, any> {
         {Status.create(status, {
           defaultProps: {
             styles: styles.status,
-            size: size * 0.3125,
             variables: {
               borderColor: variables.statusBorderColor,
               borderWidth: variables.statusBorderWidth,

--- a/src/themes/teams/components/Avatar/avatarStyles.ts
+++ b/src/themes/teams/components/Avatar/avatarStyles.ts
@@ -3,27 +3,33 @@ import { IComponentPartStylesInput, ICSSInJSStyle } from '../../../../../types/t
 import { IAvatarPropsWithDefaults } from '../../../../components/Avatar/Avatar'
 
 const avatarStyles: IComponentPartStylesInput<IAvatarPropsWithDefaults, any> = {
-  root: ({ props: { size } }): ICSSInJSStyle => ({
-    position: 'relative',
-    backgroundColor: 'inherit',
-    display: 'inline-block',
-    verticalAlign: 'middle',
-    height: pxToRem(size),
-    width: pxToRem(size),
-  }),
+  root: ({ props: { size } }): ICSSInJSStyle => {
+    const remSize = pxToRem(size)
+    return {
+      position: 'relative',
+      backgroundColor: 'inherit',
+      display: 'inline-block',
+      verticalAlign: 'middle',
+      height: remSize,
+      width: remSize,
+    }
+  },
   image: (): ICSSInJSStyle => ({
     verticalAlign: 'top',
   }),
-  label: ({ props: { size } }): ICSSInJSStyle => ({
-    display: 'inline-block',
-    width: pxToRem(size),
-    height: pxToRem(size),
-    lineHeight: pxToRem(size),
-    fontSize: pxToRem(size / 2.333),
-    verticalAlign: 'top',
-    textAlign: 'center',
-    padding: '0px',
-  }),
+  label: ({ props: { size } }): ICSSInJSStyle => {
+    const remSize = pxToRem(size)
+    return {
+      display: 'inline-block',
+      width: remSize,
+      height: remSize,
+      lineHeight: remSize,
+      fontSize: pxToRem(size / 2.333),
+      verticalAlign: 'top',
+      textAlign: 'center',
+      padding: '0px',
+    }
+  },
   status: ({ props, variables }): ICSSInJSStyle => ({
     position: 'absolute',
     bottom: `-${variables.statusBorderWidth}px`,

--- a/src/themes/teams/components/Avatar/avatarStyles.ts
+++ b/src/themes/teams/components/Avatar/avatarStyles.ts
@@ -4,26 +4,26 @@ import { IAvatarPropsWithDefaults } from '../../../../components/Avatar/Avatar'
 
 const avatarStyles: IComponentPartStylesInput<IAvatarPropsWithDefaults, any> = {
   root: ({ props: { size } }): ICSSInJSStyle => {
-    const remSize = pxToRem(size)
+    const sizeInRem = pxToRem(size)
     return {
       position: 'relative',
       backgroundColor: 'inherit',
       display: 'inline-block',
       verticalAlign: 'middle',
-      height: remSize,
-      width: remSize,
+      height: sizeInRem,
+      width: sizeInRem,
     }
   },
   image: (): ICSSInJSStyle => ({
     verticalAlign: 'top',
   }),
   label: ({ props: { size } }): ICSSInJSStyle => {
-    const remSize = pxToRem(size)
+    const sizeInRem = pxToRem(size)
     return {
       display: 'inline-block',
-      width: remSize,
-      height: remSize,
-      lineHeight: remSize,
+      width: sizeInRem,
+      height: sizeInRem,
+      lineHeight: sizeInRem,
       fontSize: pxToRem(size / 2.333),
       verticalAlign: 'top',
       textAlign: 'center',

--- a/src/themes/teams/components/Status/statusStyles.ts
+++ b/src/themes/teams/components/Status/statusStyles.ts
@@ -37,13 +37,13 @@ const getTextColor = (state: string, variables: IStatusVariables) => {
 
 const statusStyles: IComponentPartStylesInput<IStatusPropsWithDefaults, IStatusVariables> = {
   root: ({ props: { color, size, state }, variables }): ICSSInJSStyle => {
-    const remSize = pxToRem(size + 2 * (variables.borderWidth || 0))
+    const sizeInRem = pxToRem(size + 2 * ((variables.borderColor && variables.borderWidth) || 0))
     return {
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
-      height: remSize,
-      width: remSize,
+      height: sizeInRem,
+      width: sizeInRem,
       verticalAlign: 'middle',
       borderRadius: '9999px',
       ...(variables.borderColor && {

--- a/src/themes/teams/components/Status/statusStyles.ts
+++ b/src/themes/teams/components/Status/statusStyles.ts
@@ -35,22 +35,25 @@ const getTextColor = (state: string, variables: IStatusVariables) => {
   }
 }
 
-const statusStyles: IComponentPartStylesInput<IStatusPropsWithDefaults, any> = {
-  root: ({ props: { color, size, state }, variables }): ICSSInJSStyle => ({
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: pxToRem(size + 2 * ((variables.borderColor && variables.borderWidth) || 0)),
-    width: pxToRem(size + 2 * ((variables.borderColor && variables.borderWidth) || 0)),
-    verticalAlign: 'middle',
-    borderRadius: '9999px',
-    ...(variables.borderColor && {
-      borderColor: variables.borderColor,
-      borderWidth: pxToRem(variables.borderWidth),
-      borderStyle: 'solid',
-    }),
-    backgroundColor: color || getBackgroundColor(state, variables),
-  }),
+const statusStyles: IComponentPartStylesInput<IStatusPropsWithDefaults, IStatusVariables> = {
+  root: ({ props: { color, size, state }, variables }): ICSSInJSStyle => {
+    const remSize = pxToRem(size + 2 * (variables.borderWidth || 0))
+    return {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: remSize,
+      width: remSize,
+      verticalAlign: 'middle',
+      borderRadius: '9999px',
+      ...(variables.borderColor && {
+        borderColor: variables.borderColor,
+        borderWidth: pxToRem(variables.borderWidth),
+        borderStyle: 'solid',
+      }),
+      backgroundColor: color || getBackgroundColor(state, variables),
+    }
+  },
 
   icon: ({ props: { state }, variables }): ICSSInJSStyle => ({
     color: getTextColor(state, variables),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Avatar

This PR removes the hardcoded calculation for status size in the implementation of `Avatar` with `Status`.

### TODO

- [x] Minimal doc site example
- [x] Update the CHANGELOG.md

# API proposal

### default `Avatar` with `Status`:

```jsx
<Avatar name='John Doe' status={{ color: 'green', icon: 'check' }} />
```
renders:
![screen shot 2018-10-12 at 15 50 53](https://user-images.githubusercontent.com/5442794/46873369-a1a06780-ce36-11e8-9386-98c873042509.png)

### custom `Status` size:
```jsx
<Avatar name='John Doe' status={{ color: 'green', icon: 'check', size: 16 }} />
```
renders:
![screen shot 2018-10-12 at 15 47 35](https://user-images.githubusercontent.com/5442794/46873379-a6651b80-ce36-11e8-9745-ac69f7d74b19.png)

### custom `Avatar` size:

```jsx
<Avatar name='John Doe' size={48} status={{ color: 'green', icon: 'check' }} />
```
renders:
![screen shot 2018-10-12 at 15 47 40](https://user-images.githubusercontent.com/5442794/46873384-ab29cf80-ce36-11e8-86f5-e08c8bb5e979.png)

### proportionate `Avatar` and `Status` sizes:

```jsx
<Avatar
  name='John Doe'
  size={Avatar.defaultProps.size * 1.5}
  status={{ color: 'green', icon: 'check', size: Status.defaultProps.size * 1.5 }}
/>
```
renders:
![screen shot 2018-10-12 at 15 47 46](https://user-images.githubusercontent.com/5442794/46873391-b11fb080-ce36-11e8-8903-a7129af52a30.png)
