### PR TITLE
test: remove console spy in tests

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,21 +11,4 @@ enzyme.configure({
   disableLifecycleMethods: true,
 })
 
-// ----------------------------------------
-// Console
-// ----------------------------------------
-// Fail on all activity.
-// It is important we overload console here, before consoleUtil.ts is loaded and caches it.
-jest.spyOn(console, 'log')
-jest.spyOn(console, 'info')
-jest.spyOn(console, 'warn')
-jest.spyOn(console, 'error')
-
 initKeyboardFocusMock()
-
-afterAll(() => {
-  expect(console.log).not.toHaveBeenCalled()
-  expect(console.info).not.toHaveBeenCalled()
-  expect(console.warn).not.toHaveBeenCalled()
-  expect(console.error).not.toHaveBeenCalled()
-})


### PR DESCRIPTION
This check was intended to prevent improper usage of components in tests.  React propTypes throws warnings when props are used incorrectly at runtime.  We wanted to catch those and prevent our tests from improper usage.

The outcome is that actual console errors are improperly reported by jest since they are caught `afterAll`.  For now, we'd rather see the actual console messages.  We can consider better ways to catch propType issues later.