### PR TITLE
fix(menu): fix for cropped rounded corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix for cropped rounded corners in `Menu` component @Bugaa92 ([#360](https://github.com/stardust-ui/react/pull/360))
+
 <!--------------------------------[ v0.9.1 ]------------------------------- -->
 ## [v0.9.1](https://github.com/stardust-ui/react/tree/v0.9.1) (2018-10-11)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.9.0...v0.9.1)

--- a/src/themes/teams/components/Menu/menuStyles.ts
+++ b/src/themes/teams/components/Menu/menuStyles.ts
@@ -28,6 +28,7 @@ export default {
             ...solidBorder(variables.typePrimaryBorderColor),
           }),
           borderRadius: pxToRem(4),
+          overflow: 'hidden',
         }),
       ...(underlined && {
         borderBottom: `2px solid ${variables.typePrimaryUnderlinedBorderColor}`,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Menu

This PR fixes the cropped rounded corners for `Menu` component.

### BEFORE:
![screen shot 2018-10-12 at 20 19 45](https://user-images.githubusercontent.com/5442794/46886828-3ec1c700-ce5c-11e8-908f-835b15d9cdf3.png)

### AFTER:
![screen shot 2018-10-12 at 20 20 07](https://user-images.githubusercontent.com/5442794/46886830-41bcb780-ce5c-11e8-95ae-af417e6444aa.png)
