### PR TITLE
feat(segment): add inverted prop and improved styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set the ref of the `FocusZone` in `Embed` mode @sophieH29 ([#435](https://github.com/stardust-ui/react/pull/435))
 - Close `Popup` on outside click @kuzhelov ([#410](https://github.com/stardust-ui/react/pull/410))
 - Set default `chatBehavior` which uses Enter/Esc keys @sophieH29 ([#443](https://github.com/stardust-ui/react/pull/443))
-- Add `iconPosition` property to `Input` component @mnajdova ([#442](https://github.com/stardust-ui/react/pull/442)) 
+- Add `iconPosition` property to `Input` component @mnajdova ([#442](https://github.com/stardust-ui/react/pull/442))
+- Add `color`, `inverted` and `renderContent` props and `content` slot to `Segment` component @Bugaa92 ([#389](https://github.com/stardust-ui/react/pull/389))
 
 ### Documentation
 - Add all missing component descriptions and improve those existing @levithomason ([#400](https://github.com/stardust-ui/react/pull/400))

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+import { Segment, Text } from '@stardust-ui/react'
+
+const SegmentExampleInvertedShorthand = () => (
+  <div>
+    <Segment content="Colored segment." color="purple" />
+    <br />
+    <Segment
+      inverted
+      content={<Text content="Colored inverted segment." styles={{ color: 'white' }} />}
+      color="purple"
+    />
+  </div>
+)
+
+export default SegmentExampleInvertedShorthand

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react'
-import { Segment, Text } from '@stardust-ui/react'
+import { Segment } from '@stardust-ui/react'
 
 const SegmentExampleInvertedShorthand = () => (
   <div>
     <Segment content="Colored segment." color="purple" />
     <br />
-    <Segment
-      inverted
-      content={<Text content="Colored inverted segment." styles={{ color: 'white' }} />}
-      color="purple"
-    />
+    <Segment inverted content="Colored inverted segment" color="purple" />
   </div>
 )
 

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+import { Segment, Text } from '@stardust-ui/react'
+
+const SegmentExampleInvertedShorthand = () => (
+  <div>
+    <Segment color="purple">Colored segment.</Segment>
+    <br />
+    <Segment inverted color="purple">
+      <Text styles={{ color: 'white' }}>Colored inverted segment.</Text>
+    </Segment>
+  </div>
+)
+
+export default SegmentExampleInvertedShorthand

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
-import { Segment, Text } from '@stardust-ui/react'
+import { Segment } from '@stardust-ui/react'
 
 const SegmentExampleInvertedShorthand = () => (
   <div>
     <Segment color="purple">Colored segment.</Segment>
     <br />
     <Segment inverted color="purple">
-      <Text styles={{ color: 'white' }}>Colored inverted segment.</Text>
+      Colored inverted segment
     </Segment>
   </div>
 )

--- a/docs/src/examples/components/Segment/Variations/index.tsx
+++ b/docs/src/examples/components/Segment/Variations/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import ComponentExample from 'docs/src/components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
+
+const Variations = () => (
+  <ExampleSection title="Variations">
+    <ComponentExample
+      title="Inverted"
+      description="A segment can have its colors inverted for contrast."
+      examplePath="components/Segment/Variations/SegmentExampleInverted"
+    />
+  </ExampleSection>
+)
+
+export default Variations

--- a/docs/src/examples/components/Segment/index.tsx
+++ b/docs/src/examples/components/Segment/index.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import Types from './Types'
+import Variations from './Variations'
 
 const SegmentExamples = () => (
   <div>
     <Types />
+    <Variations />
   </div>
 )
 

--- a/src/components/Segment/Segment.tsx
+++ b/src/components/Segment/Segment.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import { customPropTypes, UIComponent, childrenExist } from '../../lib'
-import { Extendable } from '../../../types/utils'
+import { Extendable, ShorthandValue, ShorthandRenderFunction } from '../../../types/utils'
 import { ComponentVariablesInput, ComponentSlotStyle } from '../../themes/types'
+import Slot from '../Slot/Slot'
 
 export interface SegmentProps {
   as?: any
   className?: string
-  content?: any
+  color?: string
+  content?: ShorthandValue
+  inverted?: boolean
+  renderContent?: ShorthandRenderFunction
   styles?: ComponentSlotStyle<SegmentProps, any>
   variables?: ComponentVariablesInput
 }
@@ -27,8 +31,22 @@ class Segment extends UIComponent<Extendable<SegmentProps>, any> {
     /** Additional CSS class name(s) to apply.  */
     className: PropTypes.string,
 
+    /** A segment can have different colors */
+    color: PropTypes.string,
+
     /** Shorthand for primary content. */
-    content: PropTypes.any,
+    content: PropTypes.contentShorthand,
+
+    /** A segment can have its colors inverted for contrast. */
+    inverted: PropTypes.bool,
+
+    /**
+     * A custom render function the content slot.
+     * @param {React.ReactType} Component - The computed component for this slot.
+     * @param {object} props - The computed props for this slot.
+     * @param {ReactNode|ReactNodeArray} children - The computed children for this slot.
+     */
+    renderContent: PropTypes.func,
 
     /** Additional CSS styles to apply to the component instance.  */
     styles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
@@ -42,11 +60,11 @@ class Segment extends UIComponent<Extendable<SegmentProps>, any> {
   }
 
   renderComponent({ ElementType, classes, rest }) {
-    const { children, content } = this.props
+    const { children, content, renderContent } = this.props
 
     return (
       <ElementType {...rest} className={classes.root}>
-        {childrenExist(children) ? children : content}
+        {childrenExist(children) ? children : Slot.create(content, { render: renderContent })}
       </ElementType>
     )
   }

--- a/src/themes/teams/components/Segment/segmentStyles.ts
+++ b/src/themes/teams/components/Segment/segmentStyles.ts
@@ -1,14 +1,25 @@
-import { ICSSInJSStyle } from '../../../types'
+import { SegmentProps } from 'semantic-ui-react'
+import { ICSSInJSStyle, ComponentSlotStylesInput } from '../../../types'
 import { SegmentVariables } from './segmentVariables'
 
-export default {
-  root: ({ variables }: { variables: SegmentVariables }): ICSSInJSStyle => {
+const segmentStyles: ComponentSlotStylesInput<SegmentProps, SegmentVariables> = {
+  root: ({ props: p, variables: v }): ICSSInJSStyle => {
+    const color = p.color || v.color
     return {
-      padding: variables.padding,
-      background: variables.background,
-      border: '1px solid rgba(34,36,38,.15)',
-      borderRadius: variables.borderRadius,
-      boxShadow: '0 1px 2px 0 rgba(34,36,38,.15)',
+      padding: v.padding,
+      background: v.background,
+      borderRadius: v.borderRadius,
+      boxShadow: '0 1px 1px 1px rgba(34,36,38,.15)',
+      ...(color &&
+        (p.inverted
+          ? {
+              background: color,
+            }
+          : {
+              borderTop: `2px solid ${color}`,
+            })),
     }
   },
 }
+
+export default segmentStyles

--- a/src/themes/teams/components/Segment/segmentStyles.ts
+++ b/src/themes/teams/components/Segment/segmentStyles.ts
@@ -14,6 +14,7 @@ const segmentStyles: ComponentSlotStylesInput<SegmentProps, SegmentVariables> = 
         (p.inverted
           ? {
               background: color,
+              color: '#eee',
             }
           : {
               borderTop: `2px solid ${color}`,

--- a/src/themes/teams/components/Segment/segmentVariables.ts
+++ b/src/themes/teams/components/Segment/segmentVariables.ts
@@ -1,16 +1,17 @@
-import { pxToRem } from '../../../../lib'
 import { ComponentVariablesPrepared } from '@stardust-ui/react'
 
 export interface SegmentVariables {
   padding: string
   background: string
   borderRadius: string
+  color: string
 }
 
 const segmentVariables: ComponentVariablesPrepared = siteVariables => ({
   padding: '1em',
   background: siteVariables.bodyBackground,
-  borderRadius: pxToRem(5),
+  borderRadius: 0,
+  color: undefined,
 })
 
 export default segmentVariables


### PR DESCRIPTION
<!-----------------------------------------------------------------------------

  HEADS UP!

  1. If you're not adding a new component, you can remove this template.
 
  1. Text in [brackets] is for example only. Replace it with your information.

  2. This template includes only one prop as an example (circular). If your
     PR requires more, list them separately in similar fashion. 

------------------------------------------------------------------------------>
# Segment

This PR introduces following changes for `Segment` component:
- `inverted` prop;
- `color` variable;
- `content` slot and `renderContent` method;
- new styles. 

### TODO

- [ ] Conformance test
- [x] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [x] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] Update glossary props table
- [x] Update the CHANGELOG.md

# API Proposal

## Default

```jsx
<Segment
  content="The elevator to success is out of order. You’ll have to use the stairs."
/>
```
renders:

![screen shot 2018-10-23 at 11 38 14](https://user-images.githubusercontent.com/5442794/47351521-6c0e4080-d6b8-11e8-99a5-c3cfeb6d2c5c.png)


## `color` variable

A segment can different colors. Use `color` variable to see the effect.

```jsx
<Segment
  content="Colored segment."
  variables={siteVars => ({ color: siteVars.brand })}
/>
```
renders
![screen shot 2018-10-23 at 11 38 20](https://user-images.githubusercontent.com/5442794/47351888-3584f580-d6b9-11e8-942b-19092e913876.png)

## `inverted` with `color` variable

A segment can have its colors inverted for contrast. Use `color` variable to see the effect.

```jsx
<Segment
  inverted
  content={<Text content="Colored inverted segment." styles={{ color: 'white' }} />}
  variables={siteVars => ({ color: siteVars.brand })}
/>
```
renders
![screen shot 2018-10-23 at 11 38 25](https://user-images.githubusercontent.com/5442794/47351901-3ae24000-d6b9-11e8-8eb3-2a719b6d1042.png)
