### PR TITLE
fix(accessibility): remove 'aria-haspopup' from Popup behavior

### DIFF
--- a/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
@@ -6,14 +6,12 @@ import * as keyboardKey from 'keyboard-key'
  *  Adds role='button' to 'trigger' component's part, if it is not focusable element and no role attribute provided.
  *  Adds tabIndex='0' to 'trigger' component's part, if it is not tabbable element and no tabIndex attribute provided.
  *  Adds attribute 'aria-disabled=true' to 'trigger' component's part based on the property 'disabled'.
- *  Adds attribute 'aria-haspopup=true' to 'trigger' component's part.
  */
 const popupBehavior: Accessibility = (props: any) => ({
   attributes: {
     trigger: {
       role: getAriaAttributeFromProps('role', props, 'button'),
       tabIndex: getAriaAttributeFromProps('tabIndex', props, '0'),
-      'aria-haspopup': 'true',
       'aria-disabled': !!props['disabled'],
     },
   },


### PR DESCRIPTION
This PR removes ```aria-haspopup``` attribute from ```popupBehavior```.

Reasons for that:
- ```aria-haspopup``` set to ```true``` will be read by a screen reader as ```Menu button```, which is true only in case if the Menu component placed inside the Popup.
- Starting from ARIA 1.1, there are more options to be set as value for ```aria-haspopup`` attribute - menu, listbox, tree, grid, dialog. So users have to define the value themselves depending on their needs (or what is placed inside a popup).