### PR TITLE
fix(FocusZone): Remove redundant 'handledProps'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix build on Windows @jurokapsiar ([#383](https://github.com/stardust-ui/react/pull/383))
+- Remove redundant 'handledProps' in Focus Zone @sophieH29 ([#393](https://github.com/stardust-ui/react/pull/393))
 
 ### Features
 - Export `mergeThemes` @levithomason ([#285](https://github.com/stardust-ui/react/pull/285))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix build on Windows @jurokapsiar ([#383](https://github.com/stardust-ui/react/pull/383))
-- Remove redundant 'handledProps' in Focus Zone @sophieH29 ([#393](https://github.com/stardust-ui/react/pull/393))
 
 ### Features
 - Export `mergeThemes` @levithomason ([#285](https://github.com/stardust-ui/react/pull/285))

--- a/src/lib/accessibility/FocusZone/FocusZone.tsx
+++ b/src/lib/accessibility/FocusZone/FocusZone.tsx
@@ -46,6 +46,8 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
     componentRef: PropTypes.object,
     className: PropTypes.string,
     direction: PropTypes.number,
+    defaultTabbableElement: PropTypes.string,
+    shouldFocusOnMount: PropTypes.bool,
     disabled: PropTypes.bool,
     as: customPropTypes.as,
     isCircularNavigation: PropTypes.bool,
@@ -69,27 +71,6 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
 
   static displayName = 'FocusZone'
   static className = 'ms-FocusZone'
-
-  static handledProps = [
-    'componentRef',
-    'className',
-    'direction',
-    'defaultTabbableElement',
-    'shouldFocusOnMount',
-    'disabled',
-    'as',
-    'isCircularNavigation',
-    'shouldEnterInnerZone',
-    'onActiveElementChanged',
-    'shouldReceiveFocus',
-    'allowFocusRoot',
-    'handleTabKey',
-    'shouldInputLoseFocusOnArrowKey',
-    'stopFocusPropagation',
-    'onFocus',
-    'preventDefaultWhenHandled',
-    'isRtl',
-  ]
 
   private _root: { current: HTMLElement | null } = { current: null }
   private _id: string
@@ -167,8 +148,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
   render() {
     const { className } = this.props
     const ElementType = getElementType({ defaultProps: FocusZone.defaultProps }, this.props)
-
-    const rest = getUnhandledProps({ handledProps: FocusZone.handledProps }, this.props)
+    const rest = getUnhandledProps({ handledProps: [..._.keys(FocusZone.propTypes)] }, this.props)
 
     return (
       <ElementType


### PR DESCRIPTION
This PR removes redundant ```handledProps``` which were removed across Stardust some time ago. Let's keep a consistency of the whole lib!