### PR TITLE
fix(FocusZone) Remove unused prop 'componentRef'

### DIFF
--- a/src/lib/accessibility/FocusZone/CHANGELOG.md
+++ b/src/lib/accessibility/FocusZone/CHANGELOG.md
@@ -3,7 +3,7 @@
 This is a list of changes made to this Stardust copy of FocusZone in comparison with the original [Fabric FocusZone @ 0f567e05952c6b50c691df2fb72d100b5e525d9e](https://github.com/OfficeDev/office-ui-fabric-react/blob/0f567e05952c6b50c691df2fb72d100b5e525d9e/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx).
 
 ### fixes
-- With defaultTabbableElement prop set tabindexes are not updated accordingly ([#342](https://github.com/stardust-ui/react/pull/342))
+- With `defaultTabbableElement` prop set tab indexes are not updated accordingly ([#342](https://github.com/stardust-ui/react/pull/342))
 - Remove unused prop `componentRef` ([#397](https://github.com/stardust-ui/react/pull/397))
 
 ### feat(FocusZone): Add embed mode for FocusZone and new Chat behavior [#233](https://github.com/stardust-ui/react/pull/233)

--- a/src/lib/accessibility/FocusZone/CHANGELOG.md
+++ b/src/lib/accessibility/FocusZone/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 This is a list of changes made to this Stardust copy of FocusZone in comparison with the original [Fabric FocusZone @ 0f567e05952c6b50c691df2fb72d100b5e525d9e](https://github.com/OfficeDev/office-ui-fabric-react/blob/0f567e05952c6b50c691df2fb72d100b5e525d9e/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx).
 
-### fix(FocusZone)with defaultTabbableElement prop set tabindexes are not updated accordingly [#342](https://github.com/stardust-ui/react/pull/342)
+### fixes
+- With defaultTabbableElement prop set tabindexes are not updated accordingly ([#342](https://github.com/stardust-ui/react/pull/342))
+- Remove unused prop `componentRef` ([#397](https://github.com/stardust-ui/react/pull/397))
 
 ### feat(FocusZone): Add embed mode for FocusZone and new Chat behavior [#233](https://github.com/stardust-ui/react/pull/233)
 - Replaced `onFocusNotification` with a regular `onFocus` event callback to pass unit tests with embed.

--- a/src/lib/accessibility/FocusZone/FocusZone.tsx
+++ b/src/lib/accessibility/FocusZone/FocusZone.tsx
@@ -43,7 +43,6 @@ function getParent(child: HTMLElement): HTMLElement | null {
 
 export class FocusZone extends React.Component<FocusZoneProps> implements IFocusZone {
   static propTypes = {
-    componentRef: PropTypes.object,
     className: PropTypes.string,
     direction: PropTypes.number,
     defaultTabbableElement: PropTypes.string,

--- a/src/lib/accessibility/FocusZone/FocusZone.types.ts
+++ b/src/lib/accessibility/FocusZone/FocusZone.types.ts
@@ -33,12 +33,6 @@ export interface IFocusZone {
  */
 export interface FocusZoneProps extends React.HTMLAttributes<HTMLElement | FocusZone> {
   /**
-   * Optional callback to access the FocusZone interface. Use this instead of ref for accessing
-   * the public methods and properties of the component.
-   */
-  componentRef?: React.RefObject<FocusZone>
-
-  /**
    * Additional class name to provide on the root element, in addition to the ms-FocusZone class.
    */
   className?: string


### PR DESCRIPTION
Removed leftover from FocusZone - ```componentRef```, which is not used as we're setting ```focusZoneRef``` in parent ```UIComponent``` during components rendering.