### PR TITLE
fix(Attachment): do not render progress value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix build on Windows @jurokapsiar ([#383](https://github.com/stardust-ui/react/pull/383))
 - Add warning for rendering components outside provider @Bugaa92 ([#378](https://github.com/stardust-ui/react/pull/378))
 - Fix icon colors for Teams theme @codepretty ([#384](https://github.com/stardust-ui/react/pull/384))
+- Do not render the Attachment's `progress` value to the DOM @levithomason ([#402](https://github.com/stardust-ui/react/pull/402))
 
 ### Features
 - Export `mergeThemes` @levithomason ([#285](https://github.com/stardust-ui/react/pull/285))

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -162,7 +162,7 @@ class Attachment extends UIComponent<Extendable<AttachmentProps>, any> {
           </div>
         )}
         {!_.isNil(progress) &&
-          createHTMLDivision(progress, {
+          createHTMLDivision('', {
             defaultProps: { className: classes.progress },
             render: renderProgress,
           })}


### PR DESCRIPTION
Fixes #385 

This PR prevents the Attachment's `progress` value from the rendered to the DOM.  It is only used for styling purposes.

### Before

![image](https://user-images.githubusercontent.com/5067638/47469961-77489580-d7b8-11e8-8aed-90e90735b9aa.png)

### After

![image](https://user-images.githubusercontent.com/5067638/47469965-80396700-d7b8-11e8-99f8-44784ef08e55.png)
