### PR TITLE
feat(list): expose List's element by listRef

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -26,6 +26,7 @@ export interface ListProps extends FocusContainerProps<ShorthandValue> {
   children?: ReactChildren
   className?: string
   debug?: boolean
+  listRef?: (node: HTMLElement) => void
   selection?: boolean
   truncateContent?: boolean
   truncateHeader?: boolean
@@ -68,6 +69,9 @@ class List extends UIComponent<Extendable<ListProps>, FocusContainerState> {
 
     /** Accessibility behavior if overridden by the user. */
     accessibility: PropTypes.func,
+
+    /** Ref callback with the list DOM node. */
+    listRef: PropTypes.func,
 
     /**
      * A custom render iterator for rendering each of the List items.
@@ -114,10 +118,15 @@ class List extends UIComponent<Extendable<ListProps>, FocusContainerState> {
         {...accessibility.keyHandlers.root}
         {...rest}
         className={classes.root}
+        ref={this.handleListRef}
       >
         {childrenExist(children) ? children : this.renderItems()}
       </ElementType>
     )
+  }
+
+  private handleListRef = (listNode: HTMLElement) => {
+    _.invoke(this.props, 'listRef', listNode)
   }
 
   renderItems() {


### PR DESCRIPTION
Exposed the list html element through callback prop `listRef` . Need it for Dropdown component.
