### PR TITLE
docs: add search page prototype

### DIFF
--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -280,6 +280,14 @@ class Sidebar extends React.Component<any, any> {
                   >
                     Meeting Options
                   </Menu.Item>
+                  <Menu.Item
+                    as={NavLink}
+                    exact
+                    to="/prototype-search-page"
+                    activeClassName="active"
+                  >
+                    Search Page
+                  </Menu.Item>
                 </Menu.Menu>
               </Menu.Item>
             )}

--- a/docs/src/prototypes/SearchPage/SearchPage.tsx
+++ b/docs/src/prototypes/SearchPage/SearchPage.tsx
@@ -1,0 +1,108 @@
+import * as faker from 'faker'
+import * as _ from 'lodash'
+import * as React from 'react'
+import { Avatar, Header, Input, List, Segment } from '@stardust-ui/react'
+
+// ----------------------------------------
+// Types
+// ----------------------------------------
+interface DataRecord {
+  avatar: string
+  firstName: string
+  lastName: string
+  timestamp: string
+}
+
+interface SearchPageState {
+  loading: boolean
+  query: string
+  results: DataRecord[]
+}
+
+// ----------------------------------------
+// Mock Data
+// ----------------------------------------
+const DATA_RECORDS = _.times(100, () => ({
+  id: Math.random()
+    .toString(36)
+    .slice(2), // random string like "7llt1t638ni"
+  avatar: faker.internet.avatar(),
+  firstName: faker.name.firstName(),
+  lastName: faker.name.lastName(),
+  quote: faker.hacker.phrase(),
+  timestamp: faker.date.recent().toLocaleString(),
+}))
+
+// Converts a data record to a <ListItem />'s props object
+const dataRecordToListItem = record => ({
+  key: record.id,
+  media: <Avatar name={`${record.firstName} ${record.lastName}`} image={record.avatar} />,
+  header: `${record.firstName} ${record.lastName}`,
+  content: record.quote,
+  endMedia: record.timestamp,
+})
+
+// ----------------------------------------
+// Prototype Search Page View
+// ----------------------------------------
+class SearchPage extends React.Component<SearchPageState, any> {
+  state = { loading: false, query: '', results: [] }
+  searchTimer: any
+
+  handleSearchChange = e => {
+    const query = e.target.value
+    this.setState({ query })
+    if (query) this.filterResults(query)
+  }
+
+  filterResults = _.debounce(query => {
+    clearTimeout(this.searchTimer)
+
+    const regExp = new RegExp(_.escapeRegExp(query), 'gi')
+
+    this.setState({ loading: true })
+
+    // mock async search query, such as against an API
+    this.searchTimer = setTimeout(() => {
+      const results = DATA_RECORDS.filter(record => _.some(record, value => regExp.test(value)))
+
+      this.setState({ loading: false, results })
+    }, 500)
+  }, 500)
+
+  render() {
+    const { loading, results, query } = this.state
+
+    return (
+      <Segment>
+        <Header content="Search Page Prototype" />
+        <p>Use the input field to perform a simulated search.</p>
+
+        <p>
+          <Input
+            ref="input"
+            value={query}
+            placeholder={`Try "${_.sample(DATA_RECORDS).firstName}"`}
+            icon={loading ? 'spinner' : 'search'}
+            onChange={this.handleSearchChange}
+          />
+        </p>
+
+        {_.isEmpty(results) ? (
+          <p>No results.</p>
+        ) : (
+          <div>
+            <p>
+              <small>
+                Results <strong>{results.length}</strong> of <strong>{DATA_RECORDS.length}</strong>
+              </small>
+            </p>
+            <List selection items={results.map(dataRecordToListItem)} />
+          </div>
+        )}
+      </Segment>
+    )
+  }
+}
+
+export default SearchPage

--- a/docs/src/prototypes/SearchPage/index.ts
+++ b/docs/src/prototypes/SearchPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchPage'

--- a/docs/src/routes.tsx
+++ b/docs/src/routes.tsx
@@ -47,6 +47,12 @@ const Router = () => (
             path="/prototype-meeting-options"
             component={require('./prototypes/meetingOptions/index').default}
           />,
+          <DocsLayout
+            exact
+            key="/prototype-search-page"
+            path="/prototype-search-page"
+            component={require('./prototypes/SearchPage/index').default}
+          />,
         ]}
         <DocsLayout exact path="/glossary" component={Glossary} />
         <DocsLayout exact path="/accessibility" component={Accessibility} />


### PR DESCRIPTION
This PR adds a search page prototype.  It shows the basic usage of a controlled input, a mock data request, and a list of items for the results.