### PR TITLE
fix(Button): make `primary` & `secondary` props mutually exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix endMedia to not be removed from DOM on mouseleave for `ListItem` @musingh1 ([#278](https://github.com/stardust-ui/react/pull/278))
-- Make `secondary` and `primary` props mutually exclusive for `Button` @layershifter ([#429](https://github.com/stardust-ui/react/pull/429))
 
 ### Features
 - Make `Grid` keyboard navigable by implementing `gridBehavior` @sophieH29 ([#398](https://github.com/stardust-ui/react/pull/398))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix endMedia to not be removed from DOM on mouseleave for `ListItem` @musingh1 ([#278](https://github.com/stardust-ui/react/pull/278))
+- Make `secondary` and `primary` props mutually exclusive for `Button` @layershifter ([#429](https://github.com/stardust-ui/react/pull/429))
 
 ### Features
 - Make `Grid` keyboard navigable by implementing `gridBehavior` @sophieH29 ([#398](https://github.com/stardust-ui/react/pull/398))

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -107,13 +107,13 @@ class Button extends UIComponent<Extendable<ButtonProps>, ButtonState> {
     onFocus: PropTypes.func,
 
     /** A button can be formatted to show different levels of emphasis. */
-    primary: PropTypes.bool,
+    primary: customPropTypes.every([customPropTypes.disallow(['secondary']), PropTypes.bool]),
 
     /** A button can be formatted to show only text in order to indicate some less-pronounced actions. */
     text: PropTypes.bool,
 
     /** A button can be formatted to show different levels of emphasis. */
-    secondary: PropTypes.bool,
+    secondary: customPropTypes.every([customPropTypes.disallow(['primary']), PropTypes.bool]),
 
     /** Accessibility behavior if overridden by the user. */
     accessibility: PropTypes.func,


### PR DESCRIPTION
Refs #419.

This PR makes `primary` & `secondary` props mutually exclusive like in #429.