### PR TITLE
docs(Glossary): remove the `type` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Documentation
 - Add all missing component descriptions and improve those existing @levithomason ([#400](https://github.com/stardust-ui/react/pull/400))
+- Replace the `type` prop with `secondary` and `primary` in Glossary @layershifter ([#432](https://github.com/stardust-ui/react/pull/432))
 
 <!--------------------------------[ v0.11.0 ]------------------------------- -->
 ## [v0.11.0](https://github.com/stardust-ui/react/tree/v0.11.0) (2018-10-30)

--- a/docs/src/views/Glossary.tsx
+++ b/docs/src/views/Glossary.tsx
@@ -99,14 +99,6 @@ export default () => (
         <span>
           <strong>Description</strong>
         </span>,
-        <span>type: primary</span>,
-        <span>Used to emphasize a componet's appearance and catch user's attention.</span>,
-        <span>type: secondary</span>,
-        <span>Used to de-emphasize a component's appearance.</span>,
-        <span>type: positive ?</span>,
-        <span>Used to hint towards a positive consequence.</span>,
-        <span>type: negative ?</span>,
-        <span>Used to hint towards a negative consequence.</span>,
         <span>children</span>,
         <span>The primary content of the component.</span>,
         <span>content</span>,
@@ -170,6 +162,10 @@ export default () => (
           Used to describe the shape of the component. For example for the Menu component, beside
           the default, we have the following shapes: ('pills', 'pointing', 'underlined')
         </span>,
+        <span>primary</span>,
+        <span>Used to emphasize a component's appearance and catch user's attention.</span>,
+        <span>secondary</span>,
+        <span>Used to de-emphasize a component's appearance.</span>,
       ]}
     </Grid>
     <Header as="h2" content="Accessibility Terms" />


### PR DESCRIPTION
Refs #374 and #421.

The `type` is reserved HTML attribute, we should update our docs because we have already made changes in our components.

I also removed `positive` and `negative` because these values aren't used anywhere in project.