### PR TITLE
chore: add yarn engines entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,9 @@
     "react": ">=0.14.0 <= 16",
     "react-dom": ">=0.14.0 <= 16"
   },
+  "engines": {
+    "yarn": "^1.10.0"
+  },
   "resolutions": {
     "create-react-context": "0.2.2"
   }


### PR DESCRIPTION
# package.json engines entry for yarn (chore)

## Motivation
[**yarn `1.10.0`**](https://github.com/yarnpkg/yarn/releases/tag/v1.10.0) introduces an [**integrity field with sha512 authentication to yarn.lock**](https://github.com/yarnpkg/yarn/pull/5042) to preserve the integrity of every installed package before its code is executed.

A machine with a version of `yarn` lower than `1.10.0` would automatically remove the
```
integrity sha512-XXX==
```
entries from `yarn.lock` causing unwanted changes.

## Resolution
This PR that forces devs to upgrade to `yarn 1.10.0` or above by adding the `engines` entry to `package.json`.

_**Note**: On Mac, the most reliable way to upgrade `yarn` to latest stable version is:_
```
curl -o- -L https://yarnpkg.com/install.sh | bash
```