### PR TITLE
chore(package): remove docgen from `pretest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prestart": "yarn satisfied --fix yarn",
     "start": "gulp --series dll docs",
     "satisfied": "satisfied --skip-invalid --ignore \"^typescript$\"",
-    "pretest": "yarn satisfied && gulp --series build:docs:docgen build:docs:component-menu-behaviors",
+    "pretest": "yarn satisfied",
     "test": "gulp test",
     "test:visual": "gulp screener",
     "test:projects:cra-ts": "gulp test:projects:cra-ts",


### PR DESCRIPTION
A super small change that will save us 30 seconds in CI and locally.

Before this change we can the `docgen` task in `pretest` and `gulp test` that doesn't make any sense:

```
[02:59:01] Requiring external module ts-node/register
[02:59:06] Using gulpfile ~/project/gulpfile.ts
[02:59:06] Starting 'build:docs:docgen'...
[02:59:43] Finished 'build:docs:docgen' after 37 s
[02:59:43] Starting 'build:docs:component-menu-behaviors'...
[02:59:43] Finished 'build:docs:component-menu-behaviors' after 44 ms
$ gulp test --maxWorkers=4
[02:59:44] Requiring external module ts-node/register
[02:59:44] Using gulpfile ~/project/gulpfile.ts
[02:59:44] Starting 'test'...
[02:59:44] Starting 'test:jest:setup'...
[02:59:44] Starting 'test:jest:pre'...
$ satisfied --skip-invalid
[02:59:45] Finished 'test:jest:pre' after 689 ms
[02:59:45] Starting 'build:docs:docgen'...
[02:59:45] Starting 'build:docs:component-menu-behaviors'...
[03:00:06] Finished 'build:docs:component-menu-behaviors' after 22 s
[03:00:16] Finished 'build:docs:docgen' after 31 s // AGAIN!
[03:00:16] Finished 'test:jest:setup' after 32 s
```