### PR TITLE
fix(handleRef): handle `null` ref correctly

### DIFF
--- a/src/lib/handleRef.ts
+++ b/src/lib/handleRef.ts
@@ -20,7 +20,7 @@ const handleRef = <N>(ref: React.Ref<N>, node: N) => {
     return
   }
 
-  if (typeof ref === 'object') {
+  if (ref !== null && typeof ref === 'object') {
     // @ts-ignore The `current` property is defined as readonly, however it's a valid way because
     // `ref` is a mutable object
     ref.current = node

--- a/test/specs/lib/handleRef-test.ts
+++ b/test/specs/lib/handleRef-test.ts
@@ -18,6 +18,14 @@ describe('handleRef', () => {
     expect(ref).toBeCalledWith(node)
   })
 
+  it('does not do anything when "ref" is null', () => {
+    const node = document.createElement('div')
+
+    expect(() => {
+      handleRef(null, node)
+    }).not.toThrowError()
+  })
+
   it('assigns to "current" when "ref" is object', () => {
     const ref = React.createRef<HTMLDivElement>()
     const node = document.createElement('div')


### PR DESCRIPTION
A small fix for the `handleRef` ref utility.

```js
typeof null // "object"
```

There is a similar condition in React's code: https://github.com/facebook/react/blob/e58ecda9a2381735f2c326ee99a1ffa6486321ab/packages/react-reconciler/src/ReactFiberCommitWork.js#L625