### PR TITLE
fix(List): remove listRef from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix Teams Icons styles to match spec @codepretty ([#441](https://github.com/stardust-ui/react/pull/441))
 - Fix styles as functions in shorthands are not applied @mnajdova ([#470](https://github.com/stardust-ui/react/pull/470))
 - Add `lodash` typings and fix compilation errors @Bugaa92 ([#438](https://github.com/stardust-ui/react/pull/438))
+- Remove unsafe `listRef` from `List` API @kuzhelov ([#489](https://github.com/stardust-ui/react/pull/489))
 
 ### Features
 - Make `Grid` keyboard navigable by implementing `gridBehavior` @sophieH29 ([#398](https://github.com/stardust-ui/react/pull/398))

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -26,9 +26,6 @@ export interface ListProps extends UIComponentProps<any, any>, ChildrenComponent
   /** Shorthand array of props for ListItem. */
   items?: ShorthandValue[]
 
-  /** Ref callback with the list DOM node. */
-  listRef?: (node: HTMLElement) => void
-
   /** A selection list formats list items as possible choices. */
   selection?: boolean
 
@@ -70,7 +67,6 @@ class List extends UIComponent<Extendable<ListProps>, ListState> {
     selection: PropTypes.bool,
     truncateContent: PropTypes.bool,
     truncateHeader: PropTypes.bool,
-    listRef: PropTypes.func,
     renderItem: PropTypes.func,
   }
 
@@ -90,10 +86,6 @@ class List extends UIComponent<Extendable<ListProps>, ListState> {
 
   private focusHandler: ContainerFocusHandler = null
   private itemRefs = []
-
-  private handleListRef = (listNode: HTMLElement) => {
-    _.invoke(this.props, 'listRef', listNode)
-  }
 
   actionHandlers: AccessibilityActionHandlers = {
     moveNext: e => {
@@ -123,7 +115,6 @@ class List extends UIComponent<Extendable<ListProps>, ListState> {
         {...accessibility.keyHandlers.root}
         {...rest}
         className={classes.root}
-        ref={this.handleListRef}
       >
         {childrenExist(children) ? children : this.renderItems()}
       </ElementType>


### PR DESCRIPTION
### TODO
- [x] update CHANGELOG

----------

`listRef` prop of `List` component has lead to the problem described in #453 (and is a blocker for this PR to be merged).

### Reasons to remove `listRef`

Proposed changes eliminate this prop from `List` API for the following reasons:
- `ref` cannot be applied in cases when `ElementType` is evaluated into `React.SFC` component (this is, actually, what tests were warn about)
- the assumption that _it will be always a DOM node provided as a value to listRef_ expressed in these lines is wrong, as React `ref` may reference component instance (and will reference DOM element only for string components like `ul`, which luckily was the common case for `List`):

```js
 /** Ref callback with the list DOM node. */	
listRef?: (node: HTMLElement) => void
```


### How to cover cases where `listRef` was supposed to be used?

Cases that this `listRef` prop was aimed to cover now can be safely and easily covered with `Ref` component being exported from Stardust:

```jsx
// client component code
render() {
  return (
    <Ref innerRef=(capturedListDomNode => this.listNode = capturedListDomNode)>
      <List ...>
    </Ref>
  )
}
```

No changes to the `List` API are necessary for that.