### PR TITLE
fix(docs): fix basename logic for accessibility behaviors root component

### DIFF
--- a/docs/src/components/DocsBehaviorRoot.tsx
+++ b/docs/src/components/DocsBehaviorRoot.tsx
@@ -18,7 +18,7 @@ class DocsBehaviorRoot extends React.Component<any, any> {
   }
 
   baseName(fileName: string) {
-    const divided = _.startCase(fileName.replace('ts', ''))
+    const divided = _.startCase(fileName.replace(/\.ts$/, ''))
     return _.upperFirst(_.lowerCase(divided))
   }
 


### PR DESCRIPTION
Provided fix makes the logic of stripping out `ts` extension to be more strict. 

Previously for files like `petsBehavior.ts` (yes, contrieved:) we would have 'Pe Behavior Ts' displayed on the docs page (instead of expected 'Pets Behavior').