### PR TITLE
fix(AutoControlledComponent): fix behaviour when undefined it passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix the behaviour of `AutoControlledComponent` when `undefined` is passed as a prop value @layershifter ([#499](https://github.com/stardust-ui/react/pull/499))
+
 <!--------------------------------[ v0.12.0 ]------------------------------- -->
 ## [v0.12.0](https://github.com/stardust-ui/react/tree/v0.12.0) (2018-11-19)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.11.0...v0.12.0)

--- a/src/lib/AutoControlledComponent.tsx
+++ b/src/lib/AutoControlledComponent.tsx
@@ -171,13 +171,10 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
 
     // Solve the next state for autoControlledProps
     const newState = autoControlledProps.reduce((acc, prop) => {
-      const isNextUndefined = _.isUndefined(nextProps[prop])
-      const propWasRemoved = !_.isUndefined(this.props[prop]) && isNextUndefined
+      const isNextDefined = !_.isUndefined(nextProps[prop])
 
       // if next is defined then use its value
-      if (!isNextUndefined) acc[prop] = nextProps[prop]
-      // reinitialize state for props just removed / set undefined
-      else if (propWasRemoved) acc[prop] = getAutoControlledStateValue(prop, nextProps)
+      if (isNextDefined) acc[prop] = nextProps[prop]
 
       return acc
     }, {})

--- a/test/specs/lib/AutoControlledComponent-test.tsx
+++ b/test/specs/lib/AutoControlledComponent-test.tsx
@@ -320,7 +320,7 @@ describe('extending AutoControlledComponent', () => {
       expect(wrapper.state()).not.toHaveProperty(randomDefaultProp, randomValue)
     })
 
-    test('does not return state to default props when setting props undefined', () => {
+    test('keeps current state value when setting props undefined', () => {
       consoleUtil.disableOnce()
 
       const autoControlledProps = ['foo']
@@ -333,25 +333,7 @@ describe('extending AutoControlledComponent', () => {
       expect(wrapper.state()).toHaveProperty('foo', 'initial')
 
       wrapper.setProps({ foo: undefined })
-
-      expect(wrapper.state()).toHaveProperty('foo', undefined)
-    })
-
-    test('sets state to undefined for props passed as undefined by the parent', () => {
-      consoleUtil.disableOnce()
-      const props = makeProps()
-      const autoControlledProps = _.keys(props)
-
-      const randomProp = _.sample(autoControlledProps)
-
-      TestClass = createTestClass({ autoControlledProps, state: {} })
-      const wrapper = shallow(<TestClass {...props} />)
-
-      expect(wrapper.state()).toHaveProperty(randomProp)
-
-      wrapper.setProps({ [randomProp]: undefined })
-
-      expect(wrapper.state()).toHaveProperty(randomProp, undefined)
+      expect(wrapper.state()).toHaveProperty('foo', 'initial')
     })
 
     test('does not set state for props passed as null by the parent', () => {


### PR DESCRIPTION
We discussed this changes during meetings on the previous week, we need to change the behaviour of `AutoControlledComponent` to match React's.

An example that shows issue: https://codesandbox.io/s/l20mjn74zz

---

After this PR we can safely migrate to `getDerivedStateFromProps()` 👍 