### PR TITLE
feat(utils): add wrapper for the createComponent function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Features
+- Add `renderComponent` function in the public API @mnajdova ([#503](https://github.com/stardust-ui/react/pull/503))
+
+
 <!--------------------------------[ v0.12.0 ]------------------------------- -->
 ## [v0.12.0](https://github.com/stardust-ui/react/tree/v0.12.0) (2018-11-19)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.11.0...v0.12.0)

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,3 +126,4 @@ export { default as dialogBehavior } from './lib/accessibility/Behaviors/Dialog/
 //
 export { default as mergeThemes } from './lib/mergeThemes'
 export { createComponent } from './lib'
+export { RenderStardustResultConfig, CreateStardustComponentConfig } from '../types/utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,4 +125,4 @@ export { default as dialogBehavior } from './lib/accessibility/Behaviors/Dialog/
 // Utilities
 //
 export { default as mergeThemes } from './lib/mergeThemes'
-export { createStardustComponent } from './lib'
+export { createComponent } from './lib'

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,3 +125,4 @@ export { default as dialogBehavior } from './lib/accessibility/Behaviors/Dialog/
 // Utilities
 //
 export { default as mergeThemes } from './lib/mergeThemes'
+export { createStardustComponent } from './lib'

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,4 +126,7 @@ export { default as dialogBehavior } from './lib/accessibility/Behaviors/Dialog/
 //
 export { default as mergeThemes } from './lib/mergeThemes'
 export { createComponent } from './lib'
-export { RenderStardustResultConfig, CreateStardustComponentConfig } from '../types/utils'
+export {
+  RenderStardustResultConfig,
+  CreateStardustComponentConfig,
+} from './lib/createStardustComponent'

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -30,17 +30,15 @@ const createComponent = <P extends {} = {}, S extends {} = {}>({
   displayName = 'StardustComponent',
   render,
 }: CreateStardustComponentConfig<P>): React.SFC<P> => {
-  const StardustComponent: React.SFC<P> = createComponentInternal({
+  return createComponentInternal({
     displayName,
     render(config, props) {
       // TODO add here everything that the client may expect
-      const restrictedConfig = _.pick(config, ['classes', 'variables', 'styles', 'rtl', 'theme'])
+      const filteredConfig = _.pick(config, ['classes', 'variables', 'styles', 'rtl', 'theme'])
 
-      return render(restrictedConfig, props)
+      return render(filteredConfig, props)
     },
   })
-  StardustComponent.displayName = displayName
-  return StardustComponent
 }
 
 export default createComponent

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -10,18 +10,18 @@ export interface RenderStardustResultConfig {
 
 export interface CreateStardustComponentConfig<P> {
   displayName?: string
-  render: (config: RenderStardustResultConfig, props: P) => React.ReactNode
+  render: (props: P & { stardust: RenderStardustResultConfig }) => React.ReactNode
 }
 
 const createComponent = <P extends {} = {}, S extends {} = {}>({
   displayName = 'StardustComponent',
   render,
 }: CreateStardustComponentConfig<P>): React.SFC<P> => {
-  return createComponentInternal({
+  return createComponentInternal<P, S>({
     displayName,
-    render(config, props) {
+    render: (config, props) => {
       const filteredConfig = pick(config, ['classes', 'rtl'])
-      return render(filteredConfig, props)
+      return render(Object.assign({ stardust: filteredConfig }, props))
     },
   })
 }

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -1,19 +1,11 @@
 import createComponentInternal from './createComponent'
 import * as React from 'react'
 import * as _ from 'lodash'
-import {
-  ComponentSlotClasses,
-  ThemePrepared,
-  ComponentSlotStylesPrepared,
-  ComponentVariablesObject,
-} from '../themes/types'
+import { ComponentSlotClasses } from '../themes/types'
 
 export interface RenderStardustResultConfig {
   classes: ComponentSlotClasses
-  variables: ComponentVariablesObject
-  styles: ComponentSlotStylesPrepared
   rtl: boolean
-  theme: ThemePrepared
 }
 
 export type RenderStardustComponentCallback<P> = (
@@ -34,7 +26,7 @@ const createComponent = <P extends {} = {}, S extends {} = {}>({
     displayName,
     render(config, props) {
       // TODO add here everything that the client may expect
-      const filteredConfig = _.pick(config, ['classes', 'variables', 'styles', 'rtl', 'theme'])
+      const filteredConfig = _.pick(config, ['classes', 'rtl'])
 
       return render(filteredConfig, props)
     },

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -1,7 +1,17 @@
 import createComponentInternal from './createComponent'
 import * as React from 'react'
-import * as _ from 'lodash'
-import { CreateStardustComponentConfig } from '../../types/utils'
+import { pick } from 'lodash'
+import { ComponentSlotClasses } from '@stardust-ui/react'
+
+export interface RenderStardustResultConfig {
+  classes: ComponentSlotClasses
+  rtl: boolean
+}
+
+export interface CreateStardustComponentConfig<P> {
+  displayName?: string
+  render: (config: RenderStardustResultConfig, props: P) => React.ReactNode
+}
 
 const createComponent = <P extends {} = {}, S extends {} = {}>({
   displayName = 'StardustComponent',
@@ -10,7 +20,7 @@ const createComponent = <P extends {} = {}, S extends {} = {}>({
   return createComponentInternal({
     displayName,
     render(config, props) {
-      const filteredConfig = _.pick(config, ['classes', 'rtl'])
+      const filteredConfig = pick(config, ['classes', 'rtl'])
       return render(filteredConfig, props)
     },
   })

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -1,22 +1,7 @@
 import createComponentInternal from './createComponent'
 import * as React from 'react'
 import * as _ from 'lodash'
-import { ComponentSlotClasses } from '../themes/types'
-
-export interface RenderStardustResultConfig {
-  classes: ComponentSlotClasses
-  rtl: boolean
-}
-
-export type RenderStardustComponentCallback<P> = (
-  config: RenderStardustResultConfig,
-  props: P,
-) => any
-
-export interface CreateStardustComponentConfig<P> {
-  displayName?: string
-  render: RenderStardustComponentCallback<P>
-}
+import { CreateStardustComponentConfig } from '../../types/utils'
 
 const createComponent = <P extends {} = {}, S extends {} = {}>({
   displayName = 'StardustComponent',
@@ -25,9 +10,7 @@ const createComponent = <P extends {} = {}, S extends {} = {}>({
   return createComponentInternal({
     displayName,
     render(config, props) {
-      // TODO add here everything that the client may expect
       const filteredConfig = _.pick(config, ['classes', 'rtl'])
-
       return render(filteredConfig, props)
     },
   })

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -1,4 +1,4 @@
-import createComponent from './createComponent'
+import createComponentInternal from './createComponent'
 import * as React from 'react'
 import * as _ from 'lodash'
 import {
@@ -26,11 +26,11 @@ export interface CreateStardustComponentConfig<P> {
   render: RenderStardustComponentCallback<P>
 }
 
-const createStardustComponent = <P extends {} = {}, S extends {} = {}>({
+const createComponent = <P extends {} = {}, S extends {} = {}>({
   displayName = 'StardustComponent',
   render,
 }: CreateStardustComponentConfig<P>): React.SFC<P> => {
-  const StardustComponent: React.SFC<P> = createComponent({
+  const StardustComponent: React.SFC<P> = createComponentInternal({
     displayName,
     render(config, props) {
       // TODO add here everything that the client may expect
@@ -43,4 +43,4 @@ const createStardustComponent = <P extends {} = {}, S extends {} = {}>({
   return StardustComponent
 }
 
-export default createStardustComponent
+export default createComponent

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -1,0 +1,46 @@
+import createComponent from './createComponent'
+import * as React from 'react'
+import * as _ from 'lodash'
+import {
+  ComponentSlotClasses,
+  ThemePrepared,
+  ComponentSlotStylesPrepared,
+  ComponentVariablesObject,
+} from '../themes/types'
+
+export interface RenderStardustResultConfig {
+  classes: ComponentSlotClasses
+  variables: ComponentVariablesObject
+  styles: ComponentSlotStylesPrepared
+  rtl: boolean
+  theme: ThemePrepared
+}
+
+export type RenderStardustComponentCallback<P> = (
+  config: RenderStardustResultConfig,
+  props: P,
+) => any
+
+export interface CreateStardustComponentConfig<P> {
+  displayName?: string
+  render: RenderStardustComponentCallback<P>
+}
+
+const createStardustComponent = <P extends {} = {}, S extends {} = {}>({
+  displayName = 'StardustComponent',
+  render,
+}: CreateStardustComponentConfig<P>): React.SFC<P> => {
+  const StardustComponent: React.SFC<P> = createComponent({
+    displayName,
+    render(config, props) {
+      // TODO add here everything that the client may expect
+      const restrictedConfig = _.pick(config, ['classes', 'variables', 'styles', 'rtl', 'theme'])
+
+      return render(restrictedConfig, props)
+    },
+  })
+  StardustComponent.displayName = displayName
+  return StardustComponent
+}
+
+export default createStardustComponent

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -1,7 +1,7 @@
 import createComponentInternal from './createComponent'
 import * as React from 'react'
-import { pick } from 'lodash'
-import { ComponentSlotClasses } from '@stardust-ui/react'
+import * as _ from 'lodash'
+import { ComponentSlotClasses } from '../themes/types'
 
 export interface RenderStardustResultConfig {
   classes: ComponentSlotClasses
@@ -20,7 +20,7 @@ const createComponent = <P extends {} = {}, S extends {} = {}>({
   return createComponentInternal<P, S>({
     displayName,
     render: (config, props) => {
-      const filteredConfig = pick(config, ['classes', 'rtl'])
+      const filteredConfig = _.pick(config, ['classes', 'rtl'])
       return render(Object.assign({ stardust: filteredConfig }, props))
     },
   })

--- a/src/lib/createStardustComponent.tsx
+++ b/src/lib/createStardustComponent.tsx
@@ -9,12 +9,12 @@ export interface RenderStardustResultConfig {
 }
 
 export interface CreateStardustComponentConfig<P> {
-  displayName?: string
+  displayName: string
   render: (props: P & { stardust: RenderStardustResultConfig }) => React.ReactNode
 }
 
 const createComponent = <P extends {} = {}, S extends {} = {}>({
-  displayName = 'StardustComponent',
+  displayName,
   render,
 }: CreateStardustComponentConfig<P>): React.SFC<P> => {
   return createComponentInternal<P, S>({

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,4 +33,4 @@ export { default as leven } from './leven'
 export { pxToRem, setHTMLFontSize } from './fontSizeUtility'
 export { customPropTypes }
 export { default as createAnimationStyles } from './createAnimationStyles'
-export { default as createStardustComponent } from './createStardustComponent'
+export { default as createComponent } from './createStardustComponent'

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,3 +33,4 @@ export { default as leven } from './leven'
 export { pxToRem, setHTMLFontSize } from './fontSizeUtility'
 export { customPropTypes }
 export { default as createAnimationStyles } from './createAnimationStyles'
+export { default as createStardustComponent } from './createStardustComponent'

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -3,7 +3,6 @@
 // ========================================================
 
 import * as React from 'react'
-import { ComponentSlotClasses } from '../src/themes/types'
 
 export type Extendable<T> = T & {
   [key: string]: any
@@ -18,16 +17,6 @@ export type OneOrArray<T> = T | T[]
 export type ObjectOf<T> = { [key: string]: T }
 
 export type ObjectOrFunc<TResult, TArg = {}> = ((arg: TArg) => TResult) | TResult
-
-export interface RenderStardustResultConfig {
-  classes: ComponentSlotClasses
-  rtl: boolean
-}
-
-export interface CreateStardustComponentConfig<P> {
-  displayName?: string
-  render: (config: RenderStardustResultConfig, props: P) => React.ReactNode
-}
 
 // ========================================================
 // Props

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -3,6 +3,7 @@
 // ========================================================
 
 import * as React from 'react'
+import { ComponentSlotClasses } from '../src/themes/types'
 
 export type Extendable<T> = T & {
   [key: string]: any
@@ -17,6 +18,16 @@ export type OneOrArray<T> = T | T[]
 export type ObjectOf<T> = { [key: string]: T }
 
 export type ObjectOrFunc<TResult, TArg = {}> = ((arg: TArg) => TResult) | TResult
+
+export interface RenderStardustResultConfig {
+  classes: ComponentSlotClasses
+  rtl: boolean
+}
+
+export interface CreateStardustComponentConfig<P> {
+  displayName?: string
+  render: (config: RenderStardustResultConfig, props: P) => React.ReactNode
+}
 
 // ========================================================
 // Props


### PR DESCRIPTION
# Introducing createComponent functionality as part of the public API in Stardust
This PR aims to fix https://github.com/stardust-ui/react/issues/498 by adding a wrapper around the internal createComponent function. The API for the function looks like this:
```
export interface RenderStardustResultConfig {
  classes: ComponentSlotClasses
  rtl: boolean
}

export interface CreateStardustComponentConfig<P> {
  displayName: string
  render: (props: P & { stardust: RenderStardustResultConfig }) => React.ReactNode
}

const createComponent = <P extends {} = {}, S extends {} = {}>({
  displayName = 'StardustComponent',
  render,
}: CreateStardustComponentConfig<P>) => React.SFC<P> 
```
Only the bits related to the styles are added in the config of the component.

## Usage example

### Definition of the custom component
The createComponent function should be used for defining custom components in the following way:
```
export interface StyledButtonProps {
  styles?: ComponentSlotStyle
  variables?: ComponentVariablesInput
  children?: React.ReactNodeArray | React.ReactNode
}

const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({
  displayName: 'MyStyledButton',
  render({stardust, ...props}) {
    const { classes } = stardust
    
    return (<button className={cx(props.className, classes.root)} {...props} />)
  },
})
```
### Example usage of the custom component
Some example usages of the `StyledButton` component would be:
#### Using styles and accessing the theme from the Provider
```
<StyledButton styles={({ theme: {siteVariables} }) => ({ backgroundColor: siteVariables.brand })}>
  My styled button
</StyledButton>
```
#### Using styles and accessing the props as they would use with some Stardust component 
```
<StyledButton isRed styles={({props}) => ({backgroundColor: props.isRed ? 'red' : 'blue'})}>
  My red styled
</StyledButton>
```
## Theming support
```
<Provider theme={{
  componentStyles: {
    StyledButton: {
      root: ({ props, variables, theme: {siteVariables} }) => ({
        backgroundColor: props.isRed ? (variables as any).red : siteVariables.brand,
      }),
    },
  },
  componentVariables: {
    StyledButton: {
      red: '#fc798c',
    },
  },
}}>
  <StyledButton isRed>My styled button on Provider</StyledButton>
</Provider>
```
