### PR TITLE
docs(ChatPane): Add attachments and link to chat pane messages in prototype

### DIFF
--- a/docs/src/prototypes/chatPane/services/dataMock.ts
+++ b/docs/src/prototypes/chatPane/services/dataMock.ts
@@ -66,6 +66,7 @@ class ChatMock {
         timestamp: timestamp.short,
         timestampLong: timestamp.long,
         isImportant: random.boolean(),
+        withAttachment: random.boolean(),
       }
 
       return message

--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -34,7 +34,7 @@ const statusMap: Map<UserStatus, StatusPropsExtendable> = new Map([
 function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage {
   const { content, mine } = msg
   const msgProps: ChatMessage = {
-    content: getMessageContent(content),
+    content: createMessageContent(content),
     mine,
     tabIndex: 0,
     timestamp: { content: msg.timestamp, title: msg.timestampLong },
@@ -46,7 +46,7 @@ function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage
   return msgProps
 }
 
-function getMessageContent(content: string) {
+function createMessageContent(content: string) {
   const contextMenu = (
     <Menu
       items={[
@@ -74,20 +74,18 @@ function getMessageContent(content: string) {
       <span>
         {content} <a href="/"> Some link </a>
       </span>
-      <div style={{ marginTop: '20px' }}>
-        {_.map(['MeetingNotes.pptx', 'Document.docx'], (fileName, index) => {
-          return (
-            <Attachment
-              icon="file word outline"
-              aria-label={`File attachment ${fileName}. Press tab for more options Press Enter to open the file`}
-              header={fileName}
-              action={{ icon: 'ellipsis horizontal' }}
-              renderAction={() => actionPopup}
-              data-is-focusable={true}
-              style={index === 1 ? { marginLeft: '15px' } : {}}
-            />
-          )
-        })}
+      <div style={{ marginTop: '20px', display: 'flex' }}>
+        {_.map(['MeetingNotes.pptx', 'Document.docx'], (fileName, index) => (
+          <Attachment
+            icon="file word outline"
+            aria-label={`File attachment ${fileName}. Press tab for more options Press Enter to open the file`}
+            header={fileName}
+            action={{ icon: 'ellipsis horizontal' }}
+            renderAction={() => actionPopup}
+            data-is-focusable={true}
+            style={index === 1 ? { marginLeft: '15px' } : {}}
+          />
+        ))}
       </div>
     </>
   )

--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -34,7 +34,9 @@ const statusMap: Map<UserStatus, StatusPropsExtendable> = new Map([
 function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage {
   const { content, mine } = msg
   const msgProps: ChatMessage = {
-    content: { content: createMessageContent(content) },
+    content: msg.withAttachment
+      ? { content: createMessageContentWithAttachments(content) }
+      : content,
     mine,
     tabIndex: 0,
     timestamp: { content: msg.timestamp, title: msg.timestampLong },
@@ -46,7 +48,7 @@ function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage
   return msgProps
 }
 
-function createMessageContent(content: string) {
+function createMessageContentWithAttachments(content: string) {
   const contextMenu = (
     <Menu
       items={[

--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -34,7 +34,7 @@ const statusMap: Map<UserStatus, StatusPropsExtendable> = new Map([
 function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage {
   const { content, mine } = msg
   const msgProps: ChatMessage = {
-    content: createMessageContent(content),
+    content: { content: createMessageContent(content) },
     mine,
     tabIndex: 0,
     timestamp: { content: msg.timestamp, title: msg.timestampLong },
@@ -83,7 +83,12 @@ function createMessageContent(content: string) {
             action={{ icon: 'ellipsis horizontal' }}
             renderAction={() => actionPopup}
             data-is-focusable={true}
-            style={index === 1 ? { marginLeft: '15px' } : {}}
+            styles={{
+              '&:focus': {
+                outline: '.2rem solid #6264A7',
+              },
+              ...(index === 1 ? { marginLeft: '15px' } : {}),
+            }}
           />
         ))}
       </div>

--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -1,3 +1,5 @@
+import { Attachment, Popup, Button, Menu, popupFocusTrapBehavior } from '@stardust-ui/react'
+import * as React from 'react'
 import * as _ from 'lodash'
 import { ChatMessageProps } from 'src/components/Chat/ChatMessage'
 import { DividerProps } from 'src/components/Divider/Divider'
@@ -32,7 +34,7 @@ const statusMap: Map<UserStatus, StatusPropsExtendable> = new Map([
 function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage {
   const { content, mine } = msg
   const msgProps: ChatMessage = {
-    content,
+    content: getMessageContent(content),
     mine,
     tabIndex: 0,
     timestamp: { content: msg.timestamp, title: msg.timestampLong },
@@ -42,6 +44,53 @@ function generateChatMsgProps(msg: MessageData, fromUser: UserData): ChatMessage
   }
 
   return msgProps
+}
+
+function getMessageContent(content: string) {
+  const contextMenu = (
+    <Menu
+      items={[
+        { key: 'download', content: 'Download', icon: 'download' },
+        { key: 'linkify', content: 'Get link', icon: 'linkify' },
+        { key: 'tab', content: 'Make this a tab', icon: 'folder open' },
+      ]}
+      vertical
+      pills
+    />
+  )
+
+  const actionPopup = (
+    <Popup
+      accessibility={popupFocusTrapBehavior}
+      trigger={
+        <Button aria-label="More attachment options" iconOnly circular icon="ellipsis horizontal" />
+      }
+      content={{ content: contextMenu }}
+    />
+  )
+
+  return (
+    <>
+      <span>
+        {content} <a href="/"> Some link </a>
+      </span>
+      <div style={{ marginTop: '20px' }}>
+        {_.map(['MeetingNotes.pptx', 'Document.docx'], (fileName, index) => {
+          return (
+            <Attachment
+              icon="file word outline"
+              aria-label={`File attachment ${fileName}. Press tab for more options Press Enter to open the file`}
+              header={fileName}
+              action={{ icon: 'ellipsis horizontal' }}
+              renderAction={() => actionPopup}
+              data-is-focusable={true}
+              style={index === 1 ? { marginLeft: '15px' } : {}}
+            />
+          )
+        })}
+      </div>
+    </>
+  )
 }
 
 function generateDividerProps(props: DividerProps): Divider {

--- a/docs/src/prototypes/chatPane/services/types.ts
+++ b/docs/src/prototypes/chatPane/services/types.ts
@@ -19,6 +19,7 @@ export interface MessageData {
   from: string
   isImportant: boolean
   mine: boolean
+  withAttachment?: boolean
 }
 
 export interface ChatData {


### PR DESCRIPTION
This PR aims to improve chat pane behavior by adding Attachments and links to chat message so provide the proper accessibility experience for it.

1. Navigate with UP / DOWN arrow keys between messages
2. Click Enter on focused message
3. The link will get focus first
4. Press Tab
5. First attachment will get focus
6. Press Tab
7. Action button on the attachment will get focus
8. Press Enter
9. Popup will open with context menu and trap the focus
10. Press Esc 
11. Focus goes to action trigger
12. Press Tab and go to the next attachment OR press Esc and focus message again, so you'll be able to navigate between messages with UP/DOWN arrow keys


![image](https://user-images.githubusercontent.com/8460706/48900734-7f493300-ee53-11e8-932a-63c1f169d534.png)



Opened context menu:
![image](https://user-images.githubusercontent.com/8460706/48900840-cb947300-ee53-11e8-812a-96e6bfc090dd.png)
