### PR TITLE
fix(Popup): Stop event propagation when press Escape on the popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix the behaviour of `AutoControlledComponent` when `undefined` is passed as a prop value @layershifter ([#499](https://github.com/stardust-ui/react/pull/499))
+- Stop event propagation when press Escape on the popup @sophieH29 ([#515](https://github.com/stardust-ui/react/pull/515))
 
 <!--------------------------------[ v0.12.0 ]------------------------------- -->
 ## [v0.12.0](https://github.com/stardust-ui/react/tree/v0.12.0) (2018-11-19)

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -129,6 +129,7 @@ export default class Popup extends AutoControlledComponent<Extendable<PopupProps
       this.trySetOpen(!this.state.open, e, true)
     },
     closeAndFocusTrigger: e => this.closeAndFocusTrigger(e),
+    stopPropagation: e => e.stopPropagation(),
   }
 
   private closeAndFocusTrigger = e => {

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -128,8 +128,10 @@ export default class Popup extends AutoControlledComponent<Extendable<PopupProps
     toggle: e => {
       this.trySetOpen(!this.state.open, e, true)
     },
-    closeAndFocusTrigger: e => this.closeAndFocusTrigger(e),
-    stopPropagation: e => e.stopPropagation(),
+    closeAndFocusTrigger: e => {
+      this.closeAndFocusTrigger(e)
+      e.stopPropagation()
+    },
   }
 
   private closeAndFocusTrigger = e => {

--- a/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
@@ -25,9 +25,6 @@ const popupBehavior: Accessibility = (props: any) => ({
       closeAndFocusTrigger: {
         keyCombinations: [{ keyCode: keyboardKey.Escape }],
       },
-      stopPropagation: {
-        keyCombinations: [{ keyCode: keyboardKey.Escape }],
-      },
     },
   },
 })

--- a/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
@@ -25,6 +25,9 @@ const popupBehavior: Accessibility = (props: any) => ({
       closeAndFocusTrigger: {
         keyCombinations: [{ keyCode: keyboardKey.Escape }],
       },
+      stopPropagation: {
+        keyCombinations: [{ keyCode: keyboardKey.Escape }],
+      },
     },
   },
 })


### PR DESCRIPTION
TODO:

- [x] Update CHANGELOG.md

After using Popup in different prototypes, I encountered an issue. When pressing ```Esc``` button on popup, popup closes and trigger gets focus (that's expected). But this event is propagated, so it can be handled also by other layers and the focus can be removed from the trigger, what is not expected behavior. 

**Expected behavior**
Focus should remain on trigger element when clicking Esc, and the event shouldn't propagate.

To fix it I've added additional key action in ```popupBehavior```, so we can be quite flexible here. For e.g, if for some case we won't need it, or we need it also for other keys - appropriate behavior can be created for that, while ```Popup``` will always have it as a separate action ```stopPropagation```

```js
 stopPropagation: {
        keyCombinations: [{ keyCode: keyboardKey.Escape }],
      },
```