### PR TITLE
docs(custom-components): adding initial guide for creating custom components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix the behaviour of `AutoControlledComponent` when `undefined` is passed as a prop value @layershifter ([#499](https://github.com/stardust-ui/react/pull/499))
 
 ### Documentation
-- Add `Custom Components` guide page in the docs @mnajdova ([#517](https://github.com/stardust-ui/react/pull/517))
+- Add `Integrate Custom Components` guide page in the docs @mnajdova ([#517](https://github.com/stardust-ui/react/pull/517))
 
 <!--------------------------------[ v0.12.0 ]------------------------------- -->
 ## [v0.12.0](https://github.com/stardust-ui/react/tree/v0.12.0) (2018-11-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Features
-- Add `renderComponent` function in the public API @mnajdova ([#503](https://github.com/stardust-ui/react/pull/503))
+- Add `createComponent` function in the public API @mnajdova ([#503](https://github.com/stardust-ui/react/pull/503))
 
 ### Fixes
 - Fix the behaviour of `AutoControlledComponent` when `undefined` is passed as a prop value @layershifter ([#499](https://github.com/stardust-ui/react/pull/499))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix the behaviour of `AutoControlledComponent` when `undefined` is passed as a prop value @layershifter ([#499](https://github.com/stardust-ui/react/pull/499))
 
+### Documentation
+- Add `Custom Components` guide page in the docs @mnajdova ([#517](https://github.com/stardust-ui/react/pull/517))
+
 <!--------------------------------[ v0.12.0 ]------------------------------- -->
 ## [v0.12.0](https://github.com/stardust-ui/react/tree/v0.12.0) (2018-11-19)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.11.0...v0.12.0)

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -245,8 +245,13 @@ class Sidebar extends React.Component<any, any> {
                 <Menu.Item as={NavLink} exact to="/theming-examples" activeClassName="active">
                   Theming Examples
                 </Menu.Item>
-                <Menu.Item as={NavLink} exact to="/custom-components" activeClassName="active">
-                  Custom Components
+                <Menu.Item
+                  as={NavLink}
+                  exact
+                  to="/integrate-custom-components"
+                  activeClassName="active"
+                >
+                  Integrate Custom Components
                 </Menu.Item>
               </Menu.Menu>
             </Menu.Item>

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -245,6 +245,9 @@ class Sidebar extends React.Component<any, any> {
                 <Menu.Item as={NavLink} exact to="/theming-examples" activeClassName="active">
                   Theming Examples
                 </Menu.Item>
+                <Menu.Item as={NavLink} exact to="/custom-components" activeClassName="active">
+                  Custom Components
+                </Menu.Item>
               </Menu.Menu>
             </Menu.Item>
             {process.env.NODE_ENV !== 'production' && (

--- a/docs/src/routes.tsx
+++ b/docs/src/routes.tsx
@@ -12,6 +12,7 @@ import PageNotFound from './views/PageNotFound'
 import QuickStart from './views/QuickStart'
 import Theming from './views/Theming'
 import ThemingExamples from './views/ThemingExamples'
+import CustomComponents from './views/CustomComponents'
 
 const Router = () => (
   <BrowserRouter basename={__BASENAME__}>
@@ -57,6 +58,7 @@ const Router = () => (
         <DocsLayout exact path="/theming" component={Theming} />
         <DocsLayout exact path="/theming-examples" component={ThemingExamples} />
         <DocsLayout exact path="/shorthand-props" component={ShorthandProps} />
+        <DocsLayout exact path="/custom-components" component={CustomComponents} />
         <DocsLayout exact path="/*" component={PageNotFound} />
       </Switch>
     </Switch>

--- a/docs/src/routes.tsx
+++ b/docs/src/routes.tsx
@@ -12,7 +12,7 @@ import PageNotFound from './views/PageNotFound'
 import QuickStart from './views/QuickStart'
 import Theming from './views/Theming'
 import ThemingExamples from './views/ThemingExamples'
-import CustomComponents from './views/CustomComponents'
+import IntegrateCustomComponents from './views/IntegrateCustomComponents'
 
 const Router = () => (
   <BrowserRouter basename={__BASENAME__}>
@@ -58,7 +58,11 @@ const Router = () => (
         <DocsLayout exact path="/theming" component={Theming} />
         <DocsLayout exact path="/theming-examples" component={ThemingExamples} />
         <DocsLayout exact path="/shorthand-props" component={ShorthandProps} />
-        <DocsLayout exact path="/custom-components" component={CustomComponents} />
+        <DocsLayout
+          exact
+          path="/integrate-custom-components"
+          component={IntegrateCustomComponents}
+        />
         <DocsLayout exact path="/*" component={PageNotFound} />
       </Switch>
     </Switch>

--- a/docs/src/views/CustomComponents.tsx
+++ b/docs/src/views/CustomComponents.tsx
@@ -1,0 +1,235 @@
+import * as React from 'react'
+import * as cx from 'classnames'
+import * as _ from 'lodash'
+import { NavLink } from 'react-router-dom'
+import { Header } from 'semantic-ui-react'
+import {
+  Button,
+  Divider,
+  Provider,
+  createComponent,
+  ComponentSlotStyle,
+  ComponentVariablesInput,
+} from '@stardust-ui/react'
+
+import DocPage from '../components/DocPage/DocPage'
+import ExampleSnippet from '../components/ExampleSnippet/ExampleSnippet'
+
+interface StyledButtonProps {
+  className?: string
+  styles?: ComponentSlotStyle
+  variables?: ComponentVariablesInput
+  children?: React.ReactNodeArray | React.ReactNode
+}
+
+const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({
+  displayName: 'StyledButton',
+  render({ stardust, ...props }) {
+    const { classes } = stardust
+    const componentProps = _.pick(props, 'children')
+    return <button className={cx(props.className, classes.root)} {...componentProps} />
+  },
+})
+
+export default () => (
+  <DocPage title="Custom Components">
+    <Header as="h2" content="Overview" />
+    <p>
+      You can use your own components as part of the Stardust's theming mechanism. In order for all
+      theming aspects to be available to your custom components, you should use the{' '}
+      <code>createComponent</code>
+      function, provided by the Stardust library.
+    </p>
+
+    <Header as="h2" content="Create custom component" />
+    <p>
+      Let's take a look into one simple example of using the <code>createComponent</code> function
+      for adapting your custom component to the Stardust's theming mechanism.
+    </p>
+
+    <ExampleSnippet
+      value={[
+        `import { createComponent } from '@stardust-ui/react'`,
+        ``,
+        `export interface StyledButtonProps {`,
+        `  className?: string`,
+        `  styles?: ComponentSlotStyle`,
+        `  variables?: ComponentVariablesInput`,
+        `  children?: React.ReactNodeArray | React.ReactNode`,
+        `}`,
+        ``,
+        `const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({`,
+        `  displayName: 'StyledButton',`,
+        `  render: ({stardust, ...props}) => {`,
+        `    const { classes } = stardust`,
+        `    const componentProps = _.pick(props, 'children')`,
+        `    return (<button className={cx(props.className, classes.root)} {...componentProps} />)`,
+        `  }`,
+        `})`,
+      ].join('\n')}
+    />
+
+    <p>Let's go step by step throughout all bits from the renderComponent method.</p>
+
+    <p>
+      The first argument to the <code>createComponent</code> config's param is the displayName. This
+      name is very important, because that's the key that will be used in the Provider's theme if
+      you want to define some styles or variables for this custom component. Let's see one example:
+    </p>
+
+    <ExampleSnippet
+      value={[
+        `<Provider`,
+        `  theme={{`,
+        `    componentStyles: {`,
+        `      StyledButton: {`,
+        `        root: ({ props, variables, theme: {siteVariables} }) => ({`,
+        `          backgroundColor: siteVariables.brand,`,
+        `          color: (variables as any).color,`,
+        `        }),`,
+        `      },`,
+        `    },`,
+        `    componentVariables: {`,
+        `      StyledButton: {`,
+        `        color: '#F2F2F2',`,
+        `      },`,
+        `    },`,
+        `  }}`,
+        `>`,
+        `  <StyledButton> Provider styled button </StyledButton>`,
+        '</Provider>',
+      ].join('\n')}
+      render={() => (
+        <Provider
+          theme={{
+            componentStyles: {
+              StyledButton: {
+                root: ({ props, variables, theme: { siteVariables } }) => ({
+                  backgroundColor: siteVariables.brand,
+                  color: (variables as any).color,
+                }),
+              },
+            },
+            componentVariables: {
+              StyledButton: {
+                color: '#F2F2F2',
+              },
+            },
+          }}
+        >
+          <StyledButton>Provider styled button</StyledButton>
+        </Provider>
+      )}
+    />
+
+    <p>
+      The second argument of the <code>createComponent</code> config param is the render method.
+      This is the place where you link the Stardust bits with your custom component. This method is
+      invoked with the following parameters:
+    </p>
+    <ul>
+      <li>
+        <code>stardust</code> - this is the object containing the evaluated theming props (classes
+        and rtl)
+      </li>
+      <li>
+        <code>...props</code> - all other props provided by the user
+      </li>
+    </ul>
+    <p>
+      The previous implementation of the render method inside the <code>createComponent</code>{' '}
+      function for the
+      <code>StyledButton</code>, allows the user, to use the styles and variables properties on the
+      custom component in the same way they would be used for any Stardust component.
+    </p>
+
+    <Header as="h2" content="Using the custom components" />
+
+    <p>
+      We already saw how the <code>Provider</code> can define some stylings and variables for the
+      custom components. Next, we will take a look into few examples of how the user can further
+      customize the styling and variables of the custom components, the same way they would do with
+      the Stardust components.
+    </p>
+
+    <Header as="h3" content="Example 1. Using the variables property" />
+
+    <ExampleSnippet
+      value={[
+        `<StyledButton variables={(siteVars) => ({color: siteVars.black})}>`,
+        `  Inline styled button`,
+        `</StyledButton>`,
+      ].join('\n')}
+      render={() => (
+        <Provider
+          theme={{
+            componentStyles: {
+              StyledButton: {
+                root: ({ props, variables, theme: { siteVariables } }) => ({
+                  backgroundColor: siteVariables.brand,
+                  color: (variables as any).color,
+                }),
+              },
+            },
+            componentVariables: {
+              StyledButton: {
+                color: '#F2F2F2',
+              },
+            },
+          }}
+        >
+          <StyledButton variables={siteVariables => ({ color: siteVariables.black })}>
+            inline styled button
+          </StyledButton>
+        </Provider>
+      )}
+    />
+
+    <Header as="h3" content="Example 2. Using the styles property" />
+
+    <ExampleSnippet
+      value={[
+        `<StyledButton styles={({theme: {siteVariables}}) => ({backgroundColor: siteVariables.black})}>`,
+        `  Inline styled button`,
+        `</StyledButton>`,
+      ].join('\n')}
+      render={() => (
+        <Provider
+          theme={{
+            componentStyles: {
+              StyledButton: {
+                root: ({ props, variables, theme: { siteVariables } }) => ({
+                  backgroundColor: siteVariables.brand,
+                  color: (variables as any).color,
+                }),
+              },
+            },
+            componentVariables: {
+              StyledButton: {
+                color: '#F2F2F2',
+              },
+            },
+          }}
+        >
+          <StyledButton
+            styles={({ theme: { siteVariables } }) => ({ backgroundColor: siteVariables.black })}
+          >
+            Inline styled button
+          </StyledButton>
+        </Provider>
+      )}
+    />
+
+    <br />
+    <Divider size={1} />
+    <br />
+    <Button
+      as={NavLink}
+      content="Theming Examples"
+      icon="arrow left"
+      iconPosition="before"
+      primary
+      to="/theming-examples"
+    />
+  </DocPage>
+)

--- a/docs/src/views/CustomComponents.tsx
+++ b/docs/src/views/CustomComponents.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as cx from 'classnames'
-import * as _ from 'lodash'
 import { NavLink } from 'react-router-dom'
 import { Header } from 'semantic-ui-react'
 import {
@@ -24,10 +23,9 @@ interface StyledButtonProps {
 
 const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({
   displayName: 'StyledButton',
-  render({ stardust, ...props }) {
+  render({ stardust, className, children }) {
     const { classes } = stardust
-    const componentProps = _.pick(props, 'children')
-    return <button className={cx(props.className, classes.root)} {...componentProps} />
+    return <button className={cx(className, classes.root)}>{children}</button>
   },
 })
 
@@ -60,10 +58,9 @@ export default () => (
         ``,
         `const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({`,
         `  displayName: 'StyledButton',`,
-        `  render: ({stardust, ...props}) => {`,
+        `  render: ({stardust, className, children}) => {`,
         `    const { classes } = stardust`,
-        `    const componentProps = _.pick(props, 'children')`,
-        `    return (<button className={cx(props.className, classes.root)} {...componentProps} />)`,
+        `    return <button className={cx(className, classes.root)}>{children}</button>`,
         `  }`,
         `})`,
       ].join('\n')}

--- a/docs/src/views/CustomComponents.tsx
+++ b/docs/src/views/CustomComponents.tsx
@@ -69,7 +69,9 @@ export default () => (
       ].join('\n')}
     />
 
-    <p>Let's go step by step throughout all bits from the renderComponent method.</p>
+    <p>
+      Let's go step by step throughout all bits from the <code>createComponent</code> method.
+    </p>
 
     <p>
       The first argument to the <code>createComponent</code> config's param is the displayName. This

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -38,13 +38,11 @@ export default () => (
       order for all theming aspects to be available to your custom components, you should use the{' '}
       <code>createComponent</code> function, provided by the Stardust library.
     </p>
-
     <Header as="h2" content="Create custom component" />
     <p>
       Let's take a look into one simple example of using the <code>createComponent</code> function
       for adapting your custom component to the Stardust's styling and theming mechanisms.
     </p>
-
     <ExampleSnippet
       value={[
         `import { createComponent } from '@stardust-ui/react'`,
@@ -58,18 +56,15 @@ export default () => (
         `})`,
       ].join('\n')}
     />
-
     <p>
       Let's go step by step throughout all bits from the <code>createComponent</code> method.
     </p>
-
     <p>
       The first argument to the <code>createComponent</code> config's param is the is the{' '}
       <code>displayName</code>, which value might be used as key to define component's styles and
       variables in theme, exactly the same way how it might be done for any first-class Stardust
       component.
     </p>
-
     <ExampleSnippet
       value={[
         `<Provider`,
@@ -114,7 +109,6 @@ export default () => (
         </Provider>
       )}
     />
-
     <p>
       The second argument of the <code>createComponent</code> config param is the{' '}
       <code>render</code> method. This is the place where where you might link Stardust bits with
@@ -129,19 +123,16 @@ export default () => (
         and <code>rtl</code>).
       </li>
       <li>
-        <code>...props</code> - all other props provided by the user.
+        <code>...props</code> - all <code>user props</code>.
       </li>
     </ul>
-
     <Header as="h2" content="Using the custom components" />
-
     <p>
       We already saw how the <code>Provider</code> can define some stylings and variables for the
       custom components. Next, we will take a look into several examples of how the user can further
       customize styles and variables of these components, the same way they would do with the
       Stardust components.
     </p>
-
     <Header
       as="h3"
       content={
@@ -150,36 +141,44 @@ export default () => (
         </>
       }
     />
-
     <ExampleSnippet
       value={[
-        `<StyledButton styles={{backgroundColor: "black"}}>`,
+        `<StyledButton styles={{':hover': {backgroundColor: "yellow"}}>`,
         `  Inline styled button`,
         `</StyledButton>`,
       ].join('\n')}
       render={() => (
-        <Provider
-          theme={{
-            componentVariables: {
-              StyledButton: {
-                color: '#F2F2F2',
-              },
-            },
-            componentStyles: {
-              StyledButton: {
-                root: ({ props, variables, theme: { siteVariables } }) => ({
-                  backgroundColor: siteVariables.brand,
-                  color: (variables as any).color,
-                }),
-              },
-            },
-          }}
-        >
-          <StyledButton styles={{ backgroundColor: 'black' }}>Inline styled button</StyledButton>
-        </Provider>
+        <StyledButton styles={{ ':hover': { backgroundColor: 'yellow' } }}>
+          Inline styled button
+        </StyledButton>
       )}
     />
-
+    The same can be achieved with adding styles in the <code>componentStyles</code> part of the{' '}
+    <code>theme</code> in the <code>Provider</code>.
+    <ExampleSnippet
+      value={[
+        `<Provider`,
+        `  theme={{`,
+        `    // other theme parts`,
+        `    componentStyles: {`,
+        `      StyledButton: {`,
+        `        root: () => ({`,
+        `          ':hover': {`,
+        `            backgroundColor: "yellow"`,
+        `          }`,
+        `        }),`,
+        `      },`,
+        `    },`,
+        `  }}`,
+        `>`,
+        `  <StyledButton>Inline styled button</StyledButton>`,
+        '</Provider>',
+      ].join('\n')}
+    />
+    <p>
+      For more advanced theming scenarios, please take a look in the <b>Styles</b> section on the{' '}
+      <NavLink to="theming">Theming guide</NavLink>.
+    </p>
     <Header
       as="h3"
       content={
@@ -188,42 +187,77 @@ export default () => (
         </>
       }
     />
-
+    Let's consider that the following <code>theme</code> was passed to the <code>Provider</code>.
     <ExampleSnippet
       value={[
-        `<StyledButton variables={{color: "black" }}>`,
+        `<Provider`,
+        `  theme={{`,
+        `    // other theme parts`,
+        `    componentStyles: {`,
+        `      StyledButton: {`,
+        `        root: ({ variables }) => ({`,
+        `          color: variables.color,`,
+        `        }),`,
+        `      },`,
+        `    },`,
+        `  }}`,
+        `>`,
+        `  ...`,
+        '</Provider>',
+      ].join('\n')}
+    />
+    Then we can use the <code>variables</code> prop for changing the color inside the{' '}
+    <code>StyledButton</code>.
+    <ExampleSnippet
+      value={[
+        `<StyledButton variables={{color: "red" }}>`,
         `  Inline styled button`,
         `</StyledButton>`,
       ].join('\n')}
       render={() => (
         <Provider
           theme={{
-            componentVariables: {
-              StyledButton: {
-                color: '#F2F2F2',
-              },
-            },
             componentStyles: {
               StyledButton: {
-                root: ({ props, variables, theme: { siteVariables } }) => ({
-                  backgroundColor: siteVariables.brand,
+                root: ({ variables }) => ({
                   color: (variables as any).color,
                 }),
               },
             },
           }}
         >
-          <StyledButton variables={{ color: 'black' }}>inline styled button</StyledButton>
+          <StyledButton variables={{ color: 'red' }}>Inline styled button</StyledButton>
         </Provider>
       )}
     />
-
+    The alternative approach with defining <code>componentVariables</code> inside the{' '}
+    <code>theme</code> would like like this:
+    <ExampleSnippet
+      value={[
+        `<Provider`,
+        `  theme={{`,
+        `    componentVariables: {`,
+        `      StyledButton: {`,
+        `        color: "red"`,
+        `      },`,
+        `    }`,
+        `    componentStyles: {`,
+        `      StyledButton: {`,
+        `        root: ({ variables }) => ({`,
+        `          color: variables.color,`,
+        `        }),`,
+        `      },`,
+        `    },`,
+        `  }}`,
+        `>`,
+        `  ...`,
+        '</Provider>',
+      ].join('\n')}
+    />
     <p>
-      All other advanced scenarios for applying styles and variables are supported as well. For more
-      information, please, take a look in the{' '}
-      <NavLink to="theming-examples">Theming Examples</NavLink>.
+      For more advanced theming scenarios, please take a look in the <b>Variables</b> section on the{' '}
+      <NavLink to="theming">Theming guide</NavLink>.
     </p>
-
     <br />
     <Divider size={1} />
     <br />

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -30,33 +30,25 @@ const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonP
 })
 
 export default () => (
-  <DocPage title="Custom Components">
+  <DocPage title="Integrate Custom Components">
     <Header as="h2" content="Overview" />
     <p>
-      You can use your own components as part of the Stardust's theming mechanism. In order for all
-      theming aspects to be available to your custom components, you should use the{' '}
-      <code>createComponent</code>
-      function, provided by the Stardust library.
+      You can use your own components as part of the Stardust's styling and theming mechanisms. In
+      order for all theming aspects to be available to your custom components, you should use the{' '}
+      <code>createComponent</code> function, provided by the Stardust library.
     </p>
 
     <Header as="h2" content="Create custom component" />
     <p>
       Let's take a look into one simple example of using the <code>createComponent</code> function
-      for adapting your custom component to the Stardust's theming mechanism.
+      for adapting your custom component to the Stardust's styling and theming mechanisms.
     </p>
 
     <ExampleSnippet
       value={[
         `import { createComponent } from '@stardust-ui/react'`,
         ``,
-        `export interface StyledButtonProps {`,
-        `  className?: string`,
-        `  styles?: ComponentSlotStyle`,
-        `  variables?: ComponentVariablesInput`,
-        `  children?: React.ReactNodeArray | React.ReactNode`,
-        `}`,
-        ``,
-        `const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({`,
+        `const StyledButton = createComponent({`,
         `  displayName: 'StyledButton',`,
         `  render: ({stardust, className, children}) => {`,
         `    const { classes } = stardust`,
@@ -71,26 +63,27 @@ export default () => (
     </p>
 
     <p>
-      The first argument to the <code>createComponent</code> config's param is the displayName. This
-      name is very important, because that's the key that will be used in the Provider's theme if
-      you want to define some styles or variables for this custom component. Let's see one example:
+      The first argument to the <code>createComponent</code> config's param is the is the{' '}
+      <code>displayName</code>, which value might be used as key to define component's styles and
+      variables in theme, exactly the same way how it might be done for any first-class Stardust
+      component.
     </p>
 
     <ExampleSnippet
       value={[
         `<Provider`,
         `  theme={{`,
+        `    componentVariables: {`,
+        `      StyledButton: {`,
+        `        color: '#F2F2F2',`,
+        `      },`,
+        `    },`,
         `    componentStyles: {`,
         `      StyledButton: {`,
         `        root: ({ props, variables, theme: {siteVariables} }) => ({`,
         `          backgroundColor: siteVariables.brand,`,
         `          color: (variables as any).color,`,
         `        }),`,
-        `      },`,
-        `    },`,
-        `    componentVariables: {`,
-        `      StyledButton: {`,
-        `        color: '#F2F2F2',`,
         `      },`,
         `    },`,
         `  }}`,
@@ -101,17 +94,17 @@ export default () => (
       render={() => (
         <Provider
           theme={{
+            componentVariables: {
+              StyledButton: {
+                color: '#F2F2F2',
+              },
+            },
             componentStyles: {
               StyledButton: {
                 root: ({ props, variables, theme: { siteVariables } }) => ({
                   backgroundColor: siteVariables.brand,
                   color: (variables as any).color,
                 }),
-              },
-            },
-            componentVariables: {
-              StyledButton: {
-                color: '#F2F2F2',
               },
             },
           }}
@@ -122,46 +115,55 @@ export default () => (
     />
 
     <p>
-      The second argument of the <code>createComponent</code> config param is the render method.
-      This is the place where you link the Stardust bits with your custom component. This method is
-      invoked with the following parameters:
+      The second argument of the <code>createComponent</code> config param is the{' '}
+      <code>render</code> method. This is the place where where you might link Stardust bits with
+      your custom component - e.g. by simply passing them as props. This <code>render</code> method
+      will be invoked with the following parameters:
     </p>
     <ul>
       <li>
-        <code>stardust</code> - this is the object containing the evaluated theming props (classes
-        and rtl)
+        <code>stardust</code> - the object containing the evaluated theming props (<code>
+          classes
+        </code>
+        and <code>rtl</code>).
       </li>
       <li>
-        <code>...props</code> - all other props provided by the user
+        <code>...props</code> - all other props provided by the user.
       </li>
     </ul>
-    <p>
-      The previous implementation of the render method inside the <code>createComponent</code>{' '}
-      function for the
-      <code>StyledButton</code>, allows the user, to use the styles and variables properties on the
-      custom component in the same way they would be used for any Stardust component.
-    </p>
 
     <Header as="h2" content="Using the custom components" />
 
     <p>
       We already saw how the <code>Provider</code> can define some stylings and variables for the
-      custom components. Next, we will take a look into few examples of how the user can further
-      customize the styling and variables of the custom components, the same way they would do with
-      the Stardust components.
+      custom components. Next, we will take a look into several examples of how the user can further
+      customize styles and variables of these components, the same way they would do with the
+      Stardust components.
     </p>
 
-    <Header as="h3" content="Example 1. Using the variables property" />
+    <Header
+      as="h3"
+      content={
+        <>
+          Example 1. Using <code>styles</code> property
+        </>
+      }
+    />
 
     <ExampleSnippet
       value={[
-        `<StyledButton variables={(siteVars) => ({color: siteVars.black})}>`,
+        `<StyledButton styles={{backgroundColor: "black"}}>`,
         `  Inline styled button`,
         `</StyledButton>`,
       ].join('\n')}
       render={() => (
         <Provider
           theme={{
+            componentVariables: {
+              StyledButton: {
+                color: '#F2F2F2',
+              },
+            },
             componentStyles: {
               StyledButton: {
                 root: ({ props, variables, theme: { siteVariables } }) => ({
@@ -170,31 +172,36 @@ export default () => (
                 }),
               },
             },
-            componentVariables: {
-              StyledButton: {
-                color: '#F2F2F2',
-              },
-            },
           }}
         >
-          <StyledButton variables={siteVariables => ({ color: siteVariables.black })}>
-            inline styled button
-          </StyledButton>
+          <StyledButton styles={{ backgroundColor: 'black' }}>Inline styled button</StyledButton>
         </Provider>
       )}
     />
 
-    <Header as="h3" content="Example 2. Using the styles property" />
+    <Header
+      as="h3"
+      content={
+        <>
+          Example 2. Using <code>variables</code> property
+        </>
+      }
+    />
 
     <ExampleSnippet
       value={[
-        `<StyledButton styles={({theme: {siteVariables}}) => ({backgroundColor: siteVariables.black})}>`,
+        `<StyledButton variables={{color: "black" }}>`,
         `  Inline styled button`,
         `</StyledButton>`,
       ].join('\n')}
       render={() => (
         <Provider
           theme={{
+            componentVariables: {
+              StyledButton: {
+                color: '#F2F2F2',
+              },
+            },
             componentStyles: {
               StyledButton: {
                 root: ({ props, variables, theme: { siteVariables } }) => ({
@@ -203,21 +210,18 @@ export default () => (
                 }),
               },
             },
-            componentVariables: {
-              StyledButton: {
-                color: '#F2F2F2',
-              },
-            },
           }}
         >
-          <StyledButton
-            styles={({ theme: { siteVariables } }) => ({ backgroundColor: siteVariables.black })}
-          >
-            Inline styled button
-          </StyledButton>
+          <StyledButton variables={{ color: 'black' }}>inline styled button</StyledButton>
         </Provider>
       )}
     />
+
+    <p>
+      All other advanced scenarios for applying styles and variables are supported as well. For more
+      information, please, take a look in the{' '}
+      <NavLink to="theming-examples">Theming Examples</NavLink>.
+    </p>
 
     <br />
     <Divider size={1} />

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -159,7 +159,7 @@ export default () => (
       value={[
         `<Provider`,
         `  theme={{`,
-        `    // other theme parts`,
+        `    // component's displayName arg is used as a selector`,
         `    componentStyles: {`,
         `      StyledButton: {`,
         `        root: () => ({`,
@@ -236,6 +236,7 @@ export default () => (
       value={[
         `<Provider`,
         `  theme={{`,
+        `    // component's displayName arg is used as a selector`,
         `    componentVariables: {`,
         `      StyledButton: {`,
         `        color: "red"`,

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -57,7 +57,7 @@ export default () => (
       ].join('\n')}
     />
     <p>
-      Let's go step by step throughout all bits from the <code>createComponent</code> method.
+      Let's go step by step throughout all bits of the <code>createComponent</code> method.
     </p>
     <p>
       The first argument to the <code>createComponent</code> config's param is the is the{' '}

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -13,15 +13,16 @@ import {
 
 import DocPage from '../components/DocPage/DocPage'
 import ExampleSnippet from '../components/ExampleSnippet/ExampleSnippet'
+import { ReactChildren } from '../../../types/utils'
 
 interface StyledButtonProps {
   className?: string
   styles?: ComponentSlotStyle
   variables?: ComponentVariablesInput
-  children?: React.ReactNodeArray | React.ReactNode
+  children?: ReactChildren
 }
 
-const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps, {}>({
+const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps>({
   displayName: 'StyledButton',
   render({ stardust, className, children }) {
     const { classes } = stardust
@@ -82,7 +83,7 @@ export default () => (
         `      StyledButton: {`,
         `        root: ({ props, variables, theme: {siteVariables} }) => ({`,
         `          backgroundColor: siteVariables.brand,`,
-        `          color: (variables as any).color,`,
+        `          color: variables.color,`,
         `        }),`,
         `      },`,
         `    },`,

--- a/docs/src/views/ThemingExamples.tsx
+++ b/docs/src/views/ThemingExamples.tsx
@@ -5,6 +5,7 @@ import { Button, Divider, Icon, Label, Provider } from '@stardust-ui/react'
 
 import DocPage from '../components/DocPage/DocPage'
 import ExampleSnippet from '../components/ExampleSnippet/ExampleSnippet'
+import { pxToRem } from '../../../src/lib'
 
 export default () => (
   <DocPage title="Theming Examples">
@@ -411,11 +412,12 @@ export default () => (
     />
     <Button
       as={NavLink}
-      content="Custom Components"
+      content="Integrate Custom Components"
       icon="arrow right"
       iconPosition="after"
       primary
-      to="custom-components"
+      to="integrate-custom-components"
+      variables={{ maxWidth: pxToRem(300) }}
     />
   </DocPage>
 )

--- a/docs/src/views/ThemingExamples.tsx
+++ b/docs/src/views/ThemingExamples.tsx
@@ -409,5 +409,13 @@ export default () => (
       primary
       to="theming"
     />
+    <Button
+      as={NavLink}
+      content="Custom Components"
+      icon="arrow right"
+      iconPosition="after"
+      primary
+      to="custom-components"
+    />
   </DocPage>
 )


### PR DESCRIPTION
This PR adds guide for how the custom components can be created using the renderComponent functionality in Stardust. 
To do
- [x] update the changelog