### PR TITLE
feat(chat): remove layout component and allow styling slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Features
-- Add `renderComponent` function in the public API @mnajdova ([#503](https://github.com/stardust-ui/react/pull/503))
+- Add `createComponent` function in the public API @mnajdova ([#503](https://github.com/stardust-ui/react/pull/503))
 - Apply `dir=auto` attribute to string content of `Text` @kuzhelov  ([#5](https://github.com/stardust-ui/react/pull/5))
 - Improve `Menu` accessibility behaviors @sophieH29 ([#523](https://github.com/stardust-ui/react/pull/523))
+- Add ability to style every slot of `Chat.Message` and remove dependency on `Layout` component @Bugaa92 ([#518](https://github.com/stardust-ui/react/pull/518))
 
 ### Fixes
 - Fix the behaviour of `AutoControlledComponent` when `undefined` is passed as a prop value @layershifter ([#499](https://github.com/stardust-ui/react/pull/499))

--- a/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebar.tsx
+++ b/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebar.tsx
@@ -44,11 +44,11 @@ class ComponentSidebar extends React.Component<any, any> {
     return (
       <Sticky context={examplesRef} offset={15}>
         <Menu as={Accordion} fluid style={sidebarStyle} text vertical>
-          {_.map(sections, ({ examples, sectionName }) => (
+          {_.map(sections, ({ examples, sectionName }, index) => (
             <ComponentSidebarSection
               activePath={activePath}
               examples={examples}
-              key={sectionName}
+              key={`${sectionName}-${index}`}
               sectionName={sectionName}
               onItemClick={onItemClick}
             />

--- a/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
@@ -6,41 +6,62 @@ const janeAvatar = {
   status: { color: 'green', icon: 'check' },
 }
 
-const content = (
-  <div>
-    Sure! Let's try one of these places:<br />
-    <a href="#">www.goodFood1.com</a>,<br />
-    <a href="#">www.goodFood2.com</a> or<br />
-    <a href="#">www.goodFood3.com</a>
-  </div>
-)
-
 const items = [
-  <Chat.Message content="Hello" author="John Doe" timestamp="Yesterday, 10:15 PM" mine />,
-  <Chat.Message
-    content="Hi"
-    author="Jane Doe"
-    timestamp="Yesterday, 10:15 PM"
-    avatar={janeAvatar}
-  />,
-  <Chat.Message
-    content="Would you like to grab a lunch?"
-    author="John Doe"
-    timestamp="Yesterday, 10:16 PM"
-    mine
-  />,
-  <Chat.Message
-    content={{ content }}
-    author="Jane Doe"
-    timestamp="Yesterday, 10:15 PM"
-    avatar={janeAvatar}
-  />,
-  <Divider content="Today" type="primary" important />,
-  <Chat.Message content="Let's have a call" author="John Doe" timestamp="Today, 11:15 PM" mine />,
-].map((chatItemContent, index) => ({
-  key: `chat-item-${index}`,
-  content: chatItemContent,
-}))
+  {
+    content: (
+      <Chat.Message content="Hello" author="John Doe" timestamp="Yesterday, 10:15 PM" mine />
+    ),
+    key: 'message-id-1',
+  },
+  {
+    content: (
+      <Chat.Message
+        content="Hi"
+        author="Jane Doe"
+        timestamp="Yesterday, 10:15 PM"
+        avatar={janeAvatar}
+      />
+    ),
+    key: 'message-id-2',
+  },
+  {
+    content: (
+      <Chat.Message
+        content="Would you like to grab a lunch?"
+        author="John Doe"
+        timestamp="Yesterday, 10:16 PM"
+        mine
+      />
+    ),
+    key: 'message-id-3',
+  },
+  {
+    content: (
+      <Chat.Message
+        content="Sure! Let's try the new place downtown"
+        author="Jane Doe"
+        timestamp="Yesterday, 10:15 PM"
+        avatar={janeAvatar}
+      />
+    ),
+    key: 'message-id-4',
+  },
+  {
+    content: <Divider content="Today" type="primary" important />,
+    key: 'message-id-5',
+  },
+  {
+    content: (
+      <Chat.Message
+        content="Let's have a call"
+        author="John Doe"
+        timestamp="Today, 11:15 PM"
+        mine
+      />
+    ),
+    key: 'message-id-6',
+  },
+]
 
 const ChatExample = () => <Chat items={items} />
 

--- a/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
@@ -6,56 +6,41 @@ const janeAvatar = {
   status: { color: 'green', icon: 'check' },
 }
 
+const content = (
+  <div>
+    Sure! Let's try one of these places:<br />
+    <a href="#">www.goodFood1.com</a>,<br />
+    <a href="#">www.goodFood2.com</a> or<br />
+    <a href="#">www.goodFood3.com</a>
+  </div>
+)
+
 const items = [
-  {
-    content: (
-      <Chat.Message content="Hello" author="John Doe" timestamp="Yesterday, 10:15 PM" mine />
-    ),
-  },
-  {
-    content: (
-      <Chat.Message
-        content="Hi"
-        author="Jane Doe"
-        timestamp="Yesterday, 10:15 PM"
-        avatar={janeAvatar}
-      />
-    ),
-  },
-  {
-    content: (
-      <Chat.Message
-        content="Would you like to grab a lunch?"
-        author="John Doe"
-        timestamp="Yesterday, 10:16 PM"
-        mine
-      />
-    ),
-  },
-  {
-    content: (
-      <Chat.Message
-        content="Sure! Let's try the new place downtown"
-        author="Jane Doe"
-        timestamp="Yesterday, 10:15 PM"
-        avatar={janeAvatar}
-      />
-    ),
-  },
-  {
-    content: <Divider content="Today" type="primary" important />,
-  },
-  {
-    content: (
-      <Chat.Message
-        content="Let's have a call"
-        author="John Doe"
-        timestamp="Today, 11:15 PM"
-        mine
-      />
-    ),
-  },
-]
+  <Chat.Message content="Hello" author="John Doe" timestamp="Yesterday, 10:15 PM" mine />,
+  <Chat.Message
+    content="Hi"
+    author="Jane Doe"
+    timestamp="Yesterday, 10:15 PM"
+    avatar={janeAvatar}
+  />,
+  <Chat.Message
+    content="Would you like to grab a lunch?"
+    author="John Doe"
+    timestamp="Yesterday, 10:16 PM"
+    mine
+  />,
+  <Chat.Message
+    content={{ content }}
+    author="Jane Doe"
+    timestamp="Yesterday, 10:15 PM"
+    avatar={janeAvatar}
+  />,
+  <Divider content="Today" type="primary" important />,
+  <Chat.Message content="Let's have a call" author="John Doe" timestamp="Today, 11:15 PM" mine />,
+].map((chatItemContent, index) => ({
+  key: `chat-item-${index}`,
+  content: chatItemContent,
+}))
 
 const ChatExample = () => <Chat items={items} />
 

--- a/docs/src/examples/components/Chat/Types/ChatExample.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatExample.tsx
@@ -6,15 +6,6 @@ const janeAvatar = {
   status: { color: 'green', icon: 'check' },
 }
 
-const content = (
-  <div>
-    Sure! Let's try one of these places:<br />
-    <a href="#">www.goodFood1.com</a>,<br />
-    <a href="#">www.goodFood2.com</a> or<br />
-    <a href="#">www.goodFood3.com</a>
-  </div>
-)
-
 const ChatExample = () => (
   <Chat>
     <Chat.Item>
@@ -38,7 +29,7 @@ const ChatExample = () => (
     </Chat.Item>
     <Chat.Item>
       <Chat.Message
-        content={{ content }}
+        content="Sure! Let's try the new place downtown"
         author="Jane Doe"
         timestamp="Yesterday, 10:15 PM"
         avatar={janeAvatar}

--- a/docs/src/examples/components/Chat/Types/ChatExample.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatExample.tsx
@@ -6,6 +6,15 @@ const janeAvatar = {
   status: { color: 'green', icon: 'check' },
 }
 
+const content = (
+  <div>
+    Sure! Let's try one of these places:<br />
+    <a href="#">www.goodFood1.com</a>,<br />
+    <a href="#">www.goodFood2.com</a> or<br />
+    <a href="#">www.goodFood3.com</a>
+  </div>
+)
+
 const ChatExample = () => (
   <Chat>
     <Chat.Item>
@@ -29,7 +38,7 @@ const ChatExample = () => (
     </Chat.Item>
     <Chat.Item>
       <Chat.Message
-        content="Sure! Let's try the new place downtown"
+        content={{ content }}
         author="Jane Doe"
         timestamp="Yesterday, 10:15 PM"
         avatar={janeAvatar}

--- a/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Chat, Provider } from '@stardust-ui/react'
+
+const janeAvatar = {
+  image: 'public/images/avatar/small/ade.jpg',
+  status: { color: 'green', icon: 'check' },
+}
+
+const slotLabelStyles: any = (label, beforeStyles) => ({
+  position: 'relative',
+  border: '1px solid #000',
+  padding: '12px',
+  ':before': {
+    content: `'${label}'`,
+    position: 'absolute',
+    background: '#000',
+    paddingBottom: '2px',
+    bottom: '-1px',
+    right: '-1px',
+    color: 'white',
+    fontSize: '11px',
+    letterSpacing: '0.1px',
+    lineHeight: '9px',
+    ...beforeStyles,
+  },
+})
+
+const ChatMessageExampleStyled = () => (
+  <Provider
+    theme={{
+      componentStyles: {
+        ChatMessage: {
+          root: { ...slotLabelStyles('root'), backgroundColor: '#2E8B57' },
+          avatar: {
+            ...slotLabelStyles('avatar', { bottom: '-11px' }),
+            backgroundColor: '#FF00FF',
+            padding: 0,
+          },
+          messageBody: { ...slotLabelStyles('messageBody'), backgroundColor: '#87CEFA' },
+          author: { ...slotLabelStyles('author'), backgroundColor: '#E0FFFF' },
+          content: { ...slotLabelStyles('content'), backgroundColor: '#F08080' },
+          timestamp: { ...slotLabelStyles('timestamp'), backgroundColor: '#FFFFE0' },
+        },
+      },
+    }}
+  >
+    <Chat
+      items={[
+        {
+          content: (
+            <Chat.Message
+              content="Style me the way you want!"
+              author="Jane Doe"
+              timestamp="Yesterday, 10:15 PM"
+              avatar={janeAvatar}
+            />
+          ),
+        },
+      ]}
+    />
+  </Provider>
+)
+
+export default ChatMessageExampleStyled

--- a/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
@@ -6,6 +6,15 @@ const janeAvatar = {
   status: { color: 'green', icon: 'check' },
 }
 
+const content = (
+  <div>
+    Sure! Try one of these places:<br />
+    <a href="#">www.goodFood1.com</a>,<br />
+    <a href="#">www.goodFood2.com</a> or<br />
+    <a href="#">www.goodFood3.com</a>
+  </div>
+)
+
 const slotLabelStyles: any = (label, beforeStyles) => ({
   position: 'relative',
   border: '1px solid #000',
@@ -42,15 +51,33 @@ const ChatMessageExampleStyled = () => (
           timestamp: { ...slotLabelStyles('timestamp'), backgroundColor: '#FFFFE0' },
         },
       },
+      componentVariables: {
+        ChatMessage: siteVars => ({
+          messageBody: {
+            focusOutlineColor: siteVars.white,
+          },
+        }),
+      },
     }}
   >
     <Chat
       items={[
         {
-          key: 'chat-item',
           content: (
             <Chat.Message
-              content="Style me the way you want!"
+              content="Hey, do you know any restaurants with good food?"
+              author="John Doe"
+              timestamp="Yesterday, 10:15 PM"
+              mine
+            />
+          ),
+          key: 'message-id-1',
+        },
+        {
+          key: 'message-id-2',
+          content: (
+            <Chat.Message
+              content={{ content }}
               author="Jane Doe"
               timestamp="Yesterday, 10:15 PM"
               avatar={janeAvatar}

--- a/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
@@ -47,6 +47,7 @@ const ChatMessageExampleStyled = () => (
     <Chat
       items={[
         {
+          key: 'chat-item',
           content: (
             <Chat.Message
               content="Style me the way you want!"

--- a/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.tsx
@@ -6,6 +6,15 @@ const janeAvatar = {
   status: { color: 'green', icon: 'check' },
 }
 
+const content = (
+  <div>
+    Sure! Try one of these places:<br />
+    <a href="#">www.goodFood1.com</a>,<br />
+    <a href="#">www.goodFood2.com</a> or<br />
+    <a href="#">www.goodFood3.com</a>
+  </div>
+)
+
 const slotLabelStyles: any = (label, beforeStyles) => ({
   position: 'relative',
   border: '1px solid #000',
@@ -42,12 +51,27 @@ const ChatMessageExampleStyled = () => (
           timestamp: { ...slotLabelStyles('timestamp'), backgroundColor: '#FFFFE0' },
         },
       },
+      componentVariables: {
+        ChatMessage: siteVars => ({
+          messageBody: {
+            focusOutlineColor: siteVars.white,
+          },
+        }),
+      },
     }}
   >
     <Chat>
       <Chat.Item>
         <Chat.Message
-          content="Style me the way you want!"
+          content="Hey, do you know any restaurants with good food?"
+          author="John Doe"
+          timestamp="Yesterday, 10:15 PM"
+          mine
+        />
+      </Chat.Item>
+      <Chat.Item>
+        <Chat.Message
+          content={{ content }}
           author="Jane Doe"
           timestamp="Yesterday, 10:15 PM"
           avatar={janeAvatar}

--- a/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { Chat, Provider } from '@stardust-ui/react'
+
+const janeAvatar = {
+  image: 'public/images/avatar/small/ade.jpg',
+  status: { color: 'green', icon: 'check' },
+}
+
+const slotLabelStyles: any = (label, beforeStyles) => ({
+  position: 'relative',
+  border: '1px solid #000',
+  padding: '12px',
+  ':before': {
+    content: `'${label}'`,
+    position: 'absolute',
+    background: '#000',
+    paddingBottom: '2px',
+    bottom: '-1px',
+    right: '-1px',
+    color: 'white',
+    fontSize: '11px',
+    letterSpacing: '0.1px',
+    lineHeight: '9px',
+    ...beforeStyles,
+  },
+})
+
+const ChatMessageExampleStyled = () => (
+  <Provider
+    theme={{
+      componentStyles: {
+        ChatMessage: {
+          root: { ...slotLabelStyles('root'), backgroundColor: '#2E8B57' },
+          avatar: {
+            ...slotLabelStyles('avatar', { bottom: '-11px' }),
+            backgroundColor: '#FF00FF',
+            padding: 0,
+          },
+          messageBody: { ...slotLabelStyles('messageBody'), backgroundColor: '#87CEFA' },
+          author: { ...slotLabelStyles('author'), backgroundColor: '#E0FFFF' },
+          content: { ...slotLabelStyles('content'), backgroundColor: '#F08080' },
+          timestamp: { ...slotLabelStyles('timestamp'), backgroundColor: '#FFFFE0' },
+        },
+      },
+    }}
+  >
+    <Chat>
+      <Chat.Item>
+        <Chat.Message
+          content="Style me the way you want!"
+          author="Jane Doe"
+          timestamp="Yesterday, 10:15 PM"
+          avatar={janeAvatar}
+        />
+      </Chat.Item>
+    </Chat>
+  </Provider>
+)
+
+export default ChatMessageExampleStyled

--- a/docs/src/examples/components/Chat/Types/index.tsx
+++ b/docs/src/examples/components/Chat/Types/index.tsx
@@ -9,6 +9,11 @@ const Types = () => (
       description="A default Chat."
       examplePath="components/Chat/Types/ChatExample"
     />
+    <ComponentExample
+      title="Styled Chat Item"
+      description="A Chat item with custom styles for every slot."
+      examplePath="components/Chat/Types/ChatMessageExampleStyled"
+    />
   </ExampleSection>
 )
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -48,7 +48,7 @@ class Chat extends UIComponent<Extendable<ChatProps>, any> {
     renderItem: PropTypes.func,
   }
 
-  static defaultProps = { accessibility: chatBehavior as Accessibility, as: 'ul' }
+  static defaultProps = { accessibility: chatBehavior, as: 'ul' }
 
   static Item = ChatItem
   static Message = ChatMessage

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -53,8 +53,8 @@ class Chat extends UIComponent<Extendable<ChatProps>, any> {
   static Item = ChatItem
   static Message = ChatMessage
 
-  actionHandlers: AccessibilityActionHandlers = {
-    focus: event => this.focusZone && this.focusZone.focus(),
+  protected actionHandlers: AccessibilityActionHandlers = {
+    focus: () => this.focusZone && this.focusZone.focus(),
   }
 
   renderComponent({ ElementType, classes, accessibility, rest }) {

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -170,7 +170,6 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
         styles: styles.avatar,
         variables: variables.avatar,
       },
-      generateKey: true,
       render: renderAvatar,
     })
 
@@ -204,10 +203,7 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
     return (
       <>
         {!mine && avatarElement}
-        <Slot
-          key="chat-message-body"
-          className={cx('ui-chat__message__messageBody', classes.messageBody)}
-        >
+        <Slot className={cx('ui-chat__message__messageBody', classes.messageBody)}>
           {!mine && authorElement}
           {timestampElement}
           {contentElement}

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -183,6 +183,7 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
     const timestampElement = Text.create(timestamp, {
       defaultProps: {
         size: 'small',
+        styles: styles.timestamp,
         timestamp: true,
       },
       render: renderTimestamp,

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -112,11 +112,11 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
   }
 
   static defaultProps = {
-    accessibility: chatMessageBehavior as Accessibility,
+    accessibility: chatMessageBehavior,
     as: 'div',
   }
 
-  actionHandlers: AccessibilityActionHandlers = {
+  protected actionHandlers: AccessibilityActionHandlers = {
     // prevents default FocusZone behavior, e.g., in ChatMessageBehavior, it prevents FocusZone from using arrow keys as navigation (only Tab key should work)
     preventDefault: event => {
       event.preventDefault()
@@ -132,7 +132,6 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
     variables,
   }: RenderResultConfig<ChatMessageProps>) {
     const { children } = this.props
-
     const childrenPropExists = childrenExist(children)
     const className = childrenPropExists ? cx(classes.root, classes.content) : classes.root
 
@@ -148,7 +147,7 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
     )
   }
 
-  renderContent = (
+  private renderContent = (
     classes: ComponentSlotClasses,
     styles: ComponentSlotStylesInput,
     variables: ComponentVariablesInput,
@@ -177,7 +176,6 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
       defaultProps: {
         size: 'small',
         styles: styles.author,
-        variables: variables.author,
       },
       render: renderAuthor,
     })
@@ -186,17 +184,12 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
       defaultProps: {
         size: 'small',
         timestamp: true,
-        styles: styles.timestamp,
-        variables: variables.timestamp,
       },
       render: renderTimestamp,
     })
 
     const contentElement = Slot.create(content, {
-      defaultProps: {
-        styles: styles.content,
-        variables: variables.content,
-      },
+      defaultProps: { styles: styles.content },
       render: renderContent,
     })
 

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -18,7 +18,6 @@ import { Extendable, ShorthandRenderFunction, ShorthandValue } from '../../../ty
 import Avatar from '../Avatar/Avatar'
 import { chatMessageBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
-import Layout from '../Layout/Layout'
 import Text from '../Text/Text'
 import Slot from '../Slot/Slot'
 import {
@@ -26,11 +25,7 @@ import {
   ChildrenComponentProps,
   ContentComponentProps,
 } from '../../lib/commonPropInterfaces'
-import {
-  commonUIComponentPropTypes,
-  childrenComponentPropTypes,
-  contentComponentPropsTypes,
-} from '../../lib/commonPropTypes'
+import { commonUIComponentPropTypes, childrenComponentPropTypes } from '../../lib/commonPropTypes'
 
 export interface ChatMessageProps
   extends UIComponentProps<any, any>,
@@ -104,10 +99,10 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
   static propTypes = {
     ...commonUIComponentPropTypes,
     ...childrenComponentPropTypes,
-    ...contentComponentPropsTypes,
     accessibility: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     author: customPropTypes.itemShorthand,
     avatar: customPropTypes.itemShorthand,
+    content: customPropTypes.itemShorthand,
     mine: PropTypes.bool,
     renderAuthor: PropTypes.func,
     renderAvatar: PropTypes.func,
@@ -175,6 +170,7 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
         styles: styles.avatar,
         variables: variables.avatar,
       },
+      generateKey: true,
       render: renderAvatar,
     })
 
@@ -198,29 +194,26 @@ class ChatMessage extends UIComponent<Extendable<ChatMessageProps>, any> {
     })
 
     const contentElement = Slot.create(content, {
-      styles: styles.content,
-      variables: variables.content,
+      defaultProps: {
+        styles: styles.content,
+        variables: variables.content,
+      },
       render: renderContent,
     })
 
     return (
-      <Layout
-        start={!mine && avatarElement}
-        main={
-          <Layout
-            className={classes.content}
-            vertical
-            start={
-              <>
-                {!mine && authorElement}
-                {timestampElement}
-              </>
-            }
-            main={contentElement}
-          />
-        }
-        end={mine && avatarElement}
-      />
+      <>
+        {!mine && avatarElement}
+        <Slot
+          key="chat-message-body"
+          className={cx('ui-chat__message__messageBody', classes.messageBody)}
+        >
+          {!mine && authorElement}
+          {timestampElement}
+          {contentElement}
+        </Slot>
+        {mine && avatarElement}
+      </>
     )
   }
 }

--- a/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -4,9 +4,10 @@ import { ChatMessageVariables } from './chatMessageVariables'
 import { pxToRem } from '../../../../lib'
 
 const px10asRem = pxToRem(10)
+
 const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageVariables> = {
-  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    display: 'inline-block',
+  root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
+    display: 'inline-flex',
     position: 'relative',
     marginTop: '1rem',
     marginBottom: '1rem',
@@ -16,9 +17,16 @@ const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageV
     maxWidth: v.messageWidth,
     wordBreak: 'break-word',
     wordWrap: 'break-word',
+    ':focus': {
+      outline: 'none',
+      '& .ui-chat__message__messageBody': {
+        outline: `.2rem solid ${siteVariables.brand}`,
+      },
+    },
   }),
 
   avatar: ({ props: p }: { props: ChatMessageProps }): ICSSInJSStyle => ({
+    flex: 'none',
     display: p.mine ? 'none' : undefined,
     marginTop: px10asRem,
     marginBottom: px10asRem,
@@ -26,7 +34,7 @@ const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageV
     marginRight: p.mine ? 0 : px10asRem,
   }),
 
-  content: ({ props: p, variables: v }): ICSSInJSStyle => ({
+  messageBody: ({ props: p, variables: v }): ICSSInJSStyle => ({
     padding: '1rem',
     color: 'rgb(64, 64, 64)',
     backgroundColor: p.mine ? v.messageColorMine : v.messageColor,
@@ -36,6 +44,15 @@ const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageV
   author: ({ props: p }): ICSSInJSStyle => ({
     display: p.mine ? 'none' : undefined,
     marginRight: px10asRem,
+  }),
+
+  content: ({ theme: { siteVariables } }): ICSSInJSStyle => ({
+    display: 'block',
+    '& a:focus': {
+      outline: 'none',
+      color: siteVariables.brand,
+      textDecoration: 'underline',
+    },
   }),
 }
 

--- a/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -19,7 +19,7 @@ const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageV
     wordWrap: 'break-word',
     ':focus': {
       outline: 'none',
-      messageBody: {
+      '& .ui-chat__message__messageBody': {
         outline: `.2rem solid ${v.messageBody.focusOutlineColor}`,
       },
     },

--- a/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -6,7 +6,7 @@ import { pxToRem } from '../../../../lib'
 const px10asRem = pxToRem(10)
 
 const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageVariables> = {
-  root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
+  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
     display: 'inline-flex',
     position: 'relative',
     marginTop: '1rem',
@@ -19,8 +19,8 @@ const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageV
     wordWrap: 'break-word',
     ':focus': {
       outline: 'none',
-      '& .ui-chat__message__messageBody': {
-        outline: `.2rem solid ${siteVariables.brand}`,
+      messageBody: {
+        outline: `.2rem solid ${v.messageBody.focusOutlineColor}`,
       },
     },
   }),
@@ -46,11 +46,11 @@ const chatMessageStyles: ComponentSlotStylesInput<ChatMessageProps, ChatMessageV
     marginRight: px10asRem,
   }),
 
-  content: ({ theme: { siteVariables } }): ICSSInJSStyle => ({
+  content: ({ variables: v }): ICSSInJSStyle => ({
     display: 'block',
     '& a:focus': {
       outline: 'none',
-      color: siteVariables.brand,
+      color: v.messageBody.focusOutlineColor,
       textDecoration: 'underline',
     },
   }),

--- a/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -3,6 +3,7 @@ export interface ChatMessageVariables {
   messageColor: string
   messageColorMine: string
   avatar: { statusBorderColor: string }
+  messageBody: { focusOutlineColor: string }
 }
 
 export default (siteVars): ChatMessageVariables => ({
@@ -12,4 +13,5 @@ export default (siteVars): ChatMessageVariables => ({
   avatar: {
     statusBorderColor: siteVars.gray10,
   },
+  messageBody: { focusOutlineColor: siteVars.brand },
 })


### PR DESCRIPTION
# feat(chat): remove layout component and allow styling slots

## Description

This PR includes the following changes:

#### 1. Refactors the render function for `Chat.Message` component to not use `Layout` component
`Layout` component does not allow the users to achieve proper styling of slots and it introduces a lot of unnecessary DOM nodes; we are using `Slot` instead.

#### 2. Reduces the size of the tree for `Chat.Message` by 50% (from 6 to 3):

- before:
![screenshot 2018-11-22 at 16 19 34](https://user-images.githubusercontent.com/5442794/48911506-238ea200-ee73-11e8-8f36-3cba1d57cb4f.png)
- after:
![screenshot 2018-11-22 at 16 18 38](https://user-images.githubusercontent.com/5442794/48911514-28535600-ee73-11e8-9d59-7e299d3272b4.png)

#### 3. Adds functionality for targeting all subcomponents of `Chat.Message`:
- `avatar`;
- `messageBody` than contains `author`, `timestamp` and `content`;

#### 4. Docs example:
For showing the users the `Chat.Message` anatomy and how they can style every slot:
![screenshot 2018-11-22 at 16 16 24](https://user-images.githubusercontent.com/5442794/48911066-00172780-ee72-11e8-939d-3dfdfc4cd858.png)

#### 5. Styles (see short demo below):
  - for focusing the correct area (`messageBody` instead of the whole `Chat.Message`)
  - Teams theme styles for focus outline for `messageBody`;
  - Teams theme styles for focus underline for links.
![key-nav](https://user-images.githubusercontent.com/5442794/48911988-b845cf80-ee74-11e8-8d59-6fa7605577b9.gif)
