### PR TITLE
Fix(Popup): Trigger's props are not passed in onClick handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix styles as functions in shorthands are not applied @mnajdova ([#470](https://github.com/stardust-ui/react/pull/470))
 - Add `lodash` typings and fix compilation errors @Bugaa92 ([#438](https://github.com/stardust-ui/react/pull/438))
 - Remove unsafe `listRef` from `List` API @kuzhelov ([#489](https://github.com/stardust-ui/react/pull/489))
+- Fix Popup trigger's props are not passed in onClick handler ([#521](https://github.com/stardust-ui/react/pull/521))
 
 ### Features
 - Make `Grid` keyboard navigable by implementing `gridBehavior` @sophieH29 ([#398](https://github.com/stardust-ui/react/pull/398))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix styles as functions in shorthands are not applied @mnajdova ([#470](https://github.com/stardust-ui/react/pull/470))
 - Add `lodash` typings and fix compilation errors @Bugaa92 ([#438](https://github.com/stardust-ui/react/pull/438))
 - Remove unsafe `listRef` from `List` API @kuzhelov ([#489](https://github.com/stardust-ui/react/pull/489))
-- Fix Popup trigger's props are not passed in onClick handler ([#521](https://github.com/stardust-ui/react/pull/521))
+- Fix Popup trigger's props are not passed in onClick handler @sophieH29 ([#521](https://github.com/stardust-ui/react/pull/521))
 
 ### Features
 - Make `Grid` keyboard navigable by implementing `gridBehavior` @sophieH29 ([#398](https://github.com/stardust-ui/react/pull/398))

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -209,9 +209,9 @@ export default class Popup extends AutoControlledComponent<Extendable<PopupProps
           }}
         >
           {React.cloneElement(triggerElement, {
-            onClick: e => {
+            onClick: (e, ...rest) => {
               this.trySetOpen(!this.state.open, e)
-              _.invoke(triggerElement, 'props.onClick', e)
+              _.invoke(triggerElement, 'props.onClick', e, ...rest)
             },
             ...accessibility.attributes.trigger,
             ...accessibility.keyHandlers.trigger,


### PR DESCRIPTION
This PR addresses fix for a small issued encountered in Popup

Let's say we have a Popup, with Button component as a trigger

```js
 <Popup
        // you expect on Button's click receive 2 arguments, but recieve only event object
       // props are undefined
        trigger={<Button onClick={(e, props) =>  {}} />}
        content={{ content: <Some content> }}
      />
```

For Button's ```onClick``` you expect to receive 2 arguments, ```event``` and ```props```, but in fact, receive only ```event``` object as popup's handler cut off this from click event pipeline.

Even bigger issue with that can be found, when use ```Popup``` as ```MenuItem```

```js
  <Menu>
     <Menu.Item>
     <Menu.Item>
     <Popup><Menu.Item></Popup>
  </Menu>
```

When click on ```MenuItem```, event firstly propagates to Popup which cut off essential props, then ```Menu``` handles that event and can't find props as arguments.

