### PR TITLE
fix: Remove engines entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,9 +176,6 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },
-  "engines": {
-    "yarn": "^1.10.0"
-  },
   "resolutions": {
     "create-react-context": "0.2.2"
   }


### PR DESCRIPTION
Revert "chore: add engine entry for enforcing yarn > 1.10 to preserve… yarn.lock integrity"

This reverts commit a950fcfa72ec9a45724a36a191bfc2a619d163bc since this was not the proper fix. From @levithomason : 

_The engines field is not used to enforce development yarn versions.  It is used to force your consumers to run your node package on a compatible version of node and NPM.  See the engines docs here: https://docs.npmjs.com/files/package.json#engines._
