### PR TITLE
docs(Label): fix examples with icon

### DIFF
--- a/docs/src/examples/components/Label/Content/LabelExampleIcon.shorthand.tsx
+++ b/docs/src/examples/components/Label/Content/LabelExampleIcon.shorthand.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Label } from '@stardust-ui/react'
 
-const LabelExampleIconShorthand = <Label content="Label with icon" icon="close" />
+const LabelExampleIconShorthand = () => <Label content="Label with icon" icon="close" />
 
 export default LabelExampleIconShorthand

--- a/docs/src/examples/components/Label/Content/LabelExampleIconPosition.shorthand.tsx
+++ b/docs/src/examples/components/Label/Content/LabelExampleIconPosition.shorthand.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Label } from '@stardust-ui/react'
 
-const LabelExampleIconPositionShorthand = (
+const LabelExampleIconPositionShorthand = () => (
   <Label content="Have a coffee!" icon="coffee" iconPosition="start" />
 )
 


### PR DESCRIPTION
Picked from #473.

---

These examples export `React.Element` instead of components. They also were not rendered correctly in Screener.