### PR TITLE
fix(docs): added import in the editor for `react-dom`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- add `react-dom` as available import in the editor @mnajdova ([#553](https://github.com/stardust-ui/react/pull/553))
+
 <!--------------------------------[ v0.13.1 ]------------------------------- -->
 ## [v0.13.1](https://github.com/stardust-ui/react/tree/v0.13.1) (2018-12-03)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.13.0...v0.13.1)

--- a/docs/src/components/Playground/renderConfig.ts
+++ b/docs/src/components/Playground/renderConfig.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash'
 import * as React from 'react'
 import * as Stardust from '@stardust-ui/react'
+import * as ReactDOM from 'react-dom'
 
 export const babelConfig = {
   plugins: ['proposal-class-properties', ['transform-typescript', { isTSX: true }]],
@@ -20,6 +21,7 @@ const imports = {
   '@stardust-ui/react': Stardust,
   lodash: _,
   react: React,
+  'react-dom': ReactDOM,
 }
 
 export const importResolver = importName => imports[importName]


### PR DESCRIPTION
Added react-dom as part of the imports for the editor, as it is used in the Popup examples. Currently we have this error in the docs site:
![image](https://user-images.githubusercontent.com/4512430/49523563-593b7e00-f8aa-11e8-84a5-55698f38c7d7.png)
