### PR TITLE
fix(Editor): fix broken HTML preview when Provider.Consumer was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Add `react-dom` as available import in the editor @mnajdova ([#553](https://github.com/stardust-ui/react/pull/553))
 - Fix incorrect and missing filled or outline versions of Teams SVG icons @codepretty ([#552](https://github.com/stardust-ui/react/pull/552))
+- Fix HTML preview in the editor @layershifter ([#555](https://github.com/stardust-ui/react/pull/555))
 
 ### Features
 - Add `render` callback as an option for shorthand value @kuzhelov ([#519](https://github.com/stardust-ui/react/pull/519))

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -260,6 +260,10 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       return this.renderMissingExample()
     }
 
+    return <SourceRender.Consumer>{({ element }) => element}</SourceRender.Consumer>
+  }
+
+  private renderElement = (element: React.ReactElement<any>) => {
     const { showRtl, componentVariables, themeName } = this.state
     const theme = themes[themeName]
 
@@ -270,11 +274,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       rtl: showRtl,
     }
 
-    return (
-      <Provider theme={newTheme}>
-        <SourceRender.Consumer>{({ element }) => element}</SourceRender.Consumer>
-      </Provider>
-    )
+    return <Provider theme={newTheme}>{element}</Provider>
   }
 
   private renderMissingExample = (): JSX.Element => {
@@ -638,6 +638,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
             babelConfig={babelConfig}
             knobs={knobs}
             source={sourceCode}
+            render={this.renderElement}
             renderHtml={showCode}
             resolver={importResolver}
           >

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "react-hot-loader": "^4.1.3",
     "react-router": "^4.1.2",
     "react-router-dom": "^4.1.2",
-    "react-source-render": "^2.0.0-beta.3",
+    "react-source-render": "^2.0.0-beta.4",
     "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1",
     "satisfied": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8288,10 +8288,10 @@ react-side-effect@^1.0.2:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-source-render@^2.0.0-beta.3:
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/react-source-render/-/react-source-render-2.0.0-beta.3.tgz#9a871c7a5cfd50f994a3b96315e0e46c427df09a"
-  integrity sha512-mYip/OnYs1e2DEjR7TkRpBRkotjpGL40D3ZvlExYlzKZVMIgveYpzdZKzzBESiXHB9e1GHELBbKPUlU8zx8kIQ==
+react-source-render@^2.0.0-beta.4:
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/react-source-render/-/react-source-render-2.0.0-beta.4.tgz#a17be4c23cb1ed5934ee9f3eccdd997f0228152e"
+  integrity sha512-HqyRJebRRznoplp2CwqzIvX6eXVkUBHV3fT8mlsOih3y2hkYuc5SB0nkvmjBQ12VHv1Ekgd8cqnDVOGUf48rfw==
   dependencies:
     deepmerge "^2.2.1"
     fast-memoize "^2.5.1"


### PR DESCRIPTION
This PR fixes broken HTML preview for examples that using `Provider.Consumer`, it happens because `renderToStaticMarkup()` was done without `Provider`.

![image](https://user-images.githubusercontent.com/14183168/49442691-f1feca80-f7d2-11e8-9fe0-b637b13187aa.png)
