### PR TITLE
fix(docs): EDGE could not open the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Decouple `pxToRem` from HTML page's font size @kuzhelov ([#371](https://github.com/stardust-ui/react/pull/371))
 - The border color of the Icon is inherited if no value is provided for the `color` and `borderColor` variables @mnajdova ([#569](https://github.com/stardust-ui/react/pull/569))
 - Do not focus `Popup`'s trigger on outside click @sophieH29 ([#578](https://github.com/stardust-ui/react/pull/578))
+- Add `https` protocol to all urls used in the scripts and stylesheets in index.ejs @mnajdova ([#571](https://github.com/stardust-ui/react/pull/571))
 
 ### Features
 - `Ref` components uses `forwardRef` API by default @layershifter ([#491](https://github.com/stardust-ui/react/pull/491))

--- a/docs/src/index.ejs
+++ b/docs/src/index.ejs
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" type="image/x-icon" href='<%= __BASENAME__ + 'logo.png' %>'/>
   <link rel="stylesheet"
-        href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/<%= htmlWebpackPlugin.options.versions.sui %>/semantic.min.css">
+        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/<%= htmlWebpackPlugin.options.versions.sui %>/semantic.min.css">
   <title>Stardust</title>
   <script>
     // Redirect to HTTPs
@@ -26,24 +26,24 @@
   </script>
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.1/anchor.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.1/anchor.min.js"></script>
   <script
-    src="//unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/standalone.js"
+    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/standalone.js"
   ></script>
   <script
-    src="//unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-babylon.js"
+    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-babylon.js"
   ></script>
   <script
-    src="//unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-html.js"
+    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-html.js"
   ></script>
   <!-- Use unminified React when not in production so we get errors and warnings -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/prop-types/<%= htmlWebpackPlugin.options.versions.propTypes %>/prop-types<%= __PROD__ ? '.min' : '' %>.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.react %>/umd/react<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/react-dom/<%= htmlWebpackPlugin.options.versions.reactDOM %>/umd/react-dom<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/react-dom/<%= htmlWebpackPlugin.options.versions.reactDOM %>/umd/react-dom-server.browser<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/<%= htmlWebpackPlugin.options.versions.propTypes %>/prop-types<%= __PROD__ ? '.min' : '' %>.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.react %>/umd/react<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/<%= htmlWebpackPlugin.options.versions.reactDOM %>/umd/react-dom<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/<%= htmlWebpackPlugin.options.versions.reactDOM %>/umd/react-dom-server.browser<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
 
-  <script src="//cdn.jsdelivr.net/npm/@babel/standalone@7/babel.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/@babel/preset-env-standalone@7/babel-preset-env.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7/babel.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/preset-env-standalone@7/babel-preset-env.js"></script>
 
   <style>
     html, body {

--- a/docs/src/index.ejs
+++ b/docs/src/index.ejs
@@ -28,12 +28,15 @@
 <body>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.1/anchor.min.js"></script>
   <script
+    crossOrigin="anonymous"
     src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/standalone.js"
   ></script>
   <script
+    crossOrigin="anonymous"
     src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-babylon.js"
   ></script>
   <script
+    crossOrigin="anonymous"
     src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-html.js"
   ></script>
   <!-- Use unminified React when not in production so we get errors and warnings -->

--- a/docs/src/index.ejs
+++ b/docs/src/index.ejs
@@ -28,15 +28,12 @@
 <body>
   <script src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.1/anchor.min.js"></script>
   <script
-    crossOrigin="true"
     src="//unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/standalone.js"
   ></script>
   <script
-    crossOrigin="true"
     src="//unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-babylon.js"
   ></script>
   <script
-    crossOrigin="true"
     src="//unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-html.js"
   ></script>
   <!-- Use unminified React when not in production so we get errors and warnings -->


### PR DESCRIPTION
Removed crossOrigin='true' from the new added `script` tags in `index.ejs`, because edge has some issues with those, resulting in - **the docs can't be opened in edge**. If there is some solid reason why these were added, please let me know. @levithomason @miroslavstastny @kolaps33 