### PR TITLE
feat(Icons): mark Processed Icons moved to Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - `Ref` components uses `forwardRef` API by default @layershifter ([#491](https://github.com/stardust-ui/react/pull/491))
+- Label Processed Teams icons moved to Stardust theme @kuzhelov ([#574](https://github.com/stardust-ui/react/pull/574))
 
 ### Documentation
 - Add `prettier` support throughout the docs @levithomason  ([#568](https://github.com/stardust-ui/react/pull/568))

--- a/docs/src/prototypes/IconViewer/index.tsx
+++ b/docs/src/prototypes/IconViewer/index.tsx
@@ -3,7 +3,7 @@ import { Provider, Grid, Divider, Header, Icon } from '@stardust-ui/react'
 import themeWithProcessedIcons from 'src/themes/teams/withProcessedIcons'
 import { TeamsProcessedSvgIconSpec } from 'src/themes/teams/components/Icon/svg/types'
 
-import { Menu } from 'semantic-ui-react'
+import { Menu, Segment } from 'semantic-ui-react'
 
 const cellStyles = {
   margin: '10px 0',
@@ -40,7 +40,7 @@ class IconViewerExample extends React.Component<any, {}> {
 
   render() {
     return (
-      <div style={{ margin: '20px' }}>
+      <Segment styles={{ padding: '30px' }}>
         <Header
           as="h3"
           content="Teams Icons"
@@ -51,10 +51,11 @@ class IconViewerExample extends React.Component<any, {}> {
           }}
         />
 
-        <div>
-          <Menu pointing tabular>
+        <div style={{ marginTop: '15px' }}>
+          <Menu tabular style={{ margin: '15px 0' }}>
             {Object.keys(this.iconFilters).map(filterName => (
               <Menu.Item
+                key={filterName}
                 name={filterName}
                 active={this.state.filter === filterName}
                 onClick={() => this.setState({ filter: filterName })}
@@ -67,9 +68,7 @@ class IconViewerExample extends React.Component<any, {}> {
               render={theme => (
                 <div>
                   <div>
-                    <Divider>
-                      <Header as="h3" content="Regular" />
-                    </Divider>
+                    <Header as="h3" content="Regular" textAlign="center" />
                     <Grid columns={4} style={{ textAlign: 'center' }}>
                       {Object.keys(theme.icons)
                         .filter(name => name.startsWith(processedIconsNamePrefix))
@@ -88,7 +87,7 @@ class IconViewerExample extends React.Component<any, {}> {
                   </div>
                   <div>
                     <Divider>
-                      <Header as="h3" content="Outline" />
+                      <Header as="h3" content="Outline" textAlign="center" />
                     </Divider>
                     <Grid columns={4} style={{ textAlign: 'center' }}>
                       {Object.keys(theme.icons)
@@ -111,7 +110,7 @@ class IconViewerExample extends React.Component<any, {}> {
             />
           </Provider>
         </div>
-      </div>
+      </Segment>
     )
   }
 }

--- a/docs/src/prototypes/IconViewer/index.tsx
+++ b/docs/src/prototypes/IconViewer/index.tsx
@@ -8,6 +8,17 @@ const cellStyles = {
 
 const processedIconsNamePrefix = 'processedIcons_'
 
+const renderStardustIconName = (icon, isOutline = false) => {
+  const maybeExportedAs = (icon as any).exportedAs
+  return (
+    maybeExportedAs && (
+      <code style={{ color: 'red' }}>
+        => {maybeExportedAs} {isOutline && 'outline'}
+      </code>
+    )
+  )
+}
+
 class IconViewerExample extends React.Component<any, {}> {
   render() {
     return (
@@ -38,6 +49,8 @@ class IconViewerExample extends React.Component<any, {}> {
                           <Icon name={name} />
                           <br />
                           <code>{name.replace(processedIconsNamePrefix, '')}</code>
+                          <br />
+                          {renderStardustIconName(theme.icons[name])}
                         </div>
                       ))}
                   </Grid>
@@ -55,6 +68,8 @@ class IconViewerExample extends React.Component<any, {}> {
                           <Icon name={name} variables={{ outline: true }} />
                           <br />
                           <code>{name.replace(processedIconsNamePrefix, '')} outline</code>
+                          <br />
+                          {renderStardustIconName(theme.icons[name], /* isOutline */ true)}
                         </div>
                       ))}
                   </Grid>

--- a/docs/src/prototypes/IconViewer/index.tsx
+++ b/docs/src/prototypes/IconViewer/index.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { Provider, Grid, Divider, Header, Icon } from '@stardust-ui/react'
 import themeWithProcessedIcons from 'src/themes/teams/withProcessedIcons'
+import { TeamsProcessedSvgIconSpec } from 'src/themes/teams/components/Icon/svg/types'
+
+import { Menu } from 'semantic-ui-react'
 
 const cellStyles = {
   margin: '10px 0',
@@ -20,6 +23,21 @@ const renderStardustIconName = (icon, isOutline = false) => {
 }
 
 class IconViewerExample extends React.Component<any, {}> {
+  private readonly iconFilters = {
+    All: () => true,
+    Exported: (icon: TeamsProcessedSvgIconSpec) => icon.exportedAs,
+    'Not Exported': (icon: TeamsProcessedSvgIconSpec) => !icon.exportedAs,
+  }
+
+  state = {
+    filter: 'All',
+  }
+
+  applyCurrentFilter(icon) {
+    const currentFilter = this.iconFilters[this.state.filter]
+    return currentFilter(icon)
+  }
+
   render() {
     return (
       <div style={{ margin: '20px' }}>
@@ -32,52 +50,67 @@ class IconViewerExample extends React.Component<any, {}> {
             styles: { fontSize: '16px' },
           }}
         />
-        <Provider theme={themeWithProcessedIcons}>
-          <Provider.Consumer
-            render={theme => (
-              <div>
+
+        <div>
+          <Menu pointing tabular>
+            {Object.keys(this.iconFilters).map(filterName => (
+              <Menu.Item
+                name={filterName}
+                active={this.state.filter === filterName}
+                onClick={() => this.setState({ filter: filterName })}
+              />
+            ))}
+          </Menu>
+
+          <Provider theme={themeWithProcessedIcons}>
+            <Provider.Consumer
+              render={theme => (
                 <div>
-                  <Divider>
-                    <Header as="h3" content="Regular" />
-                  </Divider>
-                  <Grid columns={4} style={{ textAlign: 'center' }}>
-                    {Object.keys(theme.icons)
-                      .filter(name => name.startsWith(processedIconsNamePrefix))
-                      .sort()
-                      .map(name => (
-                        <div key={name} style={cellStyles}>
-                          <Icon name={name} />
-                          <br />
-                          <code>{name.replace(processedIconsNamePrefix, '')}</code>
-                          <br />
-                          {renderStardustIconName(theme.icons[name])}
-                        </div>
-                      ))}
-                  </Grid>
+                  <div>
+                    <Divider>
+                      <Header as="h3" content="Regular" />
+                    </Divider>
+                    <Grid columns={4} style={{ textAlign: 'center' }}>
+                      {Object.keys(theme.icons)
+                        .filter(name => name.startsWith(processedIconsNamePrefix))
+                        .filter(name => this.applyCurrentFilter(theme.icons[name]))
+                        .sort()
+                        .map(name => (
+                          <div key={name} style={cellStyles}>
+                            <Icon name={name} />
+                            <br />
+                            <code>{name.replace(processedIconsNamePrefix, '')}</code>
+                            <br />
+                            {renderStardustIconName(theme.icons[name])}
+                          </div>
+                        ))}
+                    </Grid>
+                  </div>
+                  <div>
+                    <Divider>
+                      <Header as="h3" content="Outline" />
+                    </Divider>
+                    <Grid columns={4} style={{ textAlign: 'center' }}>
+                      {Object.keys(theme.icons)
+                        .filter(name => name.startsWith(processedIconsNamePrefix))
+                        .filter(name => this.applyCurrentFilter(theme.icons[name]))
+                        .sort()
+                        .map(name => (
+                          <div key={`${name}-outline`} style={cellStyles}>
+                            <Icon name={name} variables={{ outline: true }} />
+                            <br />
+                            <code>{name.replace(processedIconsNamePrefix, '')} outline</code>
+                            <br />
+                            {renderStardustIconName(theme.icons[name], /* isOutline */ true)}
+                          </div>
+                        ))}
+                    </Grid>
+                  </div>
                 </div>
-                <div>
-                  <Divider>
-                    <Header as="h3" content="Outline" />
-                  </Divider>
-                  <Grid columns={4} style={{ textAlign: 'center' }}>
-                    {Object.keys(theme.icons)
-                      .filter(name => name.startsWith(processedIconsNamePrefix))
-                      .sort()
-                      .map(name => (
-                        <div key={`${name}-outline`} style={cellStyles}>
-                          <Icon name={name} variables={{ outline: true }} />
-                          <br />
-                          <code>{name.replace(processedIconsNamePrefix, '')} outline</code>
-                          <br />
-                          {renderStardustIconName(theme.icons[name], /* isOutline */ true)}
-                        </div>
-                      ))}
-                  </Grid>
-                </div>
-              </div>
-            )}
-          />
-        </Provider>
+              )}
+            />
+          </Provider>
+        </div>
       </div>
     )
   }

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-accept.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-accept.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-add-participant.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-add-participant.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'participant-add',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-add.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-add.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'add',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-analytics.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-analytics.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-apps.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-apps.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-archive.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-archive.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-down.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-down.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-left.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-left.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-right.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-right.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-up-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-up-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-up.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-arrow-up.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-assignments.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-assignments.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-attachment.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-attachment.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-audio.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-audio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-backspace.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-backspace.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-badge-add.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-badge-add.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -19,4 +19,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-badge.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-badge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bell-mute.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bell-mute.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bell.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-block.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-block.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-blur-background.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-blur-background.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bold.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bold.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bookmark.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'bookmark',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bot.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -13,4 +13,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-broadcast-view-fullscreen.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-broadcast-view-fullscreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-broadcast-view-left.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-broadcast-view-left.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-broadcast-view-right.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-broadcast-view-right.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bullets.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-bullets.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'bullets',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-calendar.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-calendar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'calendar',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-admit-all.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-admit-all.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-alert.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-alert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-audio.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-audio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-blocked.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-blocked.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-control-present-new.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-control-present-new.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'call-control-present-new',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-control-stop-presenting-new.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-control-stop-presenting-new.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'call-control-stop-presenting-new',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-dialpad.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-dialpad.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-end.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-end.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'call-end',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-hold.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-hold.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-incoming-video.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-incoming-video.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-meetup-filled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-meetup-filled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-meetup-line.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-meetup-line.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-microphone-off-filled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-microphone-off-filled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-microphone-unmuting.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-microphone-unmuting.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-missed-line-filled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-missed-line-filled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-missed-line.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-missed-line.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-missed.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-missed.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-connected.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-connected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-connecting-line.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-connecting-line.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-connecting.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-connecting.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-ending.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-ending.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-failed.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-failed.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-incoming-line.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-incoming-line.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-incoming.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-incoming.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-onhold.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-participant-onhold.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-pstn-full.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-pstn-full.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-pstn.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-pstn.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-recording.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-recording.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-switch-camera.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-switch-camera.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-transfer-notification.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-transfer-notification.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-transfer.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-transfer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video-filled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video-filled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video-line-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video-line-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'call-video-off',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video-line.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video-line.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call-video.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'call-video',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-call.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'call',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-canvas-addpage.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-canvas-addpage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-changename.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-changename.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -12,4 +12,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-channel-icon.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-channel-icon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -12,4 +12,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chat.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chat.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-checkbox-selected.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-checkbox-selected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-checkbox-unselected.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-checkbox-unselected.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevron-down.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevron-down.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevron-left.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevron-left.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevron-right.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevron-right.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevronmed-left.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevronmed-left.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevronmed-right.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chevronmed-right.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chrome-maximize.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chrome-maximize.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chrome-minimize.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chrome-minimize.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chrome-unmaximize.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-chrome-unmaximize.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-close.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-close.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-closed-caption.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-closed-caption.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-code.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-code.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-codesnippet.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-codesnippet.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-collapse.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-collapse.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose-ext-menu-item.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose-ext-menu-item.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose-extension-pin.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose-extension-pin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose-extension-unpin.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose-extension-unpin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-compose.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -19,4 +19,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-connector-badge.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-connector-badge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-contact-list.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-contact-list.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-copy.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-copy.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-cortana.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-cortana.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -12,4 +12,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-desktop.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-desktop.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-document.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-document.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -19,4 +19,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-download.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-download.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-downloaded.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-downloaded.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -19,4 +19,4 @@ export default {
       fill: v.secondaryColor,
     }),
   },
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-dropdown.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-dropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-edit.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-edit.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'edit',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-email.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-email.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-emoji.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-emoji.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-error.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-error.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
       fill: v.redColor,
     }),
   },
-} as TeamsSvgIconSpec
+  exportedAs: 'error',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-expand.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-expand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-eye-friendlier.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-eye-friendlier.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-eye-slash.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-eye-slash.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-eye.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-eye.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-faq.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-faq.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -16,4 +16,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-feedback.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-feedback.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-aftereffects.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-aftereffects.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-document.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-document.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-error-full.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-error-full.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-flash.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-flash.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-illustrator.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-illustrator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-indesign.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-indesign.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-link.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-missing.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-missing.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-photoshop.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-photoshop.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-sound.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-sound.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-upload-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-upload-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-upload.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files-upload.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-files.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-filter.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-filter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -14,4 +14,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder-download.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder-download.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder-new.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder-new.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder-upload.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder-upload.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-folder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -24,4 +24,4 @@ export default {
       fill: '#efd084',
     }),
   },
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-follow-channel.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-follow-channel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -13,4 +13,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-font-color.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-font-color.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'font-color',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-font-size.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-font-size.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'font-size',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-format.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-format.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'format',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-fullscreen.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-fullscreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -16,4 +16,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-gallery.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-gallery.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -19,4 +19,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'gallery',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-gettingstarted.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-gettingstarted.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-gif.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-gif.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-giphy.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-giphy.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'giphy',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-groups.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-groups.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-headset.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-headset.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-helparticle.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-helparticle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-highlight.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-highlight.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'highlight',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-hive.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-hive.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-home.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-home.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-image.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-image.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-indicator.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-indicator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-inferred.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-inferred.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-info.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-info.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-input-invalid.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-input-invalid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-input-valid.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-input-valid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-accepted.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-accepted.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-cancelled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-cancelled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-declined.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-declined.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-not-responded.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-not-responded.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-person.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-person.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-tentative.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-invite-tentative.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-italic.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-italic.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-keyboard.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-keyboard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -20,4 +20,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-kollective.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-kollective.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-leave.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-leave.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'leave',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-like.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-like.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-liked.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-liked.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'like',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-link.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-location-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-location-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-location.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-location.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-lock-14.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-lock-14.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-lock-18.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-lock-18.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-lock.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-lock.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-manage-teams.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-manage-teams.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mark-as-read.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mark-as-read.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mark-as-unread.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mark-as-unread.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'mark-as-unread',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-media-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-media-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-meeting-new.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-meeting-new.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-meeting-notes.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-meeting-notes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-megaphone.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-megaphone.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mention.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mention.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'mention',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-menu-light.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-menu-light.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-menu.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-menu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'menu',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mic-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mic-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'mic-off',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mic.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mic.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'mic',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-more.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-more.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'more',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mov.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mov.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-move.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-move.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-canvas.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-canvas.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-delve.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-delve.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-exchange.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-exchange.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-office.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-office.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-onedrive.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-onedrive.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-onenote-online.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-onenote-online.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-onenote.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-onenote.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-outlook-colored.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-outlook-colored.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-outlook.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-outlook.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-planner.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-planner.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -12,4 +12,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-powerbi.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-powerbi.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-ppt-online.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-ppt-online.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-ppt.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-ppt.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-sharepoint.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-sharepoint.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-sp-doc-library.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-sp-doc-library.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-stream.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-stream.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-teams.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-teams.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-visio.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-visio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-word-online.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-word-online.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-word.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-word.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-xl-online.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-xl-online.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-xl.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-msft-xl.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mutechat.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-mutechat.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-my-activity.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-my-activity.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-new-contactgroup.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-new-contactgroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-newtab.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-newtab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-no-chat.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-no-chat.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-notes.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-notes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -16,4 +16,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-notification-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-notification-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-number-list.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-number-list.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-onenote-section.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-onenote-section.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -12,4 +12,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-oof.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-oof.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-external-link-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-external-link-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-inside-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-inside-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-inside.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-inside.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-new-window-filled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-new-window-filled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-new-window.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-new-window.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-outside.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-open-outside.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-org-wide.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-org-wide.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-org.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-org.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-outline.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-outline.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -20,4 +20,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-participant-remove.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-participant-remove.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'participant-remove',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-paste.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-paste.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-patharrow.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-patharrow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pc-audio-stop.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pc-audio-stop.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pc-audio.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pc-audio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pdf.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pdf.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-person.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-person.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pin.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-pin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play-forward.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play-forward.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play-pause.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play-pause.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play-sound-mute.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play-sound-mute.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-play.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-plus-circled.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-plus-circled.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-promoted.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-promoted.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-qna.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-qna.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-quick-response.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-quick-response.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-quote.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-quote.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-read-aloud.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-read-aloud.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-recent.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-recent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-recents.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-recents.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -11,4 +11,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-recurrence.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-recurrence.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-redbang.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-redbang.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'redbang',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-refresh.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-refresh.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-reply.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-reply.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'reply',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-reset-zoom.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-reset-zoom.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-retry.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-retry.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'retry',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-roster.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-roster.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-screen-zoom-in.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-screen-zoom-in.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-screen-zoom-out.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-screen-zoom-out.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-search.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-search.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-send.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-send.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'send',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-settings.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-settings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -16,4 +16,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-sfb-viewbox-32.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-sfb-viewbox-32.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -14,4 +14,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-share-object.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-share-object.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-share.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-share.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-sketch.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-sketch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-speaker-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-speaker-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -13,4 +13,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-speaker-slashed.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-speaker-slashed.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -10,4 +10,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-star.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-star.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-starred.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-starred.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-status-yo.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-status-yo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-sticker.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-sticker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-tab-badge.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-tab-badge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-table-add.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-table-add.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-table-delete.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-table-delete.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -21,4 +21,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-table.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-table.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -19,4 +19,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-team-create.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-team-create.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'team-create',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-team-discover.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-team-discover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -15,4 +15,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-teams.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-teams.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'teams',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-tentative.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-tentative.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-time-zone-day.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-time-zone-day.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -18,4 +18,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-time-zone-night.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-time-zone-night.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-translation.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-translation.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'translation',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-trash-can.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-trash-can.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'trash-can',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-trending.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-trending.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-diagonal-right-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-diagonal-right-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-down-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-down-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-right-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-right-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-up-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-up-small.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-txt.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-txt.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-underline.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-underline.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-unfollow-channel.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-unfollow-channel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -13,4 +13,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-urgent.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-urgent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-video-off.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-video-off.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-video.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-video.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-voicemail.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-voicemail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-waffle.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-waffle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-website.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-website.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-whiteboard.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-whiteboard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -17,4 +17,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-yammer.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-yammer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -8,4 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-youtube.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-youtube.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -9,4 +9,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-zip.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-zip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -12,4 +12,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-zoom-in.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-zoom-in.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -16,4 +16,4 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-zoom-out.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-zoom-out.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
@@ -16,4 +16,5 @@ export default {
     </svg>
   ),
   styles: {},
-} as TeamsSvgIconSpec
+  exportedAs: 'foo',
+} as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/index.ts
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/index.ts
@@ -1,4 +1,4 @@
-import { TeamsSvgIconSpec } from '../types'
+import { TeamsProcessedSvgIconSpec } from '../types'
 
 // IMPORTS
 import processedIcons_zoomout from './icons-zoom-out'
@@ -592,4 +592,4 @@ export default {
   processedIcons_addparticipant,
   processedIcons_add,
   processedIcons_accept,
-} as { [iconName: string]: TeamsSvgIconSpec }
+} as { [iconName: string]: TeamsProcessedSvgIconSpec }

--- a/src/themes/teams/components/Icon/svg/processedIndex.ts
+++ b/src/themes/teams/components/Icon/svg/processedIndex.ts
@@ -1,4 +1,4 @@
 import svgIconsAndStyles from './ProcessedIcons'
-import { TeamsSvgIconSpec } from './types'
+import { TeamsProcessedSvgIconSpec } from './types'
 
-export default svgIconsAndStyles as { [iconName: string]: TeamsSvgIconSpec }
+export default svgIconsAndStyles as { [iconName: string]: TeamsProcessedSvgIconSpec }

--- a/src/themes/teams/components/Icon/svg/types.d.ts
+++ b/src/themes/teams/components/Icon/svg/types.d.ts
@@ -8,3 +8,9 @@ type SvgIconSpecWithStyles = {
 }
 
 export type TeamsSvgIconSpec = SvgIconSpec | SvgIconSpecWithStyles
+
+// TEMPORARY, till the moment when all necessary Teams icons will be moved
+// to this Stardust theme
+export type TeamsProcessedSvgIconSpec = SvgIconSpecWithStyles & {
+  exportedAs?: string
+}

--- a/src/themes/teams/withProcessedIcons.ts
+++ b/src/themes/teams/withProcessedIcons.ts
@@ -1,15 +1,19 @@
-import { ThemeInput, ThemeIconSpec, ThemeIcons, SvgIconSpec } from '../types'
+import { ThemeInput, ThemeIcons, ThemeIconSpec, SvgIconSpec } from '../types'
 
 import { default as svgIconsAndStyles } from './components/Icon/svg/ProcessedIcons'
-import { TeamsSvgIconSpec, SvgIconSpecWithStyles } from './components/Icon/svg/types'
+import { TeamsProcessedSvgIconSpec, SvgIconSpecWithStyles } from './components/Icon/svg/types'
 
-const declareSvg = (svgIcon: SvgIconSpec): ThemeIconSpec => ({
+type ThemeProcessedIconSpec = ThemeIconSpec &
+  { [K in keyof TeamsProcessedSvgIconSpec]?: TeamsProcessedSvgIconSpec[K] }
+
+const declareSvg = (svgIcon: SvgIconSpec, exportedAs?: string): ThemeProcessedIconSpec => ({
   isSvg: true,
   icon: svgIcon,
+  exportedAs,
 })
 
 const processedIcons: ThemeIcons = Object.keys(svgIconsAndStyles as {
-  [iconName: string]: TeamsSvgIconSpec
+  [iconName: string]: TeamsProcessedSvgIconSpec
 }).reduce<ThemeIcons>((accIcons, iconName) => {
   const iconAndMaybeStyles = svgIconsAndStyles[iconName]
 
@@ -17,7 +21,10 @@ const processedIcons: ThemeIcons = Object.keys(svgIconsAndStyles as {
     ? (iconAndMaybeStyles as SvgIconSpecWithStyles).icon
     : (iconAndMaybeStyles as SvgIconSpec)
 
-  return { ...accIcons, ...{ [iconName]: declareSvg(icon) } }
+  return {
+    ...accIcons,
+    ...{ [iconName]: declareSvg(icon, (iconAndMaybeStyles as any).exportedAs) },
+  }
 }, {})
 
 const theme: ThemeInput = { icons: processedIcons }


### PR DESCRIPTION
This PR introduces necessary mapping for Processed Icons that will be exported by Teams theme. This will help to address the following concerns:
- **separate this problem from the core Stardust logic**
- introduce the necessary tracking mechanism for Teams theme

## TODO
- [x] introduce filtering functionality for Processed Icons page
- [x] update changelog

## How it will look like

![image](https://user-images.githubusercontent.com/9024564/49668038-3e5d3b00-fa5d-11e8-94eb-8db0cfa14381.png)


## With Filtering

![image](https://user-images.githubusercontent.com/9024564/49668048-46b57600-fa5d-11e8-8b9e-e1329f1e0f7b.png)


## Review hint
Changes provided in `icons-*` files are only about introducing type correctness - and those are identical for each of these `icons-*`.