### PR TITLE
fix(Prototype): new "render" functionality broke an Attachment prototype

### DIFF
--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -105,8 +105,7 @@ function createMessageContentWithAttachments(content: string, messageId: string)
             icon="file word outline"
             aria-label={`File attachment ${fileName}. Press tab for more options Press Enter to open the file`}
             header={fileName}
-            action={{ icon: 'ellipsis horizontal' }}
-            renderAction={() => actionPopup}
+            action={render => render(actionPopup)}
             data-is-focusable={true}
             styles={{
               '&:focus': {


### PR DESCRIPTION
Fix Attachment prototype after introduced broken changes of 'render' functionality.