### PR TITLE
fix(docs): component styles in RTL mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Do not focus `Popup`'s trigger on outside click @sophieH29 ([#578](https://github.com/stardust-ui/react/pull/578))
 - Add `https` protocol to all urls used in the scripts and stylesheets in index.ejs @mnajdova ([#571](https://github.com/stardust-ui/react/pull/571))
 - Fix support for fallback values in styles (`color: ['#ccc', 'rgba(0, 0, 0, 0.5)']`) @miroslavstastny ([#573](https://github.com/stardust-ui/react/pull/573))
+- Fix styles for RTL mode of doc site component examples @kuzhelov ([#579](https://github.com/stardust-ui/react/pull/579))
 
 ### Features
 - `Ref` components uses `forwardRef` API by default @layershifter ([#491](https://github.com/stardust-ui/react/pull/491))

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -55,10 +55,6 @@ const codeTypeApiButtonLabels: { [key in SourceCodeType]: string } = {
 
 const disabledStyle = { opacity: 0.5, pointerEvents: 'none' }
 
-const getComponentExampleElementKey = (examplePath, isRtl) => {
-  return `${examplePath}${isRtl ? '-rtl' : ''}`
-}
-
 /**
  * Renders a `component` and the raw `code` that produced it.
  * Allows toggling the the raw `code` code block.
@@ -254,7 +250,9 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
   }
 
   renderElement = (element: React.ReactElement<any>) => {
+    const { examplePath } = this.props
     const { showRtl, componentVariables, themeName } = this.state
+
     const theme = themes[themeName]
 
     const newTheme: ThemeInput = {
@@ -265,10 +263,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
     }
 
     return (
-      <Provider
-        key={getComponentExampleElementKey(this.props.examplePath, this.state.showRtl)}
-        theme={newTheme}
-      >
+      <Provider key={`${examplePath}${showRtl ? '-rtl' : ''}`} theme={newTheme}>
         {element}
       </Provider>
     )

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -55,10 +55,9 @@ const codeTypeApiButtonLabels: { [key in SourceCodeType]: string } = {
 
 const disabledStyle = { opacity: 0.5, pointerEvents: 'none' }
 
-const generateRandomKey = () =>
-  Math.random()
-    .toString(36)
-    .substring(7)
+const getComponentExampleElementKey = (examplePath, isRtl) => {
+  return `${examplePathToHash(examplePath)}${isRtl ? '-rtl' : ''}`
+}
 
 /**
  * Renders a `component` and the raw `code` that produced it.
@@ -266,7 +265,10 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
     }
 
     return (
-      <Provider key={generateRandomKey()} theme={newTheme}>
+      <Provider
+        key={getComponentExampleElementKey(this.props.examplePath, this.state.showRtl)}
+        theme={newTheme}
+      >
         {element}
       </Provider>
     )

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -55,6 +55,11 @@ const codeTypeApiButtonLabels: { [key in SourceCodeType]: string } = {
 
 const disabledStyle = { opacity: 0.5, pointerEvents: 'none' }
 
+const generateRandomKey = () =>
+  Math.random()
+    .toString(36)
+    .substring(7)
+
 /**
  * Renders a `component` and the raw `code` that produced it.
  * Allows toggling the the raw `code` code block.
@@ -260,7 +265,11 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       rtl: showRtl,
     }
 
-    return <Provider theme={newTheme}>{element}</Provider>
+    return (
+      <Provider key={generateRandomKey()} theme={newTheme}>
+        {element}
+      </Provider>
+    )
   }
 
   renderMissingExample = (): JSX.Element => {

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -56,7 +56,7 @@ const codeTypeApiButtonLabels: { [key in SourceCodeType]: string } = {
 const disabledStyle = { opacity: 0.5, pointerEvents: 'none' }
 
 const getComponentExampleElementKey = (examplePath, isRtl) => {
-  return `${examplePathToHash(examplePath)}${isRtl ? '-rtl' : ''}`
+  return `${examplePath}${isRtl ? '-rtl' : ''}`
 }
 
 /**


### PR DESCRIPTION
Currently all the component styles are broken for docs in RTL mode. This PR fixes this problem.

## TODO
- [x] update changelog

## What was the issue

The root cause of that is the fact that Fela updates subscription to the DOM node where styles should be rendered to (i.e `<head> -> <styles>`) **only** on its Provider component being mounted.

It turns out that our rendering loigc hasn't guaranteed that new Fela's `Provider` will be mounted with RTL switch - and, this, the logic of <style> DOM node subscription wasn't fired for RTL renderer.

### Fixes: #582 

### Follow-up, general issue: #581 