### PR TITLE
chore(docgen): remove `constructorName` property

### DIFF
--- a/build/gulp/plugins/util/getComponentInfo.ts
+++ b/build/gulp/plugins/util/getComponentInfo.ts
@@ -46,10 +46,6 @@ const getComponentInfo = (filepath: string, checksum?: string) => {
   // add checksum
   info.checksum = checksum
 
-  // add exported Component info
-  const Component = require(absPath).default
-  info.constructorName = _.get(Component, 'prototype.constructor.name', null)
-
   // add component type
   info.type = componentType
 

--- a/build/gulp/tasks/generate/templates/test-specs-components/$DisplayName/$DisplayName-test.tsx
+++ b/build/gulp/tasks/generate/templates/test-specs-components/$DisplayName/$DisplayName-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import $DisplayName from 'src/components/$DisplayName/$DisplayName'
 
 describe('$DisplayName', () => {
-  isConformant($DisplayName)
+  isConformant($DisplayName, '$DisplayName')
 })

--- a/docs/src/utils/componentInfoShape.ts
+++ b/docs/src/utils/componentInfoShape.ts
@@ -17,7 +17,6 @@ const componentInfoShape = PropTypes.shape({
       name: PropTypes.string,
     }),
   ),
-  constructorName: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   isParent: PropTypes.bool.isRequired,
   isChild: PropTypes.bool.isRequired,

--- a/test/specs/commonTests/isExportedAtTopLevel.tsx
+++ b/test/specs/commonTests/isExportedAtTopLevel.tsx
@@ -5,8 +5,8 @@ import * as stardust from 'src/'
 // Is exported or private
 // ----------------------------------------
 // detect components like: stardust.H1
-export default (constructorName: string, displayName: string) => {
-  const isTopLevelAPIProp = _.has(stardust, constructorName)
+export default (componentName: string, displayName: string) => {
+  const isTopLevelAPIProp = _.has(stardust, componentName)
 
   // require all components to be exported at the top level
   test('is exported at the top level', () => {

--- a/test/specs/components/Accordion/Accordion-test.ts
+++ b/test/specs/components/Accordion/Accordion-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Accordion from 'src/components/Accordion/Accordion'
 
 describe('Accordion', () => {
-  isConformant(Accordion)
+  isConformant(Accordion, 'Accordion')
 })

--- a/test/specs/components/Animation/Animation-test.tsx
+++ b/test/specs/components/Animation/Animation-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Animation from 'src/components/Animation/Animation'
 
 describe('Animation', () => {
-  isConformant(Animation)
+  isConformant(Animation, 'Animation')
 })

--- a/test/specs/components/Attachment/Attachment-test.tsx
+++ b/test/specs/components/Attachment/Attachment-test.tsx
@@ -8,7 +8,7 @@ import Button from 'src/components/Button/Button'
 const attachmentImplementsShorthandProp = implementsShorthandProp(Attachment)
 
 describe('Attachment', () => {
-  isConformant(Attachment)
+  isConformant(Attachment, 'Attachment')
   attachmentImplementsShorthandProp('header', Text)
   attachmentImplementsShorthandProp('description', Text)
   attachmentImplementsShorthandProp('icon', Icon, { mapsValueToProp: 'name' })

--- a/test/specs/components/Avatar/Avatar-test.tsx
+++ b/test/specs/components/Avatar/Avatar-test.tsx
@@ -7,7 +7,7 @@ import Image from 'src/components/Image/Image'
 const avatarImplementsShorthandProp = implementsShorthandProp(Avatar)
 
 describe('Avatar', () => {
-  isConformant(Avatar)
+  isConformant(Avatar, 'Avatar')
   avatarImplementsShorthandProp('label', Label)
   avatarImplementsShorthandProp('image', Image, { mapsValueToProp: 'src' })
 

--- a/test/specs/components/Button/Button-test.tsx
+++ b/test/specs/components/Button/Button-test.tsx
@@ -16,7 +16,7 @@ import Icon from 'src/components/Icon/Icon'
 const buttonImplementsShorthandProp = implementsShorthandProp(Button)
 
 describe('Button', () => {
-  isConformant(Button)
+  isConformant(Button, 'Button')
   buttonImplementsShorthandProp('icon', Icon, { mapsValueToProp: 'name' })
 
   describe('accessibility', () => {

--- a/test/specs/components/Button/ButtonGroup-test.tsx
+++ b/test/specs/components/Button/ButtonGroup-test.tsx
@@ -8,7 +8,7 @@ import { AccessibilityDefinition } from 'src/lib/accessibility/types'
 const buttonGroupImplementsCollectionShorthandProp = implementsCollectionShorthandProp(ButtonGroup)
 
 describe('ButtonGroup', () => {
-  isConformant(ButtonGroup)
+  isConformant(ButtonGroup, 'ButtonGroup')
   buttonGroupImplementsCollectionShorthandProp('buttons', Button)
 
   describe('accessibility', () => {

--- a/test/specs/components/Chat/Chat-test.ts
+++ b/test/specs/components/Chat/Chat-test.ts
@@ -9,7 +9,7 @@ import { AccessibilityDefinition } from 'src/lib/accessibility/types'
 const chatImplementsCollectionShorthandProp = implementsCollectionShorthandProp(Chat)
 
 describe('Chat', () => {
-  isConformant(Chat)
+  isConformant(Chat, 'Chat')
   chatImplementsCollectionShorthandProp('items', ChatItem)
 
   describe('accessibility', () => {

--- a/test/specs/components/Chat/ChatItem-test.tsx
+++ b/test/specs/components/Chat/ChatItem-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import ChatItem from 'src/components/Chat/ChatItem'
 
 describe('ChatItem', () => {
-  isConformant(ChatItem)
+  isConformant(ChatItem, 'ChatItem')
 })

--- a/test/specs/components/Chat/ChatMessage-test.tsx
+++ b/test/specs/components/Chat/ChatMessage-test.tsx
@@ -9,7 +9,7 @@ import { AccessibilityDefinition } from 'src/lib/accessibility/types'
 import Text from 'src/components/Text/Text'
 
 describe('ChatMessage', () => {
-  isConformant(ChatMessage)
+  isConformant(ChatMessage, 'ChatMessage')
   implementsShorthandProp(ChatMessage)('avatar', Avatar, { mapsValueToProp: 'name' })
   implementsShorthandProp(ChatMessage)('author', Text)
   implementsShorthandProp(ChatMessage)('timestamp', Text)

--- a/test/specs/components/Divider/Divider-test.tsx
+++ b/test/specs/components/Divider/Divider-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Divider from 'src/components/Divider/Divider'
 
 describe('Divider', () => {
-  isConformant(Divider)
+  isConformant(Divider, 'Divider')
 })

--- a/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2,5 +2,5 @@ import { isConformant } from 'test/specs/commonTests'
 
 import Dropdown from 'src/components/Dropdown/Dropdown'
 describe('Dropdown', () => {
-  isConformant(Dropdown)
+  isConformant(Dropdown, 'Dropdown')
 })

--- a/test/specs/components/Form/Form-test.tsx
+++ b/test/specs/components/Form/Form-test.tsx
@@ -7,6 +7,6 @@ import FormField from 'src/components/Form/FormField'
 const formImplementsCollectionShorthandProp = implementsCollectionShorthandProp(Form)
 
 describe('Form', () => {
-  isConformant(Form)
+  isConformant(Form, 'Form')
   formImplementsCollectionShorthandProp('fields', FormField, { mapsValueToProp: 'label' })
 })

--- a/test/specs/components/Form/FormField-test.tsx
+++ b/test/specs/components/Form/FormField-test.tsx
@@ -12,7 +12,7 @@ const getFormField = (control: ComponentClass<any> | string) =>
   mountWithProvider(<FormField control={{ as: control }} name="firstName" />).find('FormField')
 
 describe('FormField', () => {
-  isConformant(FormField)
+  isConformant(FormField, 'FormField')
   formFieldImplementsShorthandProp('label', Text)
   formFieldImplementsShorthandProp('message', Text)
   formFieldImplementsShorthandProp('control', Slot, { mapsValueToProp: 'children' })

--- a/test/specs/components/Grid/Grid-test.tsx
+++ b/test/specs/components/Grid/Grid-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Grid from 'src/components/Grid/Grid'
 
 describe('Grid', () => {
-  isConformant(Grid)
+  isConformant(Grid, 'Grid')
 })

--- a/test/specs/components/Header/Header-test.ts
+++ b/test/specs/components/Header/Header-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Header from 'src/components/Header/Header'
 
 describe('Header', () => {
-  isConformant(Header)
+  isConformant(Header, 'Header')
 })

--- a/test/specs/components/Header/HeaderDescription-test.ts
+++ b/test/specs/components/Header/HeaderDescription-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import HeaderDescription from 'src/components/Header/HeaderDescription'
 
 describe('HeaderDescription', () => {
-  isConformant(HeaderDescription)
+  isConformant(HeaderDescription, 'HeaderDescription')
 })

--- a/test/specs/components/Icon/Icon-test.tsx
+++ b/test/specs/components/Icon/Icon-test.tsx
@@ -6,7 +6,7 @@ import { mountWithProviderAndGetComponent } from 'test/utils'
 import { ThemeInput } from 'src/themes/types'
 
 describe('Icon', () => {
-  isConformant(Icon)
+  isConformant(Icon, 'Icon')
 
   describe('accessibility', () => {
     handlesAccessibility(Icon, {

--- a/test/specs/components/Image/Image-test.tsx
+++ b/test/specs/components/Image/Image-test.tsx
@@ -5,7 +5,7 @@ import Image from 'src/components/Image/Image'
 import { mountWithProviderAndGetComponent } from 'test/utils'
 
 describe('Image', () => {
-  isConformant(Image)
+  isConformant(Image, 'Image')
 
   describe('accessibility', () => {
     handlesAccessibility(Image, {

--- a/test/specs/components/Input/Input-test.tsx
+++ b/test/specs/components/Input/Input-test.tsx
@@ -30,7 +30,7 @@ const setUserInputValue = (inputComp: ReactWrapper, value: string) => {
 
 describe('Input', () => {
   describe('conformance', () => {
-    isConformant(Input, {
+    isConformant(Input, 'Input', {
       eventTargets: { onChange: 'input' },
     })
   })

--- a/test/specs/components/ItemLayout/ItemLayout-test.ts
+++ b/test/specs/components/ItemLayout/ItemLayout-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import ItemLayout from 'src/components/ItemLayout/ItemLayout'
 
 describe('ItemLayout', () => {
-  isConformant(ItemLayout)
+  isConformant(ItemLayout, 'ItemLayout')
 })

--- a/test/specs/components/Label/Label-test.tsx
+++ b/test/specs/components/Label/Label-test.tsx
@@ -10,7 +10,7 @@ import { implementsShorthandProp } from '../../commonTests'
 const labelImplementsShorthandProp = implementsShorthandProp(Label)
 
 describe('Label', () => {
-  isConformant(Label)
+  isConformant(Label, 'Label')
   labelImplementsShorthandProp('icon', Icon, { mapsValueToProp: 'name' })
   labelImplementsShorthandProp('image', Image, { mapsValueToProp: 'src' })
 

--- a/test/specs/components/Layout/Layout-test.ts
+++ b/test/specs/components/Layout/Layout-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Layout from 'src/components/Layout/Layout'
 
 describe('Layout', () => {
-  isConformant(Layout)
+  isConformant(Layout, 'Layout')
 })

--- a/test/specs/components/List/List-test.ts
+++ b/test/specs/components/List/List-test.ts
@@ -7,7 +7,7 @@ import ListItem from 'src/components/List/ListItem'
 const listImplementsCollectionShorthandProp = implementsCollectionShorthandProp(List)
 
 describe('List', () => {
-  isConformant(List)
+  isConformant(List, 'List')
   handlesAccessibility(List, { defaultRootRole: 'list' })
   listImplementsCollectionShorthandProp('items', ListItem, { mapsValueToProp: 'main' })
 })

--- a/test/specs/components/List/ListItem-test.ts
+++ b/test/specs/components/List/ListItem-test.ts
@@ -3,6 +3,6 @@ import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
 import ListItem from 'src/components/List/ListItem'
 
 describe('ListItem', () => {
-  isConformant(ListItem)
+  isConformant(ListItem, 'ListItem')
   handlesAccessibility(ListItem, { defaultRootRole: 'listitem' })
 })

--- a/test/specs/components/Menu/Menu-test.tsx
+++ b/test/specs/components/Menu/Menu-test.tsx
@@ -12,7 +12,7 @@ import { AccessibilityDefinition } from 'src/lib/accessibility/types'
 const menuImplementsCollectionShorthandProp = implementsCollectionShorthandProp(Menu)
 
 describe('Menu', () => {
-  isConformant(Menu)
+  isConformant(Menu, 'Menu')
   menuImplementsCollectionShorthandProp('items', MenuItem)
 
   const getItems = () => [

--- a/test/specs/components/Menu/MenuItem-test.tsx
+++ b/test/specs/components/Menu/MenuItem-test.tsx
@@ -6,7 +6,7 @@ import MenuItem from 'src/components/Menu/MenuItem'
 import { toolbarButtonBehavior, tabBehavior } from '../../../../src/lib/accessibility'
 
 describe('MenuItem', () => {
-  isConformant(MenuItem, {
+  isConformant(MenuItem, 'MenuItem', {
     eventTargets: {
       onClick: 'a',
     },

--- a/test/specs/components/Popup/PopupContent-test.ts
+++ b/test/specs/components/Popup/PopupContent-test.ts
@@ -2,5 +2,5 @@ import { isConformant } from 'test/specs/commonTests'
 import PopupContent from 'src/components/Popup/PopupContent'
 
 describe('PopupContent', () => {
-  isConformant(PopupContent, { rendersPortal: true })
+  isConformant(PopupContent, 'PopupContent', { rendersPortal: true })
 })

--- a/test/specs/components/RadioGroup/RadioGroup-test.tsx
+++ b/test/specs/components/RadioGroup/RadioGroup-test.tsx
@@ -42,7 +42,7 @@ const getShorthandItems = (props?: { disabledItem?: number }) => [
 ]
 
 describe('RadioGroup', () => {
-  isConformant(RadioGroup)
+  isConformant(RadioGroup, 'RadioGroup')
 
   describe('accessibility', () => {
     handlesAccessibility(RadioGroup, {

--- a/test/specs/components/RadioGroup/RadioGroupItem-test.ts
+++ b/test/specs/components/RadioGroup/RadioGroupItem-test.ts
@@ -3,7 +3,7 @@ import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
 import RadioGroupItem from 'src/components/RadioGroup/RadioGroupItem'
 
 describe('RadioGroupItem', () => {
-  isConformant(RadioGroupItem)
+  isConformant(RadioGroupItem, 'RadioGroupItem')
 
   describe('accessibility', () => {
     handlesAccessibility(RadioGroupItem, {

--- a/test/specs/components/Segment/Segment-test.ts
+++ b/test/specs/components/Segment/Segment-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Segment from 'src/components/Segment/Segment'
 
 describe('Segment', () => {
-  isConformant(Segment)
+  isConformant(Segment, 'Segment')
 })

--- a/test/specs/components/Slot/Slot-test.ts
+++ b/test/specs/components/Slot/Slot-test.ts
@@ -8,7 +8,7 @@ describe('Slot', () => {
     mount(factoryFn(val, options)).find(Slot)
 
   xdescribe('is conformant', () => {
-    isConformant(Slot, { exportedAtTopLevel: false })
+    isConformant(Slot, 'Slot', { exportedAtTopLevel: false })
   })
 
   describe(`create`, () => {

--- a/test/specs/components/Status/Status-test.tsx
+++ b/test/specs/components/Status/Status-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Status from 'src/components/Status/Status'
 
 describe('Status', () => {
-  isConformant(Status)
+  isConformant(Status, 'Status')
 })

--- a/test/specs/components/Text/Text-test.tsx
+++ b/test/specs/components/Text/Text-test.tsx
@@ -6,7 +6,7 @@ import { mountWithProvider } from 'test/utils'
 import Text from 'src/components/Text/Text'
 
 describe('Text', () => {
-  isConformant(Text)
+  isConformant(Text, 'Text')
 
   test('renders children', () => {
     expect(mountWithProvider(<Text>children</Text>).text()).toEqual('children')

--- a/test/specs/components/Tree/Tree-test.tsx
+++ b/test/specs/components/Tree/Tree-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests'
 import Tree from 'src/components/Tree/Tree'
 
 describe('Tree', () => {
-  isConformant(Tree)
+  isConformant(Tree, 'Tree')
 })


### PR DESCRIPTION
Cut from #509.

---

This PR removes the `constructorName` property from our docgen task. This property is used only in our tests and blocks the usage of HOC, refs #509.

### Props
- we omit `require(absPath).default` in docgen task, this require is handled by `ts-node` so it will increase performance (even in CI 1:30 -> 1:12 for the `Unit Tests` task)
- unblocks the usage of HOCs in our components

### Cons
- `isConformant()` now has one more argument. However it's not a real issue. BTW, `componentName` will be compared with `displayName`, so there is a really small change to get a typo
