### PR TITLE
fix(Dropdown): use pxToRem from Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix support for fallback values in styles (`color: ['#ccc', 'rgba(0, 0, 0, 0.5)']`) @miroslavstastny ([#573](https://github.com/stardust-ui/react/pull/573))
 - Fix styles for RTL mode of doc site component examples @kuzhelov ([#579](https://github.com/stardust-ui/react/pull/579))
 - Prevent blind props forwarding for `createShorthand` calls if the value is a React element and remove manual check for `Input` `wrapper` @Bugaa92 ([#496](https://github.com/stardust-ui/react/pull/496))
+- Fix `pxToRem` referenced for `Dropdown` component styles @kuzhelov ([#590](https://github.com/stardust-ui/react/pull/590))
 
 ### Features
 - `Ref` components uses `forwardRef` API by default @layershifter ([#491](https://github.com/stardust-ui/react/pull/491))

--- a/src/themes/teams/components/Dropdown/dropdownVariables.ts
+++ b/src/themes/teams/components/Dropdown/dropdownVariables.ts
@@ -1,4 +1,4 @@
-import { pxToRem } from '../../../../lib'
+import { pxToRem } from '../../utils'
 export interface DropdownVariables {
   backgroundColor: string
   containerDivBorderRadius: string


### PR DESCRIPTION
This is a leftover from the dropdown PR - essentially, this is about right `pxToRem` tool being used used (i.e. the one that is aware of theme's font size).

Note that this source of confusion is temporary, as necessary changes to pxToRem mechanism are about to come.

### TODO
- [x] update CHANGELOG.md