### PR TITLE
fix(Popup): restore ability to render popup from React element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix support for fallback values in styles (`color: ['#ccc', 'rgba(0, 0, 0, 0.5)']`) @miroslavstastny ([#573](https://github.com/stardust-ui/react/pull/573))
 - Fix styles for RTL mode of doc site component examples @kuzhelov ([#579](https://github.com/stardust-ui/react/pull/579))
 - Prevent blind props forwarding for `createShorthand` calls if the value is a React element and remove manual check for `Input` `wrapper` @Bugaa92 ([#496](https://github.com/stardust-ui/react/pull/496))
+- Fix `Popup` logic of handling `content` value provided as React element @kuzhelov ([#592](https://github.com/stardust-ui/react/pull/592))
 
 ### Features
 - `Ref` components uses `forwardRef` API by default @layershifter ([#491](https://github.com/stardust-ui/react/pull/491))

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -280,7 +280,7 @@ export default class Popup extends AutoControlledComponent<Extendable<PopupProps
 
     const popupContent = React.isValidElement(content)
       ? React.cloneElement(content, {
-          ...content.props,
+React.cloneElement(content, popupContentAttributes)
           ...popupContentAttributes,
         })
       : Popup.Content.create(content, {

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -279,10 +279,7 @@ export default class Popup extends AutoControlledComponent<Extendable<PopupProps
     const popupContentAttributes = accessibility.focusTrap ? {} : popupWrapperAttributes
 
     const popupContent = React.isValidElement(content)
-      ? React.cloneElement(content, {
-React.cloneElement(content, popupContentAttributes)
-          ...popupContentAttributes,
-        })
+      ? React.cloneElement(content, popupContentAttributes)
       : Popup.Content.create(content, {
           defaultProps: popupContentAttributes,
         })


### PR DESCRIPTION
## TODO
- [x] update changelog

------

With recent changes being introduced to shorthand factories (specifically, because of the change that now dictates to pass React Element shorthand value 'as is'), the following way of defining `Popup` has become broken:

```jsx
<Popup content={<p>This is the content that will be rendered 'as is'</p>} ... />
```

The way it was broken is that now the content of the `<p>` element is, essentially, not visible (however, while still rendered in the DOM tree), because positioning styles are not applied.

----

This corresponds to the following example on the docs page:

![image](https://user-images.githubusercontent.com/9024564/49769487-aa9ba100-fce0-11e8-9697-8da60bafbeeb.png)

----

This PR restores this functionality.