### PR TITLE
fix(Segment): fix import path for props used in styles

### DIFF
--- a/src/themes/teams/components/Segment/segmentStyles.ts
+++ b/src/themes/teams/components/Segment/segmentStyles.ts
@@ -1,4 +1,4 @@
-import { SegmentProps } from 'semantic-ui-react'
+import { SegmentProps } from '../../../../components/Segment/Segment'
 import { ICSSInJSStyle, ComponentSlotStylesInput } from '../../../types'
 import { SegmentVariables } from './segmentVariables'
 


### PR DESCRIPTION
Previously `SegmentProps` were accidentally referenced from 'semantic-ui-react' package, instead of the ones that are declared by Stardust.