### PR TITLE
feat(text): color prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Export `canvas-add-page` SVG icon @priyankar205 ([#601](https://github.com/stardust-ui/react/pull/601))
 - Add `sizeModifier` variable (with `x` and `xx` values) to `Icon`'s Teams theme styles @priyankar205 ([#601](https://github.com/stardust-ui/react/pull/601))
 - Add `offset` prop to `Popup` to extend set of popup positioning options @kuzhelov ([#606](https://github.com/stardust-ui/react/pull/606))
+- Add `color` prop to `Text` component @Bugaa92 ([#597](https://github.com/stardust-ui/react/pull/597))
 
 ### Documentation
 - Add `prettier` support throughout the docs @levithomason  ([#568](https://github.com/stardust-ui/react/pull/568))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Features
+- Add `color` prop to `Text` component @Bugaa92 ([#597](https://github.com/stardust-ui/react/pull/597))
+
 <!--------------------------------[ v0.15.0 ]------------------------------- -->
 ## [v0.15.0](https://github.com/stardust-ui/react/tree/v0.15.0) (2018-12-17)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.14.0...v0.15.0)
@@ -54,7 +57,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Export `canvas-add-page` SVG icon @priyankar205 ([#601](https://github.com/stardust-ui/react/pull/601))
 - Add `sizeModifier` variable (with `x` and `xx` values) to `Icon`'s Teams theme styles @priyankar205 ([#601](https://github.com/stardust-ui/react/pull/601))
 - Add `offset` prop to `Popup` to extend set of popup positioning options @kuzhelov ([#606](https://github.com/stardust-ui/react/pull/606))
-- Add `color` prop to `Text` component @Bugaa92 ([#597](https://github.com/stardust-ui/react/pull/597))
 
 ### Documentation
 - Add `prettier` support throughout the docs @levithomason  ([#568](https://github.com/stardust-ui/react/pull/568))

--- a/docs/src/examples/components/Text/Variations/TextExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleColor.shorthand.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import _ from 'lodash'
+import { Text, ProviderConsumer } from '@stardust-ui/react'
+
+const TextExampleColor = () => (
+  <ProviderConsumer
+    render={({ siteVariables: { emphasisColors, naturalColors } }) =>
+      _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
+        <>
+          <Text key={color} color={color} content={_.startCase(color)} />
+          <br />
+        </>
+      ))
+    }
+  />
+)
+
+export default TextExampleColor

--- a/docs/src/examples/components/Text/Variations/TextExampleColor.tsx
+++ b/docs/src/examples/components/Text/Variations/TextExampleColor.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import _ from 'lodash'
+import { Text, ProviderConsumer } from '@stardust-ui/react'
+
+const TextExampleColor = () => (
+  <ProviderConsumer
+    render={({ siteVariables: { emphasisColors, naturalColors } }) =>
+      _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
+        <>
+          <Text key={color} color={color}>
+            {_.startCase(color)}
+          </Text>
+          <br />
+        </>
+      ))
+    }
+  />
+)
+
+export default TextExampleColor

--- a/docs/src/examples/components/Text/Variations/index.tsx
+++ b/docs/src/examples/components/Text/Variations/index.tsx
@@ -5,6 +5,11 @@ import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 const Variations = () => (
   <ExampleSection title="Variations">
     <ComponentExample
+      title="Color"
+      description="A Text component can have different colors."
+      examplePath="components/Text/Variations/TextExampleColor"
+    />
+    <ComponentExample
       title="@ mention"
       description="A Text component for @ mentions."
       examplePath="components/Text/Variations/TextExampleAtMention"

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -9,11 +9,16 @@ import {
   ContentComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
+  ColorComponentProps,
 } from '../../lib'
 
 import { Extendable } from '../../../types/utils'
 
-export interface TextProps extends UIComponentProps, ContentComponentProps, ChildrenComponentProps {
+export interface TextProps
+  extends UIComponentProps,
+    ContentComponentProps,
+    ChildrenComponentProps,
+    ColorComponentProps {
   /** At mentions can be formatted to draw users' attention. Mentions for "me" can be formatted to appear differently. */
   atMention?: boolean | 'me'
 
@@ -63,7 +68,7 @@ class Text extends UIComponent<Extendable<TextProps>, any> {
   static displayName = 'Text'
 
   static propTypes = {
-    ...commonPropTypes.createCommon(),
+    ...commonPropTypes.createCommon({ color: true }),
     atMention: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['me'])]),
     disabled: PropTypes.bool,
     error: PropTypes.bool,

--- a/src/lib/colorUtils.ts
+++ b/src/lib/colorUtils.ts
@@ -3,7 +3,7 @@ import { SiteVariablesInput, ColorVariants, ColorValues } from '../themes/types'
 
 export const mapColorsToScheme = <T>(
   siteVars: SiteVariablesInput,
-  mapper: string | number | keyof ColorVariants | ((color: ColorVariants) => T),
+  mapper: keyof ColorVariants | ((color: ColorVariants) => T),
 ): ColorValues<T> =>
   _.mapValues(
     { ...siteVars.emphasisColors, ...siteVars.naturalColors },

--- a/src/lib/colorUtils.ts
+++ b/src/lib/colorUtils.ts
@@ -1,0 +1,11 @@
+import * as _ from 'lodash'
+import { SiteVariablesInput, ColorVariants, ColorValues } from '../themes/types'
+
+export const mapColorsToScheme = <T>(
+  siteVars: SiteVariablesInput,
+  mapper: string | number | keyof ColorVariants | ((color: ColorVariants) => T),
+): ColorValues<T> =>
+  _.mapValues(
+    { ...siteVars.emphasisColors, ...siteVars.naturalColors },
+    typeof mapper === 'number' ? String(mapper) : (mapper as any),
+  ) as ColorValues<T>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,6 +3,7 @@ import * as commonPropTypes from './commonPropTypes'
 
 export { default as AutoControlledComponent } from './AutoControlledComponent'
 export { default as childrenExist } from './childrenExist'
+export { mapColorsToScheme } from './colorUtils'
 export { default as UIComponent } from './UIComponent'
 export { EventStack } from './eventStack'
 export { felaRenderer, felaRtlRenderer } from './felaRenderer'

--- a/src/themes/teams/colors.ts
+++ b/src/themes/teams/colors.ts
@@ -88,7 +88,6 @@ export const naturalColors: NaturalColors = {
     800: '#F9D844',
     900: '#F8D22A',
   },
-
   darkOrange: {
     50: '#F9ECEA',
     100: '#ECBCB3',

--- a/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/src/themes/teams/components/Divider/dividerStyles.ts
@@ -6,18 +6,22 @@ import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { DividerPropsWithDefaults } from '../../../../components/Divider/Divider'
 import { DividerVariables } from './dividerVariables'
 
-const beforeAndAfter = (color, size, variables: DividerVariables): ICSSInJSStyle => ({
+const beforeAndAfter = (
+  color: string,
+  size: number,
+  variables: DividerVariables,
+): ICSSInJSStyle => ({
   content: '""',
   flex: 1,
   height: `${size + 1}px`,
-  background: color ? _.get(variables.colors, color) : variables.dividerColor,
+  background: _.get(variables.colors, color, variables.dividerColor),
 })
 
 const dividerStyles: ComponentSlotStylesInput<DividerPropsWithDefaults, DividerVariables> = {
   root: ({ props, variables }): ICSSInJSStyle => {
     const { children, color, fitted, size, important, content } = props
     return {
-      color: color ? _.get(variables.colors, color) : variables.textColor,
+      color: _.get(variables.colors, color, variables.textColor),
       display: 'flex',
       alignItems: 'center',
       ...(!fitted && {

--- a/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/src/themes/teams/components/Divider/dividerStyles.ts
@@ -2,36 +2,27 @@ import * as _ from 'lodash'
 
 import { childrenExist } from '../../../../lib'
 import { pxToRem } from '../../utils'
-import { ComponentSlotStylesInput, ICSSInJSStyle, ICSSPseudoElementStyle } from '../../../types'
+import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { DividerPropsWithDefaults } from '../../../../components/Divider/Divider'
+import { DividerVariables } from './dividerVariables'
 
-const dividerBorderStyle = (size, color): ICSSInJSStyle => ({
-  height: `${size + 1}px`,
-  background: color,
-})
-
-const beforeAndAfter = (color, size, type, variables): ICSSPseudoElementStyle => ({
+const beforeAndAfter = (color, size, variables: DividerVariables): ICSSInJSStyle => ({
   content: '""',
   flex: 1,
-  ...dividerBorderStyle(size, variables.dividerColor),
-  ...(color && {
-    ...dividerBorderStyle(size, _.get(variables.colors, color)),
-  }),
+  height: `${size + 1}px`,
+  background: color ? _.get(variables.colors, color) : variables.dividerColor,
 })
 
-const dividerStyles: ComponentSlotStylesInput<DividerPropsWithDefaults, any> = {
+const dividerStyles: ComponentSlotStylesInput<DividerPropsWithDefaults, DividerVariables> = {
   root: ({ props, variables }): ICSSInJSStyle => {
-    const { children, color, fitted, size, type, important, content } = props
+    const { children, color, fitted, size, important, content } = props
     return {
-      color: variables.textColor,
+      color: color ? _.get(variables.colors, color) : variables.textColor,
       display: 'flex',
       alignItems: 'center',
       ...(!fitted && {
         paddingTop: variables.dividerPadding,
         paddingBottom: variables.dividerPadding,
-      }),
-      ...(color && {
-        color: _.get(variables.colors, color),
       }),
       ...(important && {
         fontWeight: variables.importantFontWeight,
@@ -42,17 +33,17 @@ const dividerStyles: ComponentSlotStylesInput<DividerPropsWithDefaults, any> = {
             fontSize: pxToRem(12 + size),
             lineHeight: variables.textLineHeight,
             '::before': {
-              ...beforeAndAfter(color, size, type, variables),
+              ...beforeAndAfter(color, size, variables),
               marginRight: pxToRem(20),
             },
             '::after': {
-              ...beforeAndAfter(color, size, type, variables),
+              ...beforeAndAfter(color, size, variables),
               marginLeft: pxToRem(20),
             },
           }
         : {
             '::before': {
-              ...beforeAndAfter(color, size, type, variables),
+              ...beforeAndAfter(color, size, variables),
             },
           }),
     }

--- a/src/themes/teams/components/Divider/dividerVariables.ts
+++ b/src/themes/teams/components/Divider/dividerVariables.ts
@@ -16,7 +16,7 @@ export interface DividerVariables {
 }
 
 export default (siteVars: any): DividerVariables => {
-  const colorVariant = '500'
+  const colorVariant = 500
 
   return {
     colors: mapColorsToScheme(siteVars, colorVariant),

--- a/src/themes/teams/components/Divider/dividerVariables.ts
+++ b/src/themes/teams/components/Divider/dividerVariables.ts
@@ -1,15 +1,17 @@
 import * as _ from 'lodash'
-import { pxToRem } from '../../utils'
+import { FontWeightProperty } from 'csstype'
 
-import { EmphasisColors, NaturalColors } from '../../../types'
+import { pxToRem } from '../../utils'
+import { ColorValues } from '../../../types'
+import { mapColorsToScheme } from '../../../../lib'
 
 export interface DividerVariables {
-  colors: Record<keyof (EmphasisColors & NaturalColors), string>
+  colors: ColorValues<string>
   dividerColor: string
   textColor: string
   textFontSize: string
   textLineHeight: string
-  importantFontWeight: string
+  importantFontWeight: FontWeightProperty
   dividerPadding: string
 }
 
@@ -17,7 +19,7 @@ export default (siteVars: any): DividerVariables => {
   const colorVariant = '500'
 
   return {
-    colors: _.mapValues({ ...siteVars.emphasisColors, ...siteVars.naturalColors }, colorVariant),
+    colors: mapColorsToScheme(siteVars, colorVariant),
     dividerColor: siteVars.gray09,
     textColor: siteVars.gray03,
     textFontSize: siteVars.fontSizeSmall,

--- a/src/themes/teams/components/Text/textStyles.ts
+++ b/src/themes/teams/components/Text/textStyles.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash'
+
 import { ComponentStyleFunctionParam, ICSSInJSStyle } from '../../../types'
 import { truncateStyle } from '../../../../styles/customCSS'
 import { TextVariables } from './textVariables'
@@ -7,6 +9,7 @@ export default {
   root: ({
     props: {
       atMention,
+      color,
       disabled,
       error,
       size,
@@ -21,6 +24,7 @@ export default {
   }: ComponentStyleFunctionParam<TextProps, TextVariables>): ICSSInJSStyle => {
     return {
       display: 'inline-block',
+      ...(color && { color: _.get(v.colors, color) }),
       ...(truncated && truncateStyle),
       ...(atMention === true && {
         color: v.atMentionOtherColor,

--- a/src/themes/teams/components/Text/textStyles.ts
+++ b/src/themes/teams/components/Text/textStyles.ts
@@ -24,7 +24,7 @@ export default {
   }: ComponentStyleFunctionParam<TextProps, TextVariables>): ICSSInJSStyle => {
     return {
       display: 'inline-block',
-      ...(color && { color: _.get(v.colors, color) }),
+      color: _.get(v.colors, color),
       ...(truncated && truncateStyle),
       ...(atMention === true && {
         color: v.atMentionOtherColor,

--- a/src/themes/teams/components/Text/textStyles.ts
+++ b/src/themes/teams/components/Text/textStyles.ts
@@ -24,7 +24,6 @@ export default {
   }: ComponentStyleFunctionParam<TextProps, TextVariables>): ICSSInJSStyle => {
     return {
       display: 'inline-block',
-      color: _.get(v.colors, color),
       ...(truncated && truncateStyle),
       ...(atMention === true && {
         color: v.atMentionOtherColor,
@@ -47,6 +46,7 @@ export default {
         fontWeight: v.importantWeight,
         color: v.importantColor,
       }),
+      ...(color && { color: _.get(v.colors, color) }),
 
       ...(weight === 'light' && {
         fontWeight: v.fontWeightLight,

--- a/src/themes/teams/components/Text/textVariables.ts
+++ b/src/themes/teams/components/Text/textVariables.ts
@@ -1,4 +1,8 @@
+import { ColorValues } from '../../../types'
+import { mapColorsToScheme } from '../../../../lib'
+
 export interface TextVariables {
+  colors: ColorValues<string>
   atMentionMeColor: string
   atMentionMeFontWeight: number
   atMentionOtherColor: string
@@ -29,7 +33,10 @@ export interface TextVariables {
 }
 
 export default (siteVariables): TextVariables => {
+  const colorVariant = '500'
+
   return {
+    colors: mapColorsToScheme(siteVariables, colorVariant),
     atMentionOtherColor: siteVariables.brand06,
     atMentionMeColor: siteVariables.orange04,
     atMentionMeFontWeight: siteVariables.fontWeightBold,

--- a/src/themes/teams/components/Text/textVariables.ts
+++ b/src/themes/teams/components/Text/textVariables.ts
@@ -33,7 +33,7 @@ export interface TextVariables {
 }
 
 export default (siteVariables): TextVariables => {
-  const colorVariant = '500'
+  const colorVariant = 500
 
   return {
     colors: mapColorsToScheme(siteVariables, colorVariant),

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -72,6 +72,16 @@ type EmphasisColorsStrict = Partial<{
 export type EmphasisColors = Extendable<EmphasisColorsStrict, ColorVariants>
 
 /**
+ * A type for extracting the color names.
+ */
+type ColorNames = keyof (EmphasisColorsStrict & NaturalColorsStrict)
+
+/**
+ * A type for extracting the color names and values.
+ */
+export type ColorValues<T> = Partial<Record<ColorNames, T>>
+
+/**
  * A type for a base colors.
  */
 export type PrimitiveColors = Partial<{

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -77,9 +77,9 @@ export type EmphasisColors = Extendable<EmphasisColorsStrict, ColorVariants>
 type ColorNames = keyof (EmphasisColorsStrict & NaturalColorsStrict)
 
 /**
- * A type for extracting the color names and values.
+ * A type for an extendable set of ColorNames properties of type T
  */
-export type ColorValues<T> = Partial<Record<ColorNames, T>>
+export type ColorValues<T> = Extendable<Partial<Record<ColorNames, T>>, T>
 
 /**
  * A type for a base colors.


### PR DESCRIPTION
## feat(text): color prop

### Description

This PR:
- adds `color` prop to `Text` component;
- creates generic types for the theme `color` story;
- creates `Text` color examples;
- cleans up `Divider` style files after #558 

### API

```jsx
<Text color={'primary' | 'secondary' | 'blue' | 'green' | 'grey'
 | 'orange' | 'pink' | 'purple' | 'teal' | 'red' | 'yellow' | string} .../>
```
![screenshot 2018-12-11 at 18 15 04](https://user-images.githubusercontent.com/5442794/49817764-699f9d00-fd71-11e8-9c98-40fe90f10135.png)
