### PR TITLE
docs: fix duplicated className in instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Documentation
 - Add `prettier` support throughout the docs @levithomason  ([#568](https://github.com/stardust-ui/react/pull/568))
 - Display available behaviors for component @jurokapsiar ([#510](https://github.com/stardust-ui/react/pull/510))
+- Fix `createComponent()` instructions for `className` @levithomason  ([#599](https://github.com/stardust-ui/react/pull/599))
 
 <!--------------------------------[ v0.14.0 ]------------------------------- -->
 ## [v0.14.0](https://github.com/stardust-ui/react/tree/v0.14.0) (2018-12-05)

--- a/docs/src/prototypes/chatMessageWithPopover/Popover.tsx
+++ b/docs/src/prototypes/chatMessageWithPopover/Popover.tsx
@@ -172,7 +172,7 @@ const ContextMenu = createComponent<ContextMenuProps>({
   displayName: 'ContextMenu',
   render: ({ stardust, className, children }) => {
     const { classes } = stardust
-    return <div className={cx(className, classes.root)}>{children}</div>
+    return <div className={classes.root}>{children}</div>
   },
 })
 

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import cx from 'classnames'
 import { NavLink } from 'react-router-dom'
 import { Header } from 'semantic-ui-react'
 import {
@@ -24,9 +23,9 @@ interface StyledButtonProps {
 
 const StyledButton: React.SFC<StyledButtonProps> = createComponent<StyledButtonProps>({
   displayName: 'StyledButton',
-  render({ stardust, className, children }) {
+  render({ stardust, children }) {
     const { classes } = stardust
-    return <button className={cx(className, classes.root)}>{children}</button>
+    return <button className={classes.root}>{children}</button>
   },
 })
 
@@ -51,7 +50,7 @@ export default () => (
           displayName: 'StyledButton',
           render: ({stardust, className, children}) => {
             const { classes } = stardust
-            return <button className={cx(className, classes.root)}>{children}</button>
+            return <button className={classes.root}>{children}</button>
           }
         })
       `}


### PR DESCRIPTION
The `renderComponent()` function merges `props.className` and `classes.root`.  However, our docs for `createComponent()` instructed users to merge these two again, resulting in duplicate classes being applied.