### PR TITLE
fix(docs): fix key warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Popup` logic of handling `content` value provided as React element @kuzhelov ([#592](https://github.com/stardust-ui/react/pull/592))
 - Do not handle `FocusZone`'s keyDownCapture in `chatBehavior` @sophieH29 ([#563](https://github.com/stardust-ui/react/pull/563))
 - Fix `getKeyDownHandler` to pass props for client's onKeyDown handler @sophieH29 ([#595](https://github.com/stardust-ui/react/pull/595))
+- fix multiple React's warnings about keys in docs @layershifter ([#602](https://github.com/stardust-ui/react/pull/602))
 
 ### Features
 - `Ref` components uses `forwardRef` API by default @layershifter ([#491](https://github.com/stardust-ui/react/pull/491))

--- a/docs/src/components/ComponentDoc/ComponentDocAccessibility.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDocAccessibility.tsx
@@ -37,11 +37,11 @@ const ComponentDocAccessibility = ({ info }) => {
         <p>
           Available behaviors:{' '}
           {info.behaviors.map(behavior => (
-            <>
+            <React.Fragment key={`${behavior.category}-${behavior.name}`}>
               <a href={`behaviors/${behavior.category}#${_.kebabCase(behavior.name)}`}>
                 {behavior.displayName}
               </a>{' '}
-            </>
+            </React.Fragment>
           ))}
         </p>
       )}

--- a/docs/src/routes.tsx
+++ b/docs/src/routes.tsx
@@ -62,6 +62,7 @@ const Router = () => (
           />,
           <DocsLayout
             exact
+            key="/prototype-popups"
             path="/prototype-popups"
             component={require('./prototypes/popups/index').default}
           />,


### PR DESCRIPTION
This PR fixes two React's warnings about missing keys in our docs.