### PR TITLE
perf(docgen): speed up `build:docs:component-menu`

### DIFF
--- a/build/gulp/plugins/gulp-component-menu.ts
+++ b/build/gulp/plugins/gulp-component-menu.ts
@@ -5,6 +5,7 @@ import * as through2 from 'through2'
 import * as Vinyl from 'vinyl'
 
 import config from '../../../config'
+import getComponentInfo from './util/getComponentInfo'
 
 const pluginName = 'gulp-component-menu'
 
@@ -29,9 +30,17 @@ export default () => {
 
     try {
       const infoFilename = file.basename.replace(/\.tsx$/, '.info.json')
+      const infoFilePath = config.paths.docsSrc('componentInfo', infoFilename)
 
-      const jsonInfo = fs.readFileSync(config.paths.docsSrc('componentInfo', infoFilename))
-      const componentInfo = JSON.parse(jsonInfo.toString())
+      let componentInfo
+
+      // We will reuse an info file if it exists.
+      if (fs.existsSync(infoFilePath)) {
+        const jsonInfo = fs.readFileSync(infoFilePath)
+        componentInfo = JSON.parse(jsonInfo.toString())
+      } else {
+        componentInfo = getComponentInfo(file.path)
+      }
 
       if (componentInfo.isParent) {
         result.push({

--- a/build/gulp/plugins/gulp-component-menu.ts
+++ b/build/gulp/plugins/gulp-component-menu.ts
@@ -1,9 +1,10 @@
 import * as gutil from 'gulp-util'
+import * as fs from 'fs'
 import * as path from 'path'
 import * as through2 from 'through2'
 import * as Vinyl from 'vinyl'
 
-import getComponentInfo from './util/getComponentInfo'
+import config from '../../../config'
 
 const pluginName = 'gulp-component-menu'
 
@@ -27,12 +28,15 @@ export default () => {
     }
 
     try {
-      const info = getComponentInfo(file.path)
+      const infoFilename = file.basename.replace(/\.tsx$/, '.info.json')
 
-      if (info.isParent) {
+      const jsonInfo = fs.readFileSync(config.paths.docsSrc('componentInfo', infoFilename))
+      const componentInfo = JSON.parse(jsonInfo.toString())
+
+      if (componentInfo.isParent) {
         result.push({
-          displayName: info.displayName,
-          type: info.type,
+          displayName: componentInfo.displayName,
+          type: componentInfo.type,
         })
       }
       cb()

--- a/build/gulp/tasks/docs.ts
+++ b/build/gulp/tasks/docs.ts
@@ -101,8 +101,7 @@ task('build:docs:example-menu', () =>
 task(
   'build:docs:json',
   parallel(
-    'build:docs:docgen',
-    'build:docs:component-menu',
+    series('build:docs:docgen', 'build:docs:component-menu'),
     'build:docs:component-menu-behaviors',
     'build:docs:example-menu',
   ),


### PR DESCRIPTION
Fixes #507.

---

This PR removes duplicate uncached call of `getComponentInfo()` and just uses already existing info files.

### Before
```
[14:06:46] Starting 'build:docs:component-menu'...
[14:08:04] Finished 'build:docs:component-menu' after 1.3 min
```

### After
```
[14:10:30] Starting 'build:docs:component-menu'...
[14:10:31] Finished 'build:docs:component-menu' after 290 ms
```
