### PR TITLE
chore: cache results of vulnerability scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,12 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash)
 
       - restore_cache:
-          key: v1-vuln-scans
+          key: v1-vuln-scans-{{ checksum "yarn.lock" }}
       - run:
           name: Vulnerability Tests
           command: yarn test:vulns
       - save_cache:
-          key: v1-vuln-scans
+          key: v1-vuln-scans-{{ checksum "yarn.lock" }}
           paths:
             - .vuln-scans
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,22 +21,6 @@ jobs:
             echo 'export PATH="${PATH}:${HOME}/.yarn/bin"' >> $BASH_ENV
       - checkout
       # because we don't invoke npm (we use yarn) we need to add npm bin to PATH manually
-      - run:
-          name: Add npm bin to PATH
-          command: echo 'export PATH="${PATH}:$(npm bin)"' >> $BASH_ENV
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
-            - v1-dependencies
-      - run:
-          name: Install Dependencies
-          command: yarn
-      - save_cache:
-          key: v1-dependencies-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-            - .yarn-cache
-            - node_modules
 
       - restore_cache:
           key: v1-vuln-scans-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       - run:
           name: Vulnerability Tests
           command: yarn test:vulns
+      # https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/12
       - save_cache:
           key: v1-vuln-scans-{{ checksum "yarn.lock" }}-{{ epoch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,18 +37,6 @@ jobs:
             - ~/.cache/yarn
             - .yarn-cache
             - node_modules
-      - run:
-          name: Lint
-          command: yarn lint
-      - run:
-          name: Prettier
-          command: yarn prettier
-      - run:
-          name: Unit Tests
-          command: yarn test --strict --maxWorkers=4
-      - run:
-          name: Report coverage
-          command: bash <(curl -s https://codecov.io/bash)
 
       - restore_cache:
           key: v1-vuln-scans-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,6 @@ jobs:
       - run:
           name: Vulnerability Tests
           command: yarn test:vulns
-      - save_cache:
-          key: v1-vuln-scans-{{ checksum "yarn.lock" }}
-          paths:
-            - .vuln-scans
 
       - run:
           name: Visual Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           name: Vulnerability Tests
           command: yarn test:vulns
       - save_cache:
-          key: v1-vuln-scans-{{ checksum "yarn.lock" }}
+          key: v1-vuln-scans-{{ checksum "yarn.lock" }}-{{ epoch }}
           paths:
             - .vuln-scans
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,14 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash)
 
       - restore_cache:
-          key: v1-vuln-tests
+          key: v1-vuln-scans
       - run:
           name: Vulnerability Tests
           command: yarn test:vulns
       - save_cache:
-          key: v1-vuln-tests
+          key: v1-vuln-scans
           paths:
-            - .vuln-tests
+            - .vuln-scans
 
       - run:
           name: Visual Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,22 @@ jobs:
             echo 'export PATH="${PATH}:${HOME}/.yarn/bin"' >> $BASH_ENV
       - checkout
       # because we don't invoke npm (we use yarn) we need to add npm bin to PATH manually
+      - run:
+          name: Add npm bin to PATH
+          command: echo 'export PATH="${PATH}:$(npm bin)"' >> $BASH_ENV
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies
+      - run:
+          name: Install Dependencies
+          command: yarn
+      - save_cache:
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+            - .yarn-cache
+            - node_modules
 
       - restore_cache:
           key: v1-vuln-scans-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,17 @@ jobs:
       - run:
           name: Report coverage
           command: bash <(curl -s https://codecov.io/bash)
+
+      - restore_cache:
+          key: v1-vuln-tests
       - run:
           name: Vulnerability Tests
           command: yarn test:vulns
+      - save_cache:
+          key: v1-vuln-tests
+          paths:
+            - .vuln-tests
+
       - run:
           name: Visual Tests
           command: yarn test:visual

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,18 @@ jobs:
             - ~/.cache/yarn
             - .yarn-cache
             - node_modules
+      - run:
+          name: Lint
+          command: yarn lint
+      - run:
+          name: Prettier
+          command: yarn prettier
+      - run:
+          name: Unit Tests
+          command: yarn test --strict --maxWorkers=4
+      - run:
+          name: Report coverage
+          command: bash <(curl -s https://codecov.io/bash)
 
       - restore_cache:
           key: v1-vuln-scans-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,10 @@ jobs:
       - run:
           name: Vulnerability Tests
           command: yarn test:vulns
+      - save_cache:
+          key: v1-vuln-scans-{{ checksum "yarn.lock" }}
+          paths:
+            - .vuln-scans
 
       - run:
           name: Visual Tests

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -3,6 +3,8 @@ import { task } from 'gulp'
 import * as path from 'path'
 import sh from '../sh'
 
+import * as crypto from 'crypto'
+
 import debug from 'debug'
 
 import config from '../../../config'
@@ -14,6 +16,13 @@ const SCAN_RESULTS_DIR = paths.base('.vuln-scans')
 const log = message => debug.log(message)
 log.success = message => debug.log(`✔ ${message}`)
 
+const computeHash = filePath => {
+  const md5 = crypto.createHash('md5')
+  md5.update(fs.readFileSync(paths.base('yarn.lock')))
+
+  return md5.digest('hex')
+}
+
 const ensureDirExists = path => {
   if (!fs.existsSync(path)) {
     sh(`mkdir -p ${path}`)
@@ -21,9 +30,11 @@ const ensureDirExists = path => {
 }
 
 const getTodayScanFilePath = () => {
+  const yarnLockHash = computeHash(paths.base('yarn.lock'))
   const now = new Date()
+
   const fileName = `snyk-scanned-${now.getUTCFullYear()}-${now.getUTCMonth() +
-    1}-${now.getUTCDate()}`
+    1}-${now.getUTCDate()}-${yarnLockHash.slice(0, 8)}`
 
   return path.resolve(SCAN_RESULTS_DIR, fileName)
 }

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -9,6 +9,7 @@ import sh from '../sh'
 const { paths } = config
 
 const SCAN_RESULTS_DIR_NAME = '.vuln-scans'
+const SCAN_RESULTS_DIR_PATH = paths.base(SCAN_RESULTS_DIR_NAME)
 
 const log = message => debug.log(message)
 log.success = message => debug.log(`✔ ${message}`)
@@ -19,17 +20,13 @@ const ensureDirExists = path => {
   }
 }
 
-const getScanResultsDirPath = () => {
-  return paths.base(SCAN_RESULTS_DIR_NAME)
-}
-
 const getTodayScanFilePath = () => {
   const now = new Date()
 
   const fileName = `snyk-scanned-${now.getUTCFullYear()}-${now.getUTCMonth() +
     1}-${now.getUTCDate()}`
 
-  return path.resolve(getScanResultsDirPath(), fileName)
+  return path.resolve(SCAN_RESULTS_DIR_PATH, fileName)
 }
 
 const recentlyChecked = () => {
@@ -38,7 +35,7 @@ const recentlyChecked = () => {
 }
 
 const registerRecentSucessfulScan = async () => {
-  ensureDirExists(getScanResultsDirPath())
+  ensureDirExists(SCAN_RESULTS_DIR_PATH)
 
   const recentScanFilePath = getTodayScanFilePath()
   await sh(`touch ${recentScanFilePath}`)

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -34,15 +34,14 @@ const getTodayScanFilePath = () => {
 
 const recentlyChecked = () => {
   const recentCheckFilePath = getTodayScanFilePath()
-  console.warn('checking of file exists:', recentCheckFilePath)
   return fs.existsSync(recentCheckFilePath)
 }
 
 const registerRecentSucessfulScan = async () => {
   ensureDirExists(getScanResultsDirPath())
 
-  // const recentScanFilePath = getTodayScanFilePath()
-  await sh(`touch aha`) // ${recentScanFilePath}`)
+  const recentScanFilePath = getTodayScanFilePath()
+  await sh(`touch ${recentScanFilePath}`)
 }
 
 /**

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -45,6 +45,7 @@ const getTodayScanFilePath = () => {
 
 const recentlyChecked = () => {
   const recentCheckFilePath = getTodayScanFilePath()
+  console.warn('recent check file path is', recentCheckFilePath)
   return fs.existsSync(recentCheckFilePath)
 }
 

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -34,14 +34,15 @@ const getTodayScanFilePath = () => {
 
 const recentlyChecked = () => {
   const recentCheckFilePath = getTodayScanFilePath()
+  console.warn('checking of file exists:', recentCheckFilePath)
   return fs.existsSync(recentCheckFilePath)
 }
 
 const registerRecentSucessfulScan = async () => {
   ensureDirExists(getScanResultsDirPath())
 
-  const recentScanFilePath = getTodayScanFilePath()
-  await sh(`touch ${recentScanFilePath}`)
+  // const recentScanFilePath = getTodayScanFilePath()
+  await sh(`touch aha`) // ${recentScanFilePath}`)
 }
 
 /**

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -23,8 +23,11 @@ const ensureDirExists = path => {
 const getTodayScanFilePath = () => {
   const now = new Date()
 
-  const fileName = `snyk-scanned-${now.getUTCFullYear()}-${now.getUTCMonth() +
-    1}-${now.getUTCDate()}`
+  const year = now.getUTCFullYear()
+  const month = now.getUTCMonth() + 1
+  const date = now.getUTCDate()
+
+  const fileName = `snyk-scanned-${year}-${month}-${date}`
 
   return path.resolve(SCAN_RESULTS_DIR_PATH, fileName)
 }

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -22,7 +22,8 @@ const ensureDirExists = path => {
 
 const getTodayScanFilePath = () => {
   const now = new Date()
-  const fileName = `snyk-${now.getUTCFullYear()}-${now.getUTCMonth() + 1}-${now.getUTCDate()}`
+  const fileName = `snyk-scanned-${now.getUTCFullYear()}-${now.getUTCMonth() +
+    1}-${now.getUTCDate()}`
 
   return path.resolve(SCAN_RESULTS_DIR, fileName)
 }

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -1,27 +1,17 @@
 import * as fs from 'fs'
 import { task } from 'gulp'
 import * as path from 'path'
-import * as crypto from 'crypto'
 import debug from 'debug'
-
-const memoize = require('fast-memoize')
 
 import config from '../../../config'
 import sh from '../sh'
 
 const { paths } = config
 
-const SCAN_RESULTS_DIR_PREFIX = '.vuln-scans'
+const SCAN_RESULTS_DIR_NAME = '.vuln-scans'
 
 const log = message => debug.log(message)
 log.success = message => debug.log(`✔ ${message}`)
-
-const computeHash = filePath => {
-  const sha256 = crypto.createHash('sha256')
-  sha256.update(fs.readFileSync(filePath))
-
-  return sha256.digest('base64')
-}
 
 const ensureDirExists = path => {
   if (!fs.existsSync(path)) {
@@ -29,10 +19,9 @@ const ensureDirExists = path => {
   }
 }
 
-const getScanResultsDirPath = memoize(() => {
-  const yarnLockHash = computeHash(paths.base('yarn.lock'))
-  return paths.base(`${SCAN_RESULTS_DIR_PREFIX}-${yarnLockHash}`)
-})
+const getScanResultsDirPath = () => {
+  return paths.base(SCAN_RESULTS_DIR_NAME)
+}
 
 const getTodayScanFilePath = () => {
   const now = new Date()
@@ -45,7 +34,6 @@ const getTodayScanFilePath = () => {
 
 const recentlyChecked = () => {
   const recentCheckFilePath = getTodayScanFilePath()
-  console.warn('recent check file path is', recentCheckFilePath)
   return fs.existsSync(recentCheckFilePath)
 }
 

--- a/build/gulp/tasks/test-vulns.ts
+++ b/build/gulp/tasks/test-vulns.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs'
+import { task } from 'gulp'
+import * as path from 'path'
+import sh from '../sh'
+
+import debug from 'debug'
+
+import config from '../../../config'
+
+const { paths } = config
+
+const SCAN_RESULTS_DIR = paths.base('.vuln-scans')
+
+const log = message => debug.log(message)
+log.success = message => debug.log(`✔ ${message}`)
+
+const ensureDirExists = path => {
+  if (!fs.existsSync(path)) {
+    sh(`mkdir -p ${path}`)
+  }
+}
+
+const getTodayScanFilePath = () => {
+  const now = new Date()
+  const fileName = `snyk-${now.getUTCFullYear()}-${now.getUTCMonth() + 1}-${now.getUTCDate()}`
+
+  return path.resolve(SCAN_RESULTS_DIR, fileName)
+}
+
+const recentlyChecked = () => {
+  const recentCheckFilePath = getTodayScanFilePath()
+  return fs.existsSync(recentCheckFilePath)
+}
+
+const registerRecentSucessfulScan = async () => {
+  ensureDirExists(SCAN_RESULTS_DIR)
+
+  const recentScanFilePath = getTodayScanFilePath()
+  await sh(`touch ${recentScanFilePath}`)
+}
+
+/**
+ * The following strategy is used to perform vulnerabilites scan
+ * - check if there is marker of recent sucessful scan
+ * - if this marker exists, skip checks
+ * - if there is no marker, perform check
+ * - if check is successful, create successful check marker
+ */
+task('test:vulns', async () => {
+  if (recentlyChecked()) {
+    log.success('Vulnerabilities check was already performed recently, skipping..')
+    return
+  }
+
+  log('Scanning dependency packages for vulnerabilities..')
+  await sh(`yarn snyk test`)
+  log.success('Vulnerability scan is successfully passed.')
+
+  registerRecentSucessfulScan()
+})

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -14,6 +14,7 @@ require('./build/gulp/tasks/screener')
 require('./build/gulp/tasks/git')
 require('./build/gulp/tasks/test-unit')
 require('./build/gulp/tasks/test-projects')
+require('./build/gulp/tasks/test-vulns')
 
 // global tasks
 task('build', series('dll', parallel('dist', 'build:docs')))

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pretest": "yarn satisfied",
     "test": "gulp test",
     "test:watch": "gulp test:watch",
-    "test:vulns": "snyk test",
+    "test:vulns": "gulp test:vulns",
     "test:visual": "gulp screener",
     "test:projects": "gulp test:projects",
     "generate:component": "gulp generate:component"


### PR DESCRIPTION
Provided changes introduce caching strategy for vulnerability tests - this caching will allow us to stay within monthly quota limit (200 runs per month, while expectation for introduced strategy is 30-60).

### Caching Strategy
The strategy is the following:
- for each yarn.lock
  - run vulnerability scan if there were no any made today, cache result
  - otherwise (if today's cached result present) just skip vulnerability tests