### PR TITLE
feat(segment): color prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add and export compose icons in Teams theme @joheredi ([#639](https://github.com/stardust-ui/react/pull/639))
 - Add `menu` prop to `MenuItem` @mnajdova ([#539](https://github.com/stardust-ui/react/pull/539))
 - Enable RTL for `FocusZone` @sophieH29 ([#646](https://github.com/stardust-ui/react/pull/646))
+- Add `color` prop to `Segment` component @Bugaa92 ([#632](https://github.com/stardust-ui/react/pull/632))
 
 ### Documentation
 - Add more accessibility descriptions to components and behaviors @jurokapsiar  ([#648](https://github.com/stardust-ui/react/pull/648))

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleColor.shorthand.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import _ from 'lodash'
+import { Segment, ProviderConsumer } from '@stardust-ui/react'
+
+const SegmentExampleColor = () => (
+  <ProviderConsumer
+    render={({ siteVariables: { emphasisColors, naturalColors } }) =>
+      _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
+        <>
+          <Segment key={color} color={color} content={_.startCase(color)} inverted />
+          <br />
+        </>
+      ))
+    }
+  />
+)
+
+export default SegmentExampleColor

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleColor.shorthand.tsx
@@ -6,10 +6,7 @@ const SegmentExampleColor = () => (
   <ProviderConsumer
     render={({ siteVariables: { emphasisColors, naturalColors } }) =>
       _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
-        <>
-          <Segment key={color} color={color} content={_.startCase(color)} inverted />
-          <br />
-        </>
+        <Segment key={color} color={color} content={_.startCase(color)} inverted />
       ))
     }
   />

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleColor.shorthand.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import _ from 'lodash'
+import * as React from 'react'
+import * as _ from 'lodash'
 import { Segment, ProviderConsumer } from '@stardust-ui/react'
 
 const SegmentExampleColor = () => (

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleColor.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleColor.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import _ from 'lodash'
+import { Segment, ProviderConsumer } from '@stardust-ui/react'
+
+const SegmentExampleColor = () => (
+  <ProviderConsumer
+    render={({ siteVariables: { emphasisColors, naturalColors } }) =>
+      _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
+        <>
+          <Segment key={color} color={color} inverted>
+            {_.startCase(color)}
+          </Segment>
+          <br />
+        </>
+      ))
+    }
+  />
+)
+
+export default SegmentExampleColor

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleColor.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleColor.tsx
@@ -6,12 +6,9 @@ const SegmentExampleColor = () => (
   <ProviderConsumer
     render={({ siteVariables: { emphasisColors, naturalColors } }) =>
       _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
-        <>
-          <Segment key={color} color={color} inverted>
-            {_.startCase(color)}
-          </Segment>
-          <br />
-        </>
+        <Segment key={color} color={color} inverted>
+          {_.startCase(color)}
+        </Segment>
       ))
     }
   />

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleColor.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleColor.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import _ from 'lodash'
+import * as React from 'react'
+import * as _ from 'lodash'
 import { Segment, ProviderConsumer } from '@stardust-ui/react'
 
 const SegmentExampleColor = () => (

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
@@ -3,9 +3,9 @@ import { Segment } from '@stardust-ui/react'
 
 const SegmentExampleInvertedShorthand = () => (
   <div>
-    <Segment content="Colored segment." color="purple" />
+    <Segment content="Colored segment." color="red" />
     <br />
-    <Segment inverted content="Colored inverted segment" color="purple" />
+    <Segment inverted content="Colored inverted segment" color="red" />
   </div>
 )
 

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.shorthand.tsx
@@ -5,7 +5,7 @@ const SegmentExampleInvertedShorthand = () => (
   <div>
     <Segment content="Colored segment." color="red" />
     <br />
-    <Segment inverted content="Colored inverted segment" color="red" />
+    <Segment inverted content="Colored inverted segment." color="red" />
   </div>
 )
 

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
@@ -6,7 +6,7 @@ const SegmentExampleInvertedShorthand = () => (
     <Segment color="red">Colored segment.</Segment>
     <br />
     <Segment inverted color="red">
-      Colored inverted segment
+      Colored inverted segment.
     </Segment>
   </div>
 )

--- a/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
+++ b/docs/src/examples/components/Segment/Variations/SegmentExampleInverted.tsx
@@ -3,9 +3,9 @@ import { Segment } from '@stardust-ui/react'
 
 const SegmentExampleInvertedShorthand = () => (
   <div>
-    <Segment color="purple">Colored segment.</Segment>
+    <Segment color="red">Colored segment.</Segment>
     <br />
-    <Segment inverted color="purple">
+    <Segment inverted color="red">
       Colored inverted segment
     </Segment>
   </div>

--- a/docs/src/examples/components/Segment/Variations/index.tsx
+++ b/docs/src/examples/components/Segment/Variations/index.tsx
@@ -9,6 +9,11 @@ const Variations = () => (
       description="A segment can have its colors inverted for contrast."
       examplePath="components/Segment/Variations/SegmentExampleInverted"
     />
+    <ComponentExample
+      title="Color"
+      description="A segment can have different colors."
+      examplePath="components/Segment/Variations/SegmentExampleColor"
+    />
   </ExampleSection>
 )
 

--- a/src/themes/teams/components/Segment/segmentStyles.ts
+++ b/src/themes/teams/components/Segment/segmentStyles.ts
@@ -6,22 +6,20 @@ import { SegmentVariables } from './segmentVariables'
 
 const segmentStyles: ComponentSlotStylesInput<SegmentProps, SegmentVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => {
-    const color = _.get(v.colors, p.color, v.color)
+    const segmentColor = _.get(v.colors, p.color)
 
     return {
       padding: v.padding,
-      background: v.background,
+      borderTop: `2px solid transparent`,
       borderRadius: v.borderRadius,
-      boxShadow: '0 1px 1px 1px rgba(34,36,38,.15)',
-      ...(color &&
-        (p.inverted
-          ? {
-              background: color,
-              color: '#eee', // TODO: fix this color once we fix #629
-            }
-          : {
-              borderTop: `2px solid ${color}`,
-            })),
+      boxShadow: `0 1px 1px 1px ${v.boxShadowColor}`,
+      color: v.color,
+      backgroundColor: v.backgroundColor,
+      borderColor: segmentColor,
+      ...(p.inverted && {
+        color: v.backgroundColor,
+        backgroundColor: segmentColor || v.color,
+      }),
     }
   },
 }

--- a/src/themes/teams/components/Segment/segmentStyles.ts
+++ b/src/themes/teams/components/Segment/segmentStyles.ts
@@ -1,10 +1,13 @@
+import * as _ from 'lodash'
+
 import { SegmentProps } from '../../../../components/Segment/Segment'
 import { ICSSInJSStyle, ComponentSlotStylesInput } from '../../../types'
 import { SegmentVariables } from './segmentVariables'
 
 const segmentStyles: ComponentSlotStylesInput<SegmentProps, SegmentVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => {
-    const color = p.color || v.color
+    const color = _.get(v.colors, p.color, v.color)
+
     return {
       padding: v.padding,
       background: v.background,
@@ -14,7 +17,7 @@ const segmentStyles: ComponentSlotStylesInput<SegmentProps, SegmentVariables> = 
         (p.inverted
           ? {
               background: color,
-              color: '#eee',
+              color: '#eee', // TODO: fix this color once we fix #629
             }
           : {
               borderTop: `2px solid ${color}`,

--- a/src/themes/teams/components/Segment/segmentVariables.ts
+++ b/src/themes/teams/components/Segment/segmentVariables.ts
@@ -1,17 +1,22 @@
-import { ComponentVariablesPrepared } from '@stardust-ui/react'
+import { ColorValues } from '../../../types'
+import { mapColorsToScheme } from '../../../../lib'
 
 export interface SegmentVariables {
-  padding: string
-  background: string
-  borderRadius: string
+  colors: ColorValues<string>
   color: string
+  background: string
+  padding: string
+  borderRadius: string | number
 }
 
-const segmentVariables: ComponentVariablesPrepared = siteVariables => ({
-  padding: '1em',
-  background: siteVariables.bodyBackground,
-  borderRadius: 0,
-  color: undefined,
-})
+export default (siteVariables): SegmentVariables => {
+  const colorVariant = 500
 
-export default segmentVariables
+  return {
+    colors: mapColorsToScheme(siteVariables, colorVariant),
+    color: undefined,
+    background: siteVariables.bodyBackground,
+    padding: '1em',
+    borderRadius: 0,
+  }
+}

--- a/src/themes/teams/components/Segment/segmentVariables.ts
+++ b/src/themes/teams/components/Segment/segmentVariables.ts
@@ -4,9 +4,10 @@ import { mapColorsToScheme } from '../../../../lib'
 export interface SegmentVariables {
   colors: ColorValues<string>
   color: string
-  background: string
+  backgroundColor: string
   padding: string
   borderRadius: string | number
+  boxShadowColor: string
 }
 
 export default (siteVariables): SegmentVariables => {
@@ -14,9 +15,10 @@ export default (siteVariables): SegmentVariables => {
 
   return {
     colors: mapColorsToScheme(siteVariables, colorVariant),
-    color: undefined,
-    background: siteVariables.bodyBackground,
+    color: siteVariables.black,
+    backgroundColor: siteVariables.bodyBackground,
     padding: '1em',
     borderRadius: 0,
+    boxShadowColor: 'rgba(34,36,38,.15)',
   }
 }


### PR DESCRIPTION
## feat(segment): color prop

### Description

This PR:
- adds `color` prop to `Segment` component
- creates `Segment` color examples

### API

```jsx
<Segment color={COLOR} .../>
```
 where `COLOR` is one of `'primary' | 'secondary' | 'blue' | 'green' | 'grey'
 | 'orange' | 'pink' | 'purple' | 'teal' | 'red' | 'yellow' | string`

![screenshot 2018-12-18 at 16 03 20](https://user-images.githubusercontent.com/5442794/50160649-8a707100-02e2-11e9-8d34-9d6aa57f27fb.png)

### Known issues:

Segment text color should be dark shade of gray on segments with light background color, tracked by #629 