### PR TITLE
feat(RTL): Enable RTL for keyboard handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add and export compose icons in Teams theme @joheredi ([#639](https://github.com/stardust-ui/react/pull/639))
 - Add `menu` prop to `MenuItem` @mnajdova ([#539](https://github.com/stardust-ui/react/pull/539))
 - Enable RTL for `FocusZone` @sophieH29 ([#646](https://github.com/stardust-ui/react/pull/646))
+- Enable RTL for keyboard handlers @sophieH29 ([#656](https://github.com/stardust-ui/react/pull/656)) 
 
 <!--------------------------------[ v0.15.0 ]------------------------------- -->
 ## [v0.15.0](https://github.com/stardust-ui/react/tree/v0.15.0) (2018-12-17)

--- a/src/lib/getKeyDownHandlers.ts
+++ b/src/lib/getKeyDownHandlers.ts
@@ -8,19 +8,19 @@ import {
 } from 'src/lib/accessibility/types'
 import { State, PropsWithVarsAndStyles } from '../themes/types'
 
+const rtlKeyMap = {
+  [keyboardKey.ArrowRight]: keyboardKey.ArrowLeft,
+  [keyboardKey.ArrowLeft]: keyboardKey.ArrowRight,
+}
+
 /**
  * Assigns onKeyDown handler to the Component's part element, based on Component's actions
  * and keys mappings defined in Accessibility behavior
  * @param {AccessibilityActionHandlers} componentActionHandlers Actions handlers defined in a component.
  * @param {KeyActions} behaviorKeyActions Mappings of actions and keys defined in Accessibility behavior.
  * @param {State & PropsWithVarsAndStyles} props The props which are used to invoke onKeyDown handler passed from top.
+ * @param {boolean} isRtl Indicates if Left and Right arrow keys should be swapped in RTL mode.
  */
-
-const rtlKeyMap = {
-  [keyboardKey.ArrowRight]: keyboardKey.ArrowLeft,
-  [keyboardKey.ArrowLeft]: keyboardKey.ArrowRight,
-}
-
 const getKeyDownHandlers = (
   componentActionHandlers: AccessibilityActionHandlers,
   behaviorKeyActions: KeyActions,

--- a/src/lib/getKeyDownHandlers.ts
+++ b/src/lib/getKeyDownHandlers.ts
@@ -19,13 +19,13 @@ const rtlKeyMap = {
  * @param {AccessibilityActionHandlers} componentActionHandlers Actions handlers defined in a component.
  * @param {KeyActions} behaviorKeyActions Mappings of actions and keys defined in Accessibility behavior.
  * @param {State & PropsWithVarsAndStyles} props The props which are used to invoke onKeyDown handler passed from top.
- * @param {boolean} isRtl Indicates if Left and Right arrow keys should be swapped in RTL mode.
+ * @param {boolean} isRtlEnabled Indicates if Left and Right arrow keys should be swapped in RTL mode.
  */
 const getKeyDownHandlers = (
   componentActionHandlers: AccessibilityActionHandlers,
   behaviorKeyActions: KeyActions,
   props: State & PropsWithVarsAndStyles,
-  isRtl?: boolean,
+  isRtlEnabled?: boolean,
 ): ActionsKeyHandler => {
   const keyHandlers = {}
 
@@ -44,10 +44,11 @@ const getKeyDownHandlers = (
         handledActions.forEach(actionName => {
           let keyCombinations = componentPartKeyAction[actionName].keyCombinations
 
-          if (isRtl) {
+          if (isRtlEnabled) {
             keyCombinations = keyCombinations.map(keyCombination => {
-              if (rtlKeyMap[keyCombination.keyCode]) {
-                keyCombination.keyCode = rtlKeyMap[keyCombination.keyCode]
+              const keyToRtlKey = rtlKeyMap[keyCombination.keyCode]
+              if (keyToRtlKey) {
+                keyCombination.keyCode = keyToRtlKey
               }
               return keyCombination
             })

--- a/src/lib/getKeyDownHandlers.ts
+++ b/src/lib/getKeyDownHandlers.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash'
+import * as keyboardKey from 'keyboard-key'
 import keyboardHandlerFilter from './keyboardHandlerFilter'
 import {
   AccessibilityActionHandlers,
@@ -14,10 +15,17 @@ import { State, PropsWithVarsAndStyles } from '../themes/types'
  * @param {KeyActions} behaviorKeyActions Mappings of actions and keys defined in Accessibility behavior.
  * @param {State & PropsWithVarsAndStyles} props The props which are used to invoke onKeyDown handler passed from top.
  */
+
+const rtlKeyMap = {
+  [keyboardKey.ArrowRight]: keyboardKey.ArrowLeft,
+  [keyboardKey.ArrowLeft]: keyboardKey.ArrowRight,
+}
+
 const getKeyDownHandlers = (
   componentActionHandlers: AccessibilityActionHandlers,
   behaviorKeyActions: KeyActions,
   props: State & PropsWithVarsAndStyles,
+  isRtl?: boolean,
 ): ActionsKeyHandler => {
   const keyHandlers = {}
 
@@ -34,9 +42,20 @@ const getKeyDownHandlers = (
     keyHandlers[componentPart] = {
       onKeyDown: (event: KeyboardEvent) => {
         handledActions.forEach(actionName => {
+          let keyCombinations = componentPartKeyAction[actionName].keyCombinations
+
+          if (isRtl) {
+            keyCombinations = keyCombinations.map(keyCombination => {
+              if (rtlKeyMap[keyCombination.keyCode]) {
+                keyCombination.keyCode = rtlKeyMap[keyCombination.keyCode]
+              }
+              return keyCombination
+            })
+          }
+
           const eventHandler = keyboardHandlerFilter(
             componentActionHandlers[actionName],
-            componentPartKeyAction[actionName].keyCombinations,
+            keyCombinations,
           )
 
           eventHandler && eventHandler(event)

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -63,14 +63,19 @@ export interface RenderConfig<P> {
 const getAccessibility = (
   props: State & PropsWithVarsAndStyles,
   actionHandlers: AccessibilityActionHandlers,
-  isRtl: boolean,
+  isRtlEnabled: boolean,
 ) => {
   const { accessibility: customAccessibility, defaultAccessibility } = props
   const accessibility: AccessibilityDefinition = (customAccessibility ||
     defaultAccessibility ||
     defaultBehavior)(props)
 
-  const keyHandlers = getKeyDownHandlers(actionHandlers, accessibility.keyActions, props, isRtl)
+  const keyHandlers = getKeyDownHandlers(
+    actionHandlers,
+    accessibility.keyActions,
+    props,
+    isRtlEnabled,
+  )
   return {
     ...accessibility,
     keyHandlers,

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -60,13 +60,14 @@ export interface RenderConfig<P> {
 const getAccessibility = (
   props: State & PropsWithVarsAndStyles,
   actionHandlers: AccessibilityActionHandlers,
+  isRtl: boolean,
 ) => {
   const { accessibility: customAccessibility, defaultAccessibility } = props
   const accessibility: AccessibilityDefinition = (customAccessibility ||
     defaultAccessibility ||
     defaultBehavior)(props)
 
-  const keyHandlers = getKeyDownHandlers(actionHandlers, accessibility.keyActions, props)
+  const keyHandlers = getKeyDownHandlers(actionHandlers, accessibility.keyActions, props, isRtl)
   return {
     ...accessibility,
     keyHandlers,
@@ -173,7 +174,13 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>): React.ReactElem
             root: props.styles,
           },
         )
-        const accessibility: AccessibilityBehavior = getAccessibility(stateAndProps, actionHandlers)
+
+        const accessibility: AccessibilityBehavior = getAccessibility(
+          stateAndProps,
+          actionHandlers,
+          rtl,
+        )
+
         const rest = getUnhandledProps(
           { handledProps: [...handledProps, ...accessibility.handledProps] },
           props,

--- a/test/specs/lib/getKeyDownHandlers-test.ts
+++ b/test/specs/lib/getKeyDownHandlers-test.ts
@@ -1,17 +1,18 @@
 import getKeyDownHandlers from 'src/lib/getKeyDownHandlers'
+import * as keyboardKey from 'keyboard-key'
 
-const testKeyCode = 27
+const testKeyCode = keyboardKey.ArrowRight
 const props = {}
 const partElementName = 'anchor'
 let actionsDefinition
 
-const eventArg: any = {
-  keyCode: testKeyCode,
+const eventArg = (keyCodeValue: number): any => ({
+  keyCode: keyCodeValue,
   altKey: false,
   ctrlKey: false,
   metaKey: false,
   shiftKey: false,
-}
+})
 
 describe('getKeyDownHandlers', () => {
   beforeEach(() => {
@@ -87,10 +88,51 @@ describe('getKeyDownHandlers', () => {
 
       const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, props)
 
-      keyHandlers[partElementName] && keyHandlers[partElementName]['onKeyDown'](eventArg)
+      keyHandlers[partElementName] &&
+        keyHandlers[partElementName]['onKeyDown'](eventArg(testKeyCode))
       expect(actions.testAction).toHaveBeenCalled()
       expect(actions.otherAction).toHaveBeenCalled()
       expect(actions.anotherTestAction).not.toHaveBeenCalled()
+    })
+
+    describe('with respect of RTL', () => {
+      test('swap Right key to Left key', () => {
+        const actions = {
+          actionOnLeftArrow: jest.fn(),
+          actionOnRightArrow: jest.fn(),
+        }
+
+        actionsDefinition[partElementName].actionOnLeftArrow = {
+          keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+        }
+        actionsDefinition[partElementName].actionOnRightArrow = {
+          keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
+        }
+        const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, props, /** isRtl */ true)
+
+        keyHandlers[partElementName]['onKeyDown'](eventArg(keyboardKey.ArrowRight))
+        expect(actions.actionOnLeftArrow).toHaveBeenCalled()
+        expect(actions.actionOnRightArrow).not.toHaveBeenCalled()
+      })
+
+      test('swap Left key to Right key', () => {
+        const actions = {
+          actionOnLeftArrow: jest.fn(),
+          actionOnRightArrow: jest.fn(),
+        }
+
+        actionsDefinition[partElementName].actionOnLeftArrow = {
+          keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+        }
+        actionsDefinition[partElementName].actionOnRightArrow = {
+          keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
+        }
+        const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, props, /** isRtl */ true)
+
+        keyHandlers[partElementName]['onKeyDown'](eventArg(keyboardKey.ArrowLeft))
+        expect(actions.actionOnLeftArrow).not.toHaveBeenCalled()
+        expect(actions.actionOnRightArrow).toHaveBeenCalled()
+      })
     })
   })
 

--- a/test/specs/lib/getKeyDownHandlers-test.ts
+++ b/test/specs/lib/getKeyDownHandlers-test.ts
@@ -108,7 +108,12 @@ describe('getKeyDownHandlers', () => {
         actionsDefinition[partElementName].actionOnRightArrow = {
           keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
         }
-        const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, props, /** isRtl */ true)
+        const keyHandlers = getKeyDownHandlers(
+          actions,
+          actionsDefinition,
+          props,
+          /** isRtlEnabled */ true,
+        )
 
         keyHandlers[partElementName]['onKeyDown'](eventArg(keyboardKey.ArrowRight))
         expect(actions.actionOnLeftArrow).toHaveBeenCalled()
@@ -127,7 +132,12 @@ describe('getKeyDownHandlers', () => {
         actionsDefinition[partElementName].actionOnRightArrow = {
           keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
         }
-        const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, props, /** isRtl */ true)
+        const keyHandlers = getKeyDownHandlers(
+          actions,
+          actionsDefinition,
+          props,
+          /** isRtlEnabled */ true,
+        )
 
         keyHandlers[partElementName]['onKeyDown'](eventArg(keyboardKey.ArrowLeft))
         expect(actions.actionOnLeftArrow).not.toHaveBeenCalled()


### PR DESCRIPTION
This PR aims to enable RTL for key handlers, so then when users define `keyHandlers` in accessibility behaviors, in RTL mode, the keys should be swapped:
`Left` -> `Right`
`Right` -> `Left`

Good example to check how it works is a Menu with submenus.