### PR TITLE
fix(Popup): defaultOpen prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `List` - items should be selectable @sophieH29 ([#566](https://github.com/stardust-ui/react/pull/566))
 - Respect `defaultTabbable` element when `FocusZone` container gets focus @sophieH29 ([#637](https://github.com/stardust-ui/react/pull/637))
 - Fix `FocusZone` - fix last breaking changes and make improvements for `Chat` usage @sophieH29 ([#614](https://github.com/stardust-ui/react/pull/614))
+- Fix `defaultOpen` prop in the `Popup` component @mnajdova ([#659](https://github.com/stardust-ui/react/pull/659))
 
 ### Features
 - Add `color` prop to `Text` component @Bugaa92 ([#597](https://github.com/stardust-ui/react/pull/597))

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -183,8 +183,6 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
     }
   }
 
-  public state = { target: undefined, open: false }
-
   public componentDidMount() {
     this.updateOutsideClickSubscription()
 


### PR DESCRIPTION
This PR fixes https://github.com/stardust-ui/react/issues/657 - `defaultOpen` prop on the `Popup` is not working.