### PR TITLE
chore(package): update `react-docgen-typescript`

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "react": "^16.0.0",
     "react-ace": "^5.1.2",
     "react-custom-scrollbars": "^4.2.1",
-    "react-docgen-typescript": "^1.12.0",
+    "react-docgen-typescript": "^1.12.2",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.0.0",
     "react-element-to-jsx-string": "^14.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8405,10 +8405,10 @@ react-custom-scrollbars@^4.2.1:
     prop-types "^15.5.10"
     raf "^3.1.0"
 
-react-docgen-typescript@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.12.0.tgz#be25d3604e05676f05a1248952f8d5823d7a216a"
-  integrity sha512-EAb2W5UNTTR75zTWm8bbn9iQmh+W/9DvnCazIdzDb+TnzvpcxEFCjRia+Rhpkx4FRRS3AYyJrw5Ar3zX51gJfQ==
+react-docgen-typescript@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.12.2.tgz#d5fb578d12f6876efdde69176f4ea658e75a9a29"
+  integrity sha512-pcot0jGiMIyhmwNeSU83GvClNwk9NbcnYHcGf4pKMmw5J43d5OzYRcTzrZTGlIOWjYfYazYhvTxjujE625P3Mw==
 
 react-document-title@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
This PR bumps `react-docgen-typescript` to latest and resolves an issue with `Ref` component:

![image](https://user-images.githubusercontent.com/14183168/50587261-d47e5880-0e85-11e9-923f-17b26bcc23fc.png)

It was fixed in [v1.12.1](https://github.com/styleguidist/react-docgen-typescript/releases/tag/v1.12.1), https://github.com/styleguidist/react-docgen-typescript/pull/153