### PR TITLE
chore(Text): remove unnecessary variable overrides in Teams theme

### DIFF
--- a/src/themes/teams/components/Text/textVariables.ts
+++ b/src/themes/teams/components/Text/textVariables.ts
@@ -1,4 +1,3 @@
-import { mapColorsToScheme } from '../../../../lib'
 import { TextVariables } from '../../../base/components/Text/textVariables'
 
 export interface TeamsTextVariables extends TextVariables {
@@ -7,41 +6,15 @@ export interface TeamsTextVariables extends TextVariables {
   timestampHoverColor: string
 }
 
-export default (siteVariables): TeamsTextVariables => {
-  const colorVariant = 500
-
-  return {
-    colors: mapColorsToScheme(siteVariables, colorVariant),
-    atMentionOtherColor: siteVariables.brand06,
-    atMentionMeColor: siteVariables.orange04,
-    atMentionMeFontWeight: siteVariables.fontWeightBold,
-    disabledColor: siteVariables.gray06,
-    errorColor: siteVariables.red,
-    importantWeight: siteVariables.fontWeightBold,
-    importantColor: siteVariables.red,
-    successColor: siteVariables.green04,
-    timestampColor: siteVariables.gray04,
-    timestampHoverColor: siteVariables.gray02,
-
-    fontSizeExtraSmall: siteVariables.fontSizes.smaller,
-    fontLineHeightExtraSmall: siteVariables.lineHeightExtraSmall,
-
-    fontSizeSmall: siteVariables.fontSizes.small,
-    fontLineHeightSmall: siteVariables.lineHeightSmall,
-
-    fontSizeMedium: siteVariables.fontSizes.medium,
-    fontLineHeightMedium: siteVariables.lineHeightBase,
-
-    fontSizeLarge: siteVariables.fontSizes.large,
-    fontLineHeightLarge: siteVariables.lineHeightSmall,
-
-    fontSizeExtraLarge: siteVariables.fontSizes.larger,
-    fontLineHeightExtraLarge: siteVariables.lineHeightSmall,
-
-    fontWeightLight: siteVariables.fontWeightLight,
-    fontWeightSemilight: siteVariables.fontWeightSemilight,
-    fontWeightRegular: siteVariables.fontWeightRegular,
-    fontWeightSemibold: siteVariables.fontWeightSemibold,
-    fontWeightBold: siteVariables.fontWeightBold,
-  }
-}
+export default (siteVariables): Partial<TeamsTextVariables> => ({
+  atMentionOtherColor: siteVariables.brand06,
+  atMentionMeColor: siteVariables.orange04,
+  atMentionMeFontWeight: siteVariables.fontWeightBold,
+  disabledColor: siteVariables.gray06,
+  errorColor: siteVariables.red,
+  importantWeight: siteVariables.fontWeightBold,
+  importantColor: siteVariables.red,
+  successColor: siteVariables.green04,
+  timestampColor: siteVariables.gray04,
+  timestampHoverColor: siteVariables.gray02,
+})


### PR DESCRIPTION
Teams theme should override only the variables which differ/are added compared to the base theme.
This PR removes redundant variable overrides for `Text` component as these were setting the same value base theme had already set.

No consumer facing change, CHANGELOG entry intentionally not added.