### PR TITLE
fix(Accordion, Menu): consilidating unicode arrow characters across the components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `defaultOpen` prop in the `Popup` component @mnajdova ([#659](https://github.com/stardust-ui/react/pull/659))
 - Fix `Chat` - added themes values for dark and contrast @bcalvery ([#652](https://github.com/stardust-ui/react/pull/652))
 - Fix compatibility with TypeScript 3.2 and handle `null` as a valid value in all optional props @layershifter ([#550](https://github.com/stardust-ui/react/pull/550))
+- Unifying the arrow unicode characters used in different components @mnajdova ([#673](https://github.com/stardust-ui/react/pull/673))
 
 ### Features
 - Add `color` prop to `Text` component @Bugaa92 ([#597](https://github.com/stardust-ui/react/pull/597))

--- a/src/components/Accordion/AccordionTitle.tsx
+++ b/src/components/Accordion/AccordionTitle.tsx
@@ -66,7 +66,7 @@ class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
 
     return (
       <ElementType {...rest} className={classes.root} onClick={this.handleClick}>
-        {active ? <span>&#9660;</span> : <span>&#9654;</span>}
+        {active ? <span>&#x25BE;</span> : <span>&#x25B8;</span>}
         {content}
       </ElementType>
     )

--- a/src/components/Accordion/AccordionTitle.tsx
+++ b/src/components/Accordion/AccordionTitle.tsx
@@ -66,7 +66,6 @@ class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
 
     return (
       <ElementType {...rest} className={classes.root} onClick={this.handleClick}>
-        <span className={classes.arrow} />
         {content}
       </ElementType>
     )

--- a/src/components/Accordion/AccordionTitle.tsx
+++ b/src/components/Accordion/AccordionTitle.tsx
@@ -54,7 +54,7 @@ class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
   }
 
   renderComponent({ ElementType, classes, rest }) {
-    const { active, children, content } = this.props
+    const { children, content } = this.props
 
     if (childrenExist(children)) {
       return (
@@ -66,7 +66,7 @@ class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
 
     return (
       <ElementType {...rest} className={classes.root} onClick={this.handleClick}>
-        {active ? <span>&#x25BE;</span> : <span>&#x25B8;</span>}
+        <span className={classes.arrow} />
         {content}
       </ElementType>
     )

--- a/src/themes/teams/components/Accordion/accordionTitleStyles.ts
+++ b/src/themes/teams/components/Accordion/accordionTitleStyles.ts
@@ -1,4 +1,5 @@
 import { ICSSInJSStyle } from '../../../types'
+import constants from '../../constants'
 
 const accordionTitleStyles = {
   root: (): ICSSInJSStyle => ({
@@ -7,6 +8,16 @@ const accordionTitleStyles = {
     padding: '.5rem 0',
     cursor: 'pointer',
   }),
+  arrow: ({ props }): ICSSInJSStyle => {
+    const { active } = props
+    const { arrowDown, arrowRight } = constants.unicodeCharacters
+    return {
+      '::before': {
+        userSelect: 'none',
+        content: active ? `"${arrowDown}"` : `"${arrowRight}"`,
+      },
+    }
+  },
 }
 
 export default accordionTitleStyles

--- a/src/themes/teams/components/Accordion/accordionTitleStyles.ts
+++ b/src/themes/teams/components/Accordion/accordionTitleStyles.ts
@@ -1,17 +1,14 @@
 import { ICSSInJSStyle } from '../../../types'
-import constants from '../../constants'
 
 const accordionTitleStyles = {
-  root: (): ICSSInJSStyle => ({
-    display: 'inline-block',
-    verticalAlign: 'middle',
-    padding: '.5rem 0',
-    cursor: 'pointer',
-  }),
-  arrow: ({ props }): ICSSInJSStyle => {
+  root: ({ props, theme }): ICSSInJSStyle => {
     const { active } = props
-    const { arrowDown, arrowRight } = constants.unicodeCharacters
+    const { arrowDown, arrowRight } = theme.siteVariables
     return {
+      display: 'inline-block',
+      verticalAlign: 'middle',
+      padding: '.5rem 0',
+      cursor: 'pointer',
       '::before': {
         userSelect: 'none',
         content: active ? `"${arrowDown}"` : `"${arrowRight}"`,

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -2,6 +2,7 @@ import { pxToRem } from '../../utils'
 import { ComponentSlotStyleFunction, ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { MenuVariables } from './menuVariables'
 import { MenuItemProps, MenuItemState } from '../../../../components/Menu/MenuItem'
+import constants from '../../constants'
 
 type MenuItemPropsAndState = MenuItemProps & MenuItemState
 
@@ -252,6 +253,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
 
   root: ({ props, variables: v }): ICSSInJSStyle => {
     const { active, iconOnly, isFromKeyboard, pointing, primary, underlined, vertical } = props
+    const { arrowDown, arrowRight } = constants.unicodeCharacters
 
     return {
       color: 'inherit',
@@ -336,7 +338,8 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
           position: 'relative',
           float: 'right',
           left: pxToRem(10),
-          content: props.vertical ? '"\u25B8"' : '"\u25BE"',
+          userSelect: 'none',
+          content: props.vertical ? `"${arrowRight}"` : `"${arrowDown}"`,
         }),
       },
     }

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -2,7 +2,6 @@ import { pxToRem } from '../../utils'
 import { ComponentSlotStyleFunction, ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { MenuVariables } from './menuVariables'
 import { MenuItemProps, MenuItemState } from '../../../../components/Menu/MenuItem'
-import constants from '../../constants'
 
 type MenuItemPropsAndState = MenuItemProps & MenuItemState
 
@@ -251,9 +250,9 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
     }
   },
 
-  root: ({ props, variables: v }): ICSSInJSStyle => {
+  root: ({ props, variables: v, theme }): ICSSInJSStyle => {
     const { active, iconOnly, isFromKeyboard, pointing, primary, underlined, vertical } = props
-    const { arrowDown, arrowRight } = constants.unicodeCharacters
+    const { arrowDown, arrowRight } = theme.siteVariables
 
     return {
       color: 'inherit',

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -336,10 +336,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
           position: 'relative',
           float: 'right',
           left: pxToRem(10),
-          content: v.submenuIndicatorContent,
-          ...(!props.vertical && {
-            transform: `rotate(${v.submenuIndicatorRotationAngle}deg)`,
-          }),
+          content: props.vertical ? '"\u25B8"' : '"\u25BE"',
         }),
       },
     }

--- a/src/themes/teams/components/Menu/menuVariables.ts
+++ b/src/themes/teams/components/Menu/menuVariables.ts
@@ -22,9 +22,6 @@ export interface MenuVariables {
 
   circularRadius: string
   lineHeightBase: string
-
-  submenuIndicatorContent: string
-  submenuIndicatorRotationAngle: number
 }
 
 export default (siteVars: any): MenuVariables => {
@@ -50,8 +47,5 @@ export default (siteVars: any): MenuVariables => {
 
     circularRadius: pxToRem(999),
     lineHeightBase: siteVars.lineHeightBase,
-
-    submenuIndicatorContent: '">"',
-    submenuIndicatorRotationAngle: 90,
   }
 }

--- a/src/themes/teams/constants.ts
+++ b/src/themes/teams/constants.ts
@@ -1,0 +1,8 @@
+const constants = {
+  unicodeCharacters: {
+    arrowRight: '\u25B8',
+    arrowDown: '\u25BE',
+  },
+}
+
+export default constants

--- a/src/themes/teams/constants.ts
+++ b/src/themes/teams/constants.ts
@@ -1,8 +1,0 @@
-const constants = {
-  unicodeCharacters: {
-    arrowRight: '\u25B8',
-    arrowDown: '\u25BE',
-  },
-}
-
-export default constants

--- a/src/themes/teams/siteVariables.ts
+++ b/src/themes/teams/siteVariables.ts
@@ -98,3 +98,9 @@ export const bodyFontSize = '1.4rem'
 export const bodyBackground = white
 export const bodyColor = black
 export const bodyLineHeight = lineHeightBase
+
+//
+// UNICODE CHARACTERS
+//
+export const arrowRight = '\u25B8'
+export const arrowDown = '\u25BE'


### PR DESCRIPTION
We have inconsistency of using the unicode arrow characters across different components: Accordinon, Menu, Dropdown etc.

## Accordion
![image](https://user-images.githubusercontent.com/4512430/50597553-102a1a00-0ea8-11e9-85ff-757650d58ccb.png)

## Menu
![image](https://user-images.githubusercontent.com/4512430/50597587-2a63f800-0ea8-11e9-8a20-b09e8680f4ae.png)

## Dropdown
The problem on the Dropdown is slightly different, as we are using icon name, that may not even be defined in some themes. (see comment https://github.com/stardust-ui/react/pull/584/files#r244750605)
![image](https://user-images.githubusercontent.com/4512430/50597596-351e8d00-0ea8-11e9-8474-a8e8501ca306.png)

This PR fixes this inconsistency for the Accordion and Menu components (as there is already started work on the Dropdown for handling the toggle button, I propose that it should be fixed in that PR).

This is the look of the components after the changes:

## Accordion
![image](https://user-images.githubusercontent.com/4512430/50597681-8f1f5280-0ea8-11e9-8339-aa41486ab922.png)

## Menu:
![image](https://user-images.githubusercontent.com/4512430/50597676-8595ea80-0ea8-11e9-8ad0-be218563256e.png)
