### PR TITLE
Allow targeting of ListItem content

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -128,7 +128,10 @@ class List extends AutoControlledComponent<ReactProps<ListProps>, ListState> {
           const targetComponent = this.itemRefs[index] && this.itemRefs[index].current
           const targetDomNode = ReactDOM.findDOMNode(targetComponent) as any
 
-          targetDomNode && targetDomNode.focus()
+          if (targetDomNode) {
+            const itemElements = targetDomNode.getElementsByClassName('ui-list__item')
+            if (itemElements.length > 0) itemElements.item(0).focus()
+          }
         })
       },
     )

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -12,6 +12,8 @@ import ItemLayout from '../ItemLayout/ItemLayout'
 import { listItemBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
 import { ReactProps, ComponentEventHandler } from '../../../types/utils'
+import Slot from '../Slot/Slot'
+import cx from 'classnames'
 
 export interface ListItemProps extends UIComponentProps, ContentComponentProps<any> {
   /**
@@ -81,10 +83,13 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>> {
 
     accessibility: PropTypes.func,
     onClick: PropTypes.func,
+
+    wrapper: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
   }
 
   static defaultProps = {
-    as: 'li',
+    as: 'div',
+    wrapper: { as: 'li' },
     accessibility: listItemBehavior as Accessibility,
   }
 
@@ -111,9 +116,10 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>> {
       headerMedia,
       truncateContent,
       truncateHeader,
+      wrapper,
     } = this.props
 
-    return (
+    const itemLayout = (
       <ItemLayout
         as={as}
         className={classes.root}
@@ -132,11 +138,28 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>> {
         headerMediaCSS={styles.headerMedia}
         contentCSS={styles.content}
         onClick={this.handleClick}
-        {...accessibility.attributes.root}
-        {...accessibility.keyHandlers.root}
+        {...accessibility.attributes.item}
+        {...accessibility.keyHandlers.item}
         {...rest}
+        {...!wrapper && { onClick: this.handleClick }}
       />
     )
+
+    if (wrapper) {
+      return Slot.create(wrapper, {
+        defaultProps: {
+          className: cx('ui-list__item__wrapper', classes.wrapper),
+          ...accessibility.attributes.root,
+          ...accessibility.keyHandlers.root,
+        },
+        overrideProps: () => ({
+          children: itemLayout,
+          onClick: this.handleClick,
+        }),
+      })
+    }
+
+    return itemLayout
   }
 }
 

--- a/src/lib/accessibility/Behaviors/List/basicListItemBehavior.ts
+++ b/src/lib/accessibility/Behaviors/List/basicListItemBehavior.ts
@@ -5,12 +5,16 @@ import { Accessibility } from '../../types'
  * The 'listitem' role is used to identify an element that is a single item in a list.
  *
  * @specification
- * Adds role='listitem'.
+ * Adds role 'presentation' to 'root' component's part.
+ * Adds role 'listitem' to 'item' component's part.
  */
 
 const basicListItemBehavior: Accessibility = (props: any) => ({
   attributes: {
     root: {
+      role: 'presentation',
+    },
+    item: {
       role: 'listitem',
     },
   },

--- a/src/lib/accessibility/Behaviors/List/selectableListItemBehavior.ts
+++ b/src/lib/accessibility/Behaviors/List/selectableListItemBehavior.ts
@@ -3,7 +3,8 @@ import * as keyboardKey from 'keyboard-key'
 
 /**
  * @specification
- * Adds role='option'. This role is used for a selectable item in a list.
+ * Adds role 'presentation' to 'root' component's part.
+ * Adds role 'option' to 'item' component's part. This role is used for a selectable item in a list.
  * Adds attribute 'aria-selected=true' based on the property 'selected'. Based on this screen readers will recognize the selected state of the item.
  * Performs click action with 'Enter' and 'Spacebar' on 'root'.
  */
@@ -11,6 +12,9 @@ import * as keyboardKey from 'keyboard-key'
 const selectableListItemBehavior: Accessibility = (props: any) => ({
   attributes: {
     root: {
+      role: 'presentation',
+    },
+    item: {
       role: 'option',
       'aria-selected': !!props['selected'],
     },


### PR DESCRIPTION
Currently ListItem renders a `<li>` and group of `div`s in it. For accessibility purposes, it needs to behave similar to MenuItem and have a wrapper and item slot.
