### PR TITLE
refactor: rename rest to unhandledProps

### DIFF
--- a/build/gulp/tasks/generate/templates/src-components/$DisplayName/$DisplayName.tsx
+++ b/build/gulp/tasks/generate/templates/src-components/$DisplayName/$DisplayName.tsx
@@ -38,11 +38,11 @@ class $DisplayName extends UIComponent<$DisplayNameProps, any> {
     variables: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   }
 
-  renderComponent({ ElementType, classes, rest, styles, variables }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles, variables }) {
     const { children, content } = this.props
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -17,7 +17,7 @@ const formatters = {
   jsx: (val: string = ''): string => formatCode(val, 'babylon'),
 }
 
-const CodeSnippet = ({ fitted, label, value, mode = 'jsx', ...rest }: CodeSnippetProps) => {
+const CodeSnippet = ({ fitted, label, value, mode = 'jsx', ...restProps }: CodeSnippetProps) => {
   const format = formatters[mode]
   const formattedValue = format(value)
     // remove eof line break, they are not helpful for snippets
@@ -30,7 +30,7 @@ const CodeSnippet = ({ fitted, label, value, mode = 'jsx', ...rest }: CodeSnippe
         padding: '1rem',
         marginBottom: fitted ? 0 : '2rem',
         background: EDITOR_BACKGROUND_COLOR,
-        ...rest.style,
+        ...restProps.style,
       }}
     >
       <div
@@ -57,7 +57,7 @@ const CodeSnippet = ({ fitted, label, value, mode = 'jsx', ...rest }: CodeSnippe
         showGutter={false}
         showCursor={false}
         value={formattedValue}
-        {...rest}
+        {...restProps}
       />
     </div>
   )

--- a/docs/src/components/ComponentDoc/ComponentProp/ComponentPropExtra.tsx
+++ b/docs/src/components/ComponentDoc/ComponentProp/ComponentPropExtra.tsx
@@ -26,9 +26,9 @@ const ComponentPropExtra = ({
   children,
   inline,
   title,
-  ...rest
+  ...restProps
 }: Extendable<ComponentPropExtraProps>) => (
-  <div {...rest} style={descriptionStyle}>
+  <div {...restProps} style={descriptionStyle}>
     <strong>{title}</strong>
     <div style={inline ? contentInlineStyle : contentBlockStyle}>{children}</div>
   </div>

--- a/docs/src/components/ComponentDoc/ExampleSection.tsx
+++ b/docs/src/components/ComponentDoc/ExampleSection.tsx
@@ -14,8 +14,8 @@ const sectionStyle: React.CSSProperties = {
   paddingBottom: '5em',
 }
 
-const ExampleSection: any = ({ title, children, ...rest }) => (
-  <Grid padded style={sectionStyle} {...rest}>
+const ExampleSection: any = ({ title, children, ...restProps }) => (
+  <Grid padded style={sectionStyle} {...restProps}>
     <Grid.Column>
       <Header as="h2" style={headerStyle} className="no-anchor">
         {title}

--- a/docs/src/components/DocsLayout.tsx
+++ b/docs/src/components/DocsLayout.tsx
@@ -73,9 +73,9 @@ class DocsLayout extends React.Component<any, any> {
   }
 
   render() {
-    const rest = getUnhandledProps(DocsLayout, this.props)
+    const unhandledProps = getUnhandledProps(DocsLayout, this.props)
 
-    return <Route {...rest} render={this.renderChildren} />
+    return <Route {...unhandledProps} render={this.renderChildren} />
   }
 }
 

--- a/docs/src/examples/components/Tree/Types/TreeTitleCustomizationExample.shorthand.tsx
+++ b/docs/src/examples/components/Tree/Types/TreeTitleCustomizationExample.shorthand.tsx
@@ -30,8 +30,8 @@ const items = [
   },
 ]
 
-const titleRenderer = (Component, { content, open, hasSubtree, ...rest }) => (
-  <Component open={open} hasSubtree={hasSubtree} {...rest}>
+const titleRenderer = (Component, { content, open, hasSubtree, ...restProps }) => (
+  <Component open={open} hasSubtree={hasSubtree} {...restProps}>
     {hasSubtree && <Icon name={open ? 'arrow down' : 'arrow right'} />}
     <span>{content}</span>
   </Component>

--- a/docs/src/prototypes/employeeCard/EmployeeCard.tsx
+++ b/docs/src/prototypes/employeeCard/EmployeeCard.tsx
@@ -27,13 +27,13 @@ class EmployeeCard extends React.Component<Extendable<EmployeeCardProps>, any> {
       email,
       avatar,
       phone,
-      ...rest
+      ...restProps
     } = this.props
     return (
       <Grid
         columns="80% 20%"
         styles={{ width: '320px', padding: '10px 20px 10px 10px', background: 'white' }}
-        {...rest}
+        {...restProps}
       >
         <div>
           <Text size={'medium'} weight={'bold'} as="div">

--- a/docs/src/prototypes/employeeCard/Text.tsx
+++ b/docs/src/prototypes/employeeCard/Text.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { Text as StardustUIText } from '@stardust-ui/react'
 
 const Text = props => {
-  const { muted, ...rest } = props
-  return <StardustUIText {...rest} styles={{ ...(muted && { color: '#888' }) }} />
+  const { muted, ...restProps } = props
+  return <StardustUIText {...restProps} styles={{ ...(muted && { color: '#888' }) }} />
 }
 
 export default Text

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -176,11 +176,11 @@ class Accordion extends AutoControlledComponent<ReactProps<AccordionProps>, any>
     return children
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
     const { children } = this.props
 
     return (
-      <ElementType {...accessibility.attributes.root} {...rest} className={classes.root}>
+      <ElementType {...accessibility.attributes.root} {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : this.renderPanels()}
       </ElementType>
     )

--- a/src/components/Accordion/AccordionContent.tsx
+++ b/src/components/Accordion/AccordionContent.tsx
@@ -44,11 +44,11 @@ class AccordionContent extends UIComponent<ReactProps<AccordionContentProps>, an
     onClick: PropTypes.func,
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  renderComponent({ ElementType, classes, unhandledProps }) {
     const { children, content } = this.props
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/src/components/Accordion/AccordionTitle.tsx
+++ b/src/components/Accordion/AccordionTitle.tsx
@@ -53,19 +53,19 @@ class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  renderComponent({ ElementType, classes, unhandledProps }) {
     const { children, content } = this.props
 
     if (childrenExist(children)) {
       return (
-        <ElementType {...rest} className={classes.root} onClick={this.handleClick}>
+        <ElementType {...unhandledProps} className={classes.root} onClick={this.handleClick}>
           {children}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes.root} onClick={this.handleClick}>
+      <ElementType {...unhandledProps} className={classes.root} onClick={this.handleClick}>
         {content}
       </ElementType>
     )

--- a/src/components/Animation/Animation.tsx
+++ b/src/components/Animation/Animation.tsx
@@ -102,7 +102,7 @@ class Animation extends UIComponent<ReactPropsStrict<AnimationProps>, any> {
     timingFunction: PropTypes.string,
   }
 
-  renderComponent({ ElementType, classes, rest, styles, variables, theme }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles, variables, theme }) {
     const { children, name } = this.props
 
     const animation: AnimationProp = {
@@ -126,7 +126,7 @@ class Animation extends UIComponent<ReactPropsStrict<AnimationProps>, any> {
       : ''
 
     return (
-      <ElementType className={classes.root} {...rest}>
+      <ElementType className={classes.root} {...unhandledProps}>
         {result}
       </ElementType>
     )

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -92,7 +92,7 @@ class Attachment extends UIComponent<ReactProps<AttachmentProps>, any> {
     isFromKeyboard: false,
   }
 
-  renderComponent({ ElementType, classes, rest, styles, variables, accessibility }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles, variables, accessibility }) {
     const { header, description, icon, action, progress } = this.props
 
     return (
@@ -102,7 +102,7 @@ class Attachment extends UIComponent<ReactProps<AttachmentProps>, any> {
         onFocus={this.handleFocus}
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
       >
         {icon && (
           <div className={classes.icon}>

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -80,11 +80,11 @@ class Avatar extends UIComponent<ReactProps<AvatarProps>, any> {
     },
   }
 
-  renderComponent({ ElementType, classes, rest, styles, variables }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles, variables }) {
     const { name, status, image, label, getInitials } = this.props as AvatarPropsWithDefaults
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {Image.create(image, {
           defaultProps: {
             fluid: true,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -125,7 +125,7 @@ class Button extends UIComponent<ReactProps<ButtonProps>, ButtonState> {
     accessibility,
     variables,
     styles,
-    rest,
+    unhandledProps,
   }): React.ReactNode {
     const { children, content, disabled, iconPosition } = this.props
     const hasChildren = childrenExist(children)
@@ -137,7 +137,7 @@ class Button extends UIComponent<ReactProps<ButtonProps>, ButtonState> {
         onClick={this.handleClick}
         onFocus={this.handleFocus}
         {...accessibility.attributes.root}
-        {...rest}
+        {...unhandledProps}
       >
         {hasChildren && children}
         {!hasChildren && iconPosition !== 'after' && this.renderIcon(variables, styles)}

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -44,18 +44,28 @@ class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
     as: 'div',
   }
 
-  public renderComponent({ ElementType, classes, accessibility, styles, rest }): React.ReactNode {
+  public renderComponent({
+    ElementType,
+    classes,
+    accessibility,
+    styles,
+    unhandledProps,
+  }): React.ReactNode {
     const { children, content, buttons, circular } = this.props
     if (_.isNil(buttons)) {
       return (
-        <ElementType {...accessibility.attributes.root} {...rest} className={classes.root}>
+        <ElementType
+          {...accessibility.attributes.root}
+          {...unhandledProps}
+          className={classes.root}
+        >
           {childrenExist(children) ? children : content}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {_.map(buttons, (button, idx) =>
           Button.create(button, {
             defaultProps: {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -46,7 +46,7 @@ class Chat extends UIComponent<ReactProps<ChatProps>, any> {
     focus: () => this.focusZone && this.focusZone.focus(),
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
     const { children, items } = this.props
 
     return (
@@ -54,7 +54,7 @@ class Chat extends UIComponent<ReactProps<ChatProps>, any> {
         className={classes.root}
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
       >
         {childrenExist(children) ? children : _.map(items, item => ChatItem.create(item))}
       </ElementType>

--- a/src/components/Chat/ChatItem.tsx
+++ b/src/components/Chat/ChatItem.tsx
@@ -46,11 +46,16 @@ class ChatItem extends UIComponent<ReactProps<ChatItemProps>, any> {
     gutterPosition: 'start',
   }
 
-  renderComponent({ ElementType, classes, rest, styles }: RenderResultConfig<ChatItemProps>) {
+  renderComponent({
+    ElementType,
+    classes,
+    unhandledProps,
+    styles,
+  }: RenderResultConfig<ChatItemProps>) {
     const { children } = this.props
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : this.renderChatItem(styles)}
       </ElementType>
     )

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -74,7 +74,7 @@ class ChatMessage extends UIComponent<ReactProps<ChatMessageProps>, any> {
     ElementType,
     classes,
     accessibility,
-    rest,
+    unhandledProps,
     styles,
   }: RenderResultConfig<ChatMessageProps>) {
     const { author, children, content, mine, timestamp } = this.props
@@ -85,7 +85,7 @@ class ChatMessage extends UIComponent<ReactProps<ChatMessageProps>, any> {
       <ElementType
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
         className={className}
       >
         {childrenPropExists ? (

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -49,11 +49,11 @@ class Divider extends UIComponent<ReactProps<DividerProps>, any> {
     size: 0,
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  renderComponent({ ElementType, classes, unhandledProps }) {
     const { children, content } = this.props
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -209,13 +209,13 @@ export default class Dropdown extends AutoControlledComponent<
     classes,
     styles,
     variables,
-    rest,
+    unhandledProps,
   }: RenderResultConfig<DropdownProps>) {
     const { search, multiple, toggleButton, getA11yStatusMessage, itemToString } = this.props
     const { searchQuery } = this.state
 
     return (
-      <ElementType className={classes.root} {...rest}>
+      <ElementType className={classes.root} {...unhandledProps}>
         <Downshift
           onChange={this.handleSelectedChange}
           inputValue={search ? searchQuery : undefined}

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -64,7 +64,7 @@ class DropdownItem extends UIComponent<ReactProps<DropdownItemProps>, any> {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  public renderComponent({ classes, rest }: RenderResultConfig<DropdownItemProps>) {
+  public renderComponent({ classes, unhandledProps }: RenderResultConfig<DropdownItemProps>) {
     const { content, header, image, accessibilityItemProps } = this.props
     return (
       <ListItem
@@ -78,7 +78,7 @@ class DropdownItem extends UIComponent<ReactProps<DropdownItemProps>, any> {
         })}
         content={content}
         {...accessibilityItemProps}
-        {...rest}
+        {...unhandledProps}
       />
     )
   }

--- a/src/components/Dropdown/DropdownLabel.tsx
+++ b/src/components/Dropdown/DropdownLabel.tsx
@@ -72,7 +72,7 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  public renderComponent({ rest, styles }: RenderResultConfig<DropdownLabelProps>) {
+  public renderComponent({ unhandledProps, styles }: RenderResultConfig<DropdownLabelProps>) {
     const { header, icon, image } = this.props
 
     return (
@@ -95,7 +95,7 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
             avatar: true,
           },
         })}
-        {...rest}
+        {...unhandledProps}
       />
     )
   }

--- a/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/src/components/Dropdown/DropdownSearchInput.tsx
@@ -92,7 +92,7 @@ class DropdownSearchInput extends UIComponent<ReactProps<DropdownSearchInputProp
     _.invoke(this.props, 'onKeyUp', e, this.props)
   }
 
-  public renderComponent({ rest, styles }: RenderResultConfig<DropdownSearchInputProps>) {
+  public renderComponent({ unhandledProps, styles }: RenderResultConfig<DropdownSearchInputProps>) {
     const {
       accessibilityComboboxProps,
       accessibilityInputProps,
@@ -116,7 +116,7 @@ class DropdownSearchInput extends UIComponent<ReactProps<DropdownSearchInputProp
           onKeyDown: this.handleInputKeyDown,
           ...accessibilityInputProps,
         }}
-        {...rest}
+        {...unhandledProps}
       />
     )
   }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -55,10 +55,15 @@ class Form extends UIComponent<ReactProps<FormProps>, any> {
 
   public static Field = FormField
 
-  public renderComponent({ ElementType, classes, rest }): React.ReactNode {
+  public renderComponent({ ElementType, classes, unhandledProps }): React.ReactNode {
     const { action, children } = this.props
     return (
-      <ElementType className={classes.root} action={action} onSubmit={this.handleSubmit} {...rest}>
+      <ElementType
+        className={classes.root}
+        action={action}
+        onSubmit={this.handleSubmit}
+        {...unhandledProps}
+      >
         {childrenExist(children) ? children : this.renderFields()}
       </ElementType>
     )

--- a/src/components/Form/FormField.tsx
+++ b/src/components/Form/FormField.tsx
@@ -76,7 +76,7 @@ class FormField extends UIComponent<ReactProps<FormFieldProps>, any> {
     accessibility,
     variables,
     styles,
-    rest,
+    unhandledProps,
   }): React.ReactNode {
     const { children, control, id, label, message, name, required, type } = this.props
 
@@ -108,7 +108,7 @@ class FormField extends UIComponent<ReactProps<FormFieldProps>, any> {
     )
 
     return (
-      <ElementType className={classes.root} {...rest}>
+      <ElementType className={classes.root} {...unhandledProps}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -64,11 +64,15 @@ class Grid extends UIComponent<ReactProps<GridProps>, any> {
     accessibility: defaultBehavior,
   }
 
-  public renderComponent({ ElementType, classes, rest }: RenderResultConfig<any>): ReactNode {
+  public renderComponent({
+    ElementType,
+    classes,
+    unhandledProps,
+  }: RenderResultConfig<any>): ReactNode {
     const { children, content } = this.props
 
     return (
-      <ElementType className={classes.root} {...rest}>
+      <ElementType className={classes.root} {...unhandledProps}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -53,19 +53,19 @@ class Header extends UIComponent<ReactProps<HeaderProps>, any> {
 
   static Description = HeaderDescription
 
-  renderComponent({ ElementType, classes, variables: v, rest }) {
+  renderComponent({ ElementType, classes, variables: v, unhandledProps }) {
     const { children, content, description } = this.props
 
     if (childrenExist(children)) {
       return (
-        <ElementType {...rest} className={classes.root}>
+        <ElementType {...unhandledProps} className={classes.root}>
           {children}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {content}
         {HeaderDescription.create(description, {
           defaultProps: {

--- a/src/components/Header/HeaderDescription.tsx
+++ b/src/components/Header/HeaderDescription.tsx
@@ -36,10 +36,10 @@ class HeaderDescription extends UIComponent<ReactProps<HeaderDescriptionProps>, 
     as: 'p',
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  renderComponent({ ElementType, classes, unhandledProps }) {
     const { children, content } = this.props
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -75,32 +75,44 @@ class Icon extends UIComponent<ReactProps<IconProps>, any> {
     accessibility: iconBehavior,
   }
 
-  private renderFontIcon(ElementType, classes, rest, accessibility): React.ReactNode {
-    return <ElementType className={classes.root} {...accessibility.attributes.root} {...rest} />
+  private renderFontIcon(ElementType, classes, unhandledProps, accessibility): React.ReactNode {
+    return (
+      <ElementType
+        className={classes.root}
+        {...accessibility.attributes.root}
+        {...unhandledProps}
+      />
+    )
   }
 
   private renderSvgIcon(
     ElementType,
     svgIconDescriptor: SvgIconSpec,
     classes,
-    rest,
+    unhandledProps,
     accessibility,
   ): React.ReactNode {
     return (
-      <ElementType className={classes.root} {...accessibility.attributes.root} {...rest}>
+      <ElementType className={classes.root} {...accessibility.attributes.root} {...unhandledProps}>
         {svgIconDescriptor && callable(svgIconDescriptor)({ classes })}
       </ElementType>
     )
   }
 
-  public renderComponent({ ElementType, classes, rest, accessibility, theme }) {
+  public renderComponent({ ElementType, classes, unhandledProps, accessibility, theme }) {
     const { icons = {} } = theme
 
     const maybeIcon = icons[this.props.name]
 
     return maybeIcon && maybeIcon.isSvg
-      ? this.renderSvgIcon(ElementType, maybeIcon.icon as SvgIconSpec, classes, rest, accessibility)
-      : this.renderFontIcon(ElementType, classes, rest, accessibility)
+      ? this.renderSvgIcon(
+          ElementType,
+          maybeIcon.icon as SvgIconSpec,
+          classes,
+          unhandledProps,
+          accessibility,
+        )
+      : this.renderFontIcon(ElementType, classes, unhandledProps, accessibility)
   }
 }
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -60,8 +60,14 @@ class Image extends UIComponent<ReactProps<ImageProps>, any> {
     accessibility: imageBehavior as Accessibility,
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest }) {
-    return <ElementType {...accessibility.attributes.root} {...rest} className={classes.root} />
+  renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
+    return (
+      <ElementType
+        {...accessibility.attributes.root}
+        {...unhandledProps}
+        className={classes.root}
+      />
+    )
   }
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -109,13 +109,13 @@ class Input extends AutoControlledComponent<ReactProps<InputProps>, InputState> 
   renderComponent({
     ElementType,
     classes,
-    rest: restProps,
+    unhandledProps,
     styles,
     variables,
   }: RenderResultConfig<InputProps>) {
     const { className, input, inputRef, type, wrapper } = this.props
     const { value = '' } = this.state
-    const [htmlInputProps, rest] = partitionHTMLProps(restProps)
+    const [htmlInputProps, restProps] = partitionHTMLProps(unhandledProps)
 
     return Slot.create(wrapper, {
       defaultProps: {
@@ -149,7 +149,7 @@ class Input extends AutoControlledComponent<ReactProps<InputProps>, InputState> 
           </>
         ),
         styles: styles.root,
-        ...rest,
+        ...restProps,
       },
       overrideProps: {
         as: (wrapper && (wrapper as any).as) || ElementType,

--- a/src/components/ItemLayout/ItemLayout.tsx
+++ b/src/components/ItemLayout/ItemLayout.tsx
@@ -166,7 +166,7 @@ class ItemLayout extends UIComponent<ReactProps<ItemLayoutProps>, any> {
     },
   }
 
-  renderComponent({ ElementType, classes, rest, styles }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles }) {
     const { as, debug, endMedia, media, renderMainArea, rootCSS, mediaCSS, endMediaCSS } = this
       .props as ItemLayoutPropsWithDefaults
 
@@ -202,7 +202,7 @@ class ItemLayout extends UIComponent<ReactProps<ItemLayoutProps>, any> {
             </span>
           )
         }
-        {...rest}
+        {...unhandledProps}
       />
     )
   }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -79,12 +79,12 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     }
   }
 
-  renderComponent({ ElementType, classes, rest, variables, styles }) {
+  renderComponent({ ElementType, classes, unhandledProps, variables, styles }) {
     const { children, content, icon, iconPosition, image, imagePosition } = this.props
 
     if (childrenExist(children)) {
       return (
-        <ElementType {...rest} className={classes.root}>
+        <ElementType {...unhandledProps} className={classes.root}>
           {children}
         </ElementType>
       )
@@ -113,7 +113,7 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     const hasEndElement = endIcon || endImage
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         <Layout
           start={
             hasStartElement && (

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -114,7 +114,7 @@ class Layout extends UIComponent<ReactProps<LayoutProps>, any> {
     },
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  renderComponent({ ElementType, classes, unhandledProps }) {
     const {
       reducing,
       disappearing,
@@ -132,7 +132,7 @@ class Layout extends UIComponent<ReactProps<LayoutProps>, any> {
     const endArea = renderEndArea({ ...this.props, classes })
 
     if (!startArea && !mainArea && !endArea) {
-      return <ElementType {...rest} className={classes.root} />
+      return <ElementType {...unhandledProps} className={classes.root} />
     }
 
     const activeAreas = [startArea, mainArea, endArea].filter(Boolean)
@@ -151,14 +151,14 @@ class Layout extends UIComponent<ReactProps<LayoutProps>, any> {
         endArea && 'ui-layout--reduced__end',
       )
       return (
-        <ElementType {...rest} className={composedClasses}>
+        <ElementType {...unhandledProps} className={composedClasses}>
           {start || main || end}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {startArea}
         {startArea && mainArea && renderGap({ ...this.props, classes })}
         {mainArea}

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -134,14 +134,14 @@ class List extends AutoControlledComponent<ReactProps<ListProps>, ListState> {
     )
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
     const { children } = this.props
 
     return (
       <ElementType
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
         className={classes.root}
       >
         {childrenExist(children) ? children : this.renderItems()}

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -99,7 +99,7 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>> {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  renderComponent({ classes, accessibility, rest, styles }) {
+  renderComponent({ classes, accessibility, unhandledProps, styles }) {
     const {
       as,
       debug,
@@ -134,7 +134,7 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>> {
         onClick={this.handleClick}
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
       />
     )
   }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -183,10 +183,10 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
     })
   }
 
-  renderComponent({ ElementType, classes, accessibility, variables, rest }) {
+  renderComponent({ ElementType, classes, accessibility, variables, unhandledProps }) {
     const { children } = this.props
     return (
-      <ElementType {...accessibility.attributes.root} {...rest} className={classes.root}>
+      <ElementType {...accessibility.attributes.root} {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : this.renderItems(variables)}
       </ElementType>
     )

--- a/src/components/Menu/MenuDivider.tsx
+++ b/src/components/Menu/MenuDivider.tsx
@@ -33,8 +33,8 @@ class MenuDivider extends UIComponent<ReactProps<MenuDividerProps>, any> {
     vertical: PropTypes.bool,
   }
 
-  renderComponent({ ElementType, classes, rest }) {
-    return <ElementType {...rest} className={classes.root} />
+  renderComponent({ ElementType, classes, unhandledProps }) {
+    return <ElementType {...unhandledProps} className={classes.root} />
   }
 }
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -171,7 +171,7 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
     this.outsideClickSubscription.unsubscribe()
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest, styles }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps, styles }) {
     const { children, content, icon, wrapper, menu, primary, secondary, active } = this.props
 
     const { menuOpen } = this.state
@@ -185,7 +185,7 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
           {...accessibility.attributes.anchor}
-          {...rest}
+          {...unhandledProps}
           {...!wrapper && { onClick: this.handleClick }}
         >
           {icon &&

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -248,21 +248,21 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
      * The focus is adding the focus, blur and click event (always opening on click)
      */
     if (_.includes(normalizedOn, 'focus')) {
-      triggerProps.onFocus = (e, ...rest) => {
+      triggerProps.onFocus = (e, ...args) => {
         if (isFromKeyboard()) {
           this.trySetOpen(true, e)
         }
-        _.invoke(triggerElement, 'props.onFocus', e, ...rest)
+        _.invoke(triggerElement, 'props.onFocus', e, ...args)
       }
-      triggerProps.onBlur = (e, ...rest) => {
+      triggerProps.onBlur = (e, ...args) => {
         if (this.shouldBlurClose(e)) {
           this.trySetOpen(false, e)
         }
-        _.invoke(triggerElement, 'props.onBlur', e, ...rest)
+        _.invoke(triggerElement, 'props.onBlur', e, ...args)
       }
-      triggerProps.onClick = (e, ...rest) => {
+      triggerProps.onClick = (e, ...args) => {
         this.setPopupOpen(true, e)
-        _.invoke(triggerElement, 'props.onClick', e, ...rest)
+        _.invoke(triggerElement, 'props.onClick', e, ...args)
       }
     }
 
@@ -270,9 +270,9 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
      * The click is toggling the open state of the popup
      */
     if (_.includes(normalizedOn, 'click')) {
-      triggerProps.onClick = (e, ...rest) => {
+      triggerProps.onClick = (e, ...args) => {
         this.trySetOpen(!this.state.open, e)
-        _.invoke(triggerElement, 'props.onClick', e, ...rest)
+        _.invoke(triggerElement, 'props.onClick', e, ...args)
       }
     }
 
@@ -280,23 +280,23 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
      * The hover is adding the mouseEnter, mouseLeave, blur and click event (always opening on click)
      */
     if (_.includes(normalizedOn, 'hover')) {
-      triggerProps.onMouseEnter = (e, ...rest) => {
+      triggerProps.onMouseEnter = (e, ...args) => {
         this.setPopupOpen(true, e)
-        _.invoke(triggerElement, 'props.onMouseEnter', e, ...rest)
+        _.invoke(triggerElement, 'props.onMouseEnter', e, ...args)
       }
-      triggerProps.onMouseLeave = (e, ...rest) => {
+      triggerProps.onMouseLeave = (e, ...args) => {
         this.setPopupOpen(false, e)
-        _.invoke(triggerElement, 'props.onMouseLeave', e, ...rest)
+        _.invoke(triggerElement, 'props.onMouseLeave', e, ...args)
       }
-      triggerProps.onClick = (e, ...rest) => {
+      triggerProps.onClick = (e, ...args) => {
         this.setPopupOpen(true, e)
-        _.invoke(triggerElement, 'props.onClick', e, ...rest)
+        _.invoke(triggerElement, 'props.onClick', e, ...args)
       }
-      triggerProps.onBlur = (e, ...rest) => {
+      triggerProps.onBlur = (e, ...args) => {
         if (this.shouldBlurClose(e)) {
           this.trySetOpen(false, e)
         }
-        _.invoke(triggerElement, 'props.onBlur', e, ...rest)
+        _.invoke(triggerElement, 'props.onBlur', e, ...args)
       }
     }
 

--- a/src/components/Popup/PopupContent.tsx
+++ b/src/components/Popup/PopupContent.tsx
@@ -61,14 +61,14 @@ class PopupContent extends UIComponent<ReactProps<PopupContentProps>, any> {
   public renderComponent({
     ElementType,
     classes,
-    rest,
+    unhandledProps,
   }: RenderResultConfig<PopupContentProps>): React.ReactNode {
     const { children, content } = this.props
 
     return (
       <ElementType
         className={classes.root}
-        {...rest}
+        {...unhandledProps}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
       >

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -179,11 +179,11 @@ class Portal extends AutoControlledComponent<ReactPropsStrict<PortalProps>, Port
     _.invoke(this.props, 'triggerRef', triggerNode)
   }
 
-  private handleTriggerClick = (e: ReactMouseEvent, ...rest) => {
+  private handleTriggerClick = (e: ReactMouseEvent, ...unhandledProps) => {
     const { trigger } = this.props
 
     _.invoke(this.props, 'onTriggerClick', e) // Call handler from parent component
-    _.invoke(trigger, 'props.onClick', e, ...rest) // Call original event handler
+    _.invoke(trigger, 'props.onClick', e, ...unhandledProps) // Call original event handler
     this.trySetState({ open: !this.state.open })
   }
 

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -77,13 +77,13 @@ class RadioGroup extends AutoControlledComponent<ReactProps<RadioGroupProps>, an
 
   static Item = RadioGroupItem
 
-  renderComponent({ ElementType, classes, accessibility, rest }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
     const { children, vertical } = this.props
     return (
       <ElementType
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
         className={classes.root}
       >
         {childrenExist(children) ? children : this.renderItems(vertical)}

--- a/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/src/components/RadioGroup/RadioGroupItem.tsx
@@ -142,14 +142,14 @@ class RadioGroupItem extends AutoControlledComponent<
     this.elementRef = ReactDOM.findDOMNode(this) as HTMLElement
   }
 
-  renderComponent({ ElementType, classes, rest, styles, variables, accessibility }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles, variables, accessibility }) {
     const { label, icon } = this.props
 
     return (
       <ElementType
         {...accessibility.attributes.root}
         {...accessibility.keyHandlers.root}
-        {...rest}
+        {...unhandledProps}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         onClick={this.handleClick}

--- a/src/components/Segment/Segment.tsx
+++ b/src/components/Segment/Segment.tsx
@@ -38,11 +38,11 @@ class Segment extends UIComponent<ReactProps<SegmentProps>, any> {
     as: 'div',
   }
 
-  renderComponent({ ElementType, classes, rest }) {
+  renderComponent({ ElementType, classes, unhandledProps }) {
     const { children, content } = this.props
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : Slot.create(content)}
       </ElementType>
     )

--- a/src/components/Slot/Slot.tsx
+++ b/src/components/Slot/Slot.tsx
@@ -30,11 +30,11 @@ const Slot: CreateComponentReturnType<ReactProps<SlotProps>> & {
   },
 
   render(config, props) {
-    const { ElementType, classes, rest } = config
+    const { ElementType, classes, unhandledProps } = config
     const { children, content } = props
 
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {childrenExist(children) ? children : content}
       </ElementType>
     )

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -52,10 +52,10 @@ class Status extends UIComponent<ReactProps<StatusProps>, any> {
     state: 'unknown',
   }
 
-  renderComponent({ ElementType, classes, rest, variables, styles }) {
+  renderComponent({ ElementType, classes, unhandledProps, variables, styles }) {
     const { icon } = this.props as StatusPropsWithDefaults
     return (
-      <ElementType {...rest} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {Icon.create(icon, {
           defaultProps: {
             size: 'smallest',

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -85,7 +85,7 @@ class Text extends UIComponent<ReactProps<TextProps>, any> {
     as: 'span',
   }
 
-  renderComponent({ ElementType, classes, rest }): React.ReactNode {
+  renderComponent({ ElementType, classes, unhandledProps }): React.ReactNode {
     const { children, content } = this.props
 
     const hasChildren = childrenExist(children)
@@ -93,7 +93,7 @@ class Text extends UIComponent<ReactProps<TextProps>, any> {
     const maybeDirAuto = !hasChildren && typeof content === 'string' ? { dir: 'auto' } : null
 
     return (
-      <ElementType className={classes.root} {...maybeDirAuto} {...rest}>
+      <ElementType className={classes.root} {...maybeDirAuto} {...unhandledProps}>
         {hasChildren ? children : content}
       </ElementType>
     )

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -71,11 +71,11 @@ class Tree extends UIComponent<ReactProps<TreeProps>> {
     )
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest, styles, variables }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps, styles, variables }) {
     const { children } = this.props
 
     return (
-      <ElementType className={classes.root} {...accessibility.attributes.root} {...rest}>
+      <ElementType className={classes.root} {...accessibility.attributes.root} {...unhandledProps}>
         {childrenExist(children) ? children : this.renderContent()}
       </ElementType>
     )

--- a/src/components/Tree/TreeItem.tsx
+++ b/src/components/Tree/TreeItem.tsx
@@ -108,11 +108,11 @@ class TreeItem extends AutoControlledComponent<ReactProps<TreeItemProps>, TreeIt
     )
   }
 
-  renderComponent({ ElementType, accessibility, classes, rest, styles, variables }) {
+  renderComponent({ ElementType, accessibility, classes, unhandledProps, styles, variables }) {
     const { children } = this.props
 
     return (
-      <ElementType className={classes.root} {...accessibility.attributes.root} {...rest}>
+      <ElementType className={classes.root} {...accessibility.attributes.root} {...unhandledProps}>
         {childrenExist(children) ? children : this.renderContent()}
       </ElementType>
     )

--- a/src/components/Tree/TreeTitle.tsx
+++ b/src/components/Tree/TreeTitle.tsx
@@ -56,7 +56,7 @@ class TreeTitle extends UIComponent<ReactProps<TreeTitleProps>> {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  renderComponent({ ElementType, classes, accessibility, rest, styles, variables }) {
+  renderComponent({ ElementType, classes, accessibility, unhandledProps, styles, variables }) {
     const { children, content } = this.props
 
     return (
@@ -64,7 +64,7 @@ class TreeTitle extends UIComponent<ReactProps<TreeTitleProps>> {
         className={classes.root}
         onClick={this.handleClick}
         {...accessibility.attributes.root}
-        {...rest}
+        {...unhandledProps}
       >
         {childrenExist(children) ? children : content}
       </ElementType>

--- a/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -72,7 +72,7 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
 
   public render(): JSX.Element {
     const { className, ariaLabelledBy } = this.props
-    const rest = getUnhandledProps(
+    const unhandledProps = getUnhandledProps(
       { handledProps: [..._.keys(FocusTrapZone.propTypes)] },
       this.props,
     )
@@ -85,7 +85,7 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
 
     return (
       <ElementType
-        {...rest}
+        {...unhandledProps}
         className={className}
         ref={this.createRef}
         aria-labelledby={ariaLabelledBy}

--- a/src/lib/accessibility/FocusZone/FocusZone.tsx
+++ b/src/lib/accessibility/FocusZone/FocusZone.tsx
@@ -146,11 +146,14 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
       { defaultProps: FocusZone.defaultProps },
       this.props,
     ) as React.ComponentClass<FocusZoneProps>
-    const rest = getUnhandledProps({ handledProps: [..._.keys(FocusZone.propTypes)] }, this.props)
+    const unhandledProps = getUnhandledProps(
+      { handledProps: [..._.keys(FocusZone.propTypes)] },
+      this.props,
+    )
 
     return (
       <ElementType
-        {...rest}
+        {...unhandledProps}
         className={cx(FocusZone.className, className)}
         data-focuszone-id={this._id}
         onKeyDown={this._onKeyDown}

--- a/src/lib/customPropTypes.tsx
+++ b/src/lib/customPropTypes.tsx
@@ -159,7 +159,7 @@ export const every = (validators: Function[]) => (
   props: ObjectOf<any>,
   propName: string,
   componentName: string,
-  ...rest: any[]
+  ...args: any[]
 ) => {
   if (!Array.isArray(validators)) {
     throw new Error(
@@ -177,7 +177,7 @@ export const every = (validators: Function[]) => (
           `every() argument "validators" should contain functions, found: ${typeOf(validator)}.`,
         )
       }
-      return validator(props, propName, componentName, ...rest)
+      return validator(props, propName, componentName, ...args)
     }),
     _.compact,
   )(validators)
@@ -194,7 +194,7 @@ export const some = (validators: Function[]) => (
   props: ObjectOf<any>,
   propName: string,
   componentName: string,
-  ...rest: any[]
+  ...args: any[]
 ) => {
   if (!Array.isArray(validators)) {
     throw new Error(
@@ -212,7 +212,7 @@ export const some = (validators: Function[]) => (
           `some() argument "validators" should contain functions, found: ${typeOf(validator)}.`,
         )
       }
-      return validator(props, propName, componentName, ...rest)
+      return validator(props, propName, componentName, ...args)
     }, validators),
   )
 
@@ -235,7 +235,7 @@ export const givenProps = (propsShape: object, validator: Function) => (
   props: ObjectOf<any>,
   propName: string,
   componentName: string,
-  ...rest: any
+  ...args: any
 ) => {
   if (!_.isPlainObject(propsShape)) {
     throw new Error(
@@ -259,13 +259,13 @@ export const givenProps = (propsShape: object, validator: Function) => (
     const val = propsShape[key]
     // require propShape validators to pass or prop values to match
     return typeof val === 'function'
-      ? !val(props, key, componentName, ...rest)
+      ? !val(props, key, componentName, ...args)
       : val === props[propName]
   })
 
   if (!shouldValidate) return undefined
 
-  const error = validator(props, propName, componentName, ...rest)
+  const error = validator(props, propName, componentName, ...args)
 
   if (error) {
     // poor mans shallow pretty print, prevents JSON circular reference errors

--- a/src/lib/htmlPropsUtils.tsx
+++ b/src/lib/htmlPropsUtils.tsx
@@ -81,7 +81,7 @@ export const htmlInputEvents = [
 export const htmlInputProps = [...htmlInputAttrs, ...htmlInputEvents]
 
 /**
- * Returns an array of objects consisting of: props of html input element and rest.
+ * Returns an array of objects consisting of: props of html input element and restProps.
  * @param {object} props A ReactElement props object
  * @param {Object} [options={}]
  * @param {Array} [options.htmlProps] An array of html input props
@@ -91,13 +91,13 @@ export const htmlInputProps = [...htmlInputAttrs, ...htmlInputEvents]
 export const partitionHTMLProps = (props, options: any = {}) => {
   const { htmlProps = htmlInputProps, includeAria = true } = options
   const inputProps = {}
-  const rest = {}
+  const restProps = {}
 
   _.forEach(props, (val, prop) => {
     const possibleAria = includeAria && (/^aria-.*$/.test(prop) || prop === 'role')
-    const target = _.includes(htmlProps, prop) || possibleAria ? inputProps : rest
+    const target = _.includes(htmlProps, prop) || possibleAria ? inputProps : restProps
     target[prop] = val
   })
 
-  return [inputProps, rest]
+  return [inputProps, restProps]
 }

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -38,7 +38,7 @@ export interface RenderResultConfig<P> {
   // https://github.com/Microsoft/TypeScript/issues/28768
   ElementType: React.ComponentType<P> | string
   classes: ComponentSlotClasses
-  rest: Props
+  unhandledProps: Props
   variables: ComponentVariablesObject
   styles: ComponentSlotStylesPrepared
   accessibility: AccessibilityBehavior
@@ -129,10 +129,10 @@ const renderWithFocusZone = <P extends {}>(
   if (focusZoneDefinition.mode === FocusZoneMode.Embed) {
     const originalElementType = config.ElementType
     config.ElementType = FabricFocusZone as any
-    config.rest = { ...config.rest, ...focusZoneDefinition.props }
-    config.rest.as = originalElementType
-    config.rest.ref = focusZoneRef
-    config.rest.isRtl = config.rtl
+    config.unhandledProps = { ...config.unhandledProps, ...focusZoneDefinition.props }
+    config.unhandledProps.as = originalElementType
+    config.unhandledProps.ref = focusZoneRef
+    config.unhandledProps.isRtl = config.rtl
   }
   return render(config)
 }
@@ -198,7 +198,7 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>): React.ReactElem
           rtl,
         )
 
-        const rest = getUnhandledProps(
+        const unhandledProps = getUnhandledProps(
           { handledProps: [...handledProps, ...accessibility.handledProps] },
           props,
         )
@@ -223,7 +223,7 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>): React.ReactElem
 
         const config: RenderResultConfig<P> = {
           ElementType,
-          rest,
+          unhandledProps,
           classes,
           variables: resolvedVariables,
           styles: resolvedStyles,

--- a/test/specs/commonTests/isConformant.tsx
+++ b/test/specs/commonTests/isConformant.tsx
@@ -345,7 +345,7 @@ export default (Component, options: Conformant = {}) => {
         if (eventTarget.length === 0) {
           throw new Error(
             'The event prop was not delegated to the children. You probably ' +
-              'forgot to use `getUnhandledProps` util to spread the `rest` props.',
+              'forgot to use `getUnhandledProps` util to spread the `unhandledProps` props.',
           )
         }
         const customHandler: Function = eventTarget.prop(listenerName)
@@ -484,7 +484,7 @@ export default (Component, options: Conformant = {}) => {
       const mixedClasses = getClassesOfRootElement(wrapperWithCustomClasses)
 
       const message = [
-        'Make sure you are using the `getUnhandledProps` util to spread the `rest` props.',
+        'Make sure you are using the `getUnhandledProps` util to spread the `unhandledProps` props.',
         'This may also be of help: https://facebook.github.io/react/docs/transferring-props.html.',
       ].join(' ')
 

--- a/test/specs/commonTests/stylesFunction-test.tsx
+++ b/test/specs/commonTests/stylesFunction-test.tsx
@@ -37,8 +37,8 @@ const testStylesForComponent = ({
 
     public state = state
 
-    public renderComponent({ ElementType, classes, rest }): React.ReactNode {
-      return <ElementType {...rest} className={classes.root} />
+    public renderComponent({ ElementType, classes, unhandledProps }): React.ReactNode {
+      return <ElementType {...unhandledProps} className={classes.root} />
     }
   }
 

--- a/test/specs/lib/htmlInputPropsUtils-test.ts
+++ b/test/specs/lib/htmlInputPropsUtils-test.ts
@@ -13,28 +13,28 @@ describe('partitionHTMLProps', () => {
   })
 
   test('should split props by definition', () => {
-    const [htmlProps, rest] = partitionHTMLProps(props)
+    const [htmlProps, restProps] = partitionHTMLProps(props)
 
     expect(htmlProps).toEqual({
       autoFocus: false,
       placeholder: 'baz',
       required: true,
     })
-    expect(rest).toEqual({ className: 'foo' })
+    expect(restProps).toEqual({ className: 'foo' })
   })
 
   test('should split props by own definition', () => {
-    const [htmlProps, rest] = partitionHTMLProps(props, {
+    const [htmlProps, restProps] = partitionHTMLProps(props, {
       htmlProps: ['placeholder', 'required'],
     })
 
     expect(htmlProps).toEqual({ placeholder: 'baz', required: true })
-    expect(rest).toEqual({ autoFocus: false, className: 'foo' })
+    expect(restProps).toEqual({ autoFocus: false, className: 'foo' })
   })
 
   describe('aria', () => {
     test('split aria props by default to htmlProps', () => {
-      const [htmlProps, rest] = partitionHTMLProps({
+      const [htmlProps, restProps] = partitionHTMLProps({
         'aria-atomic': false,
         'aria-busy': true,
         className: 'foo',
@@ -46,11 +46,11 @@ describe('partitionHTMLProps', () => {
         'aria-busy': true,
         role: 'bar',
       })
-      expect(rest).toEqual({ className: 'foo' })
+      expect(restProps).toEqual({ className: 'foo' })
     })
 
-    test('split aria props by default to rest when disabled', () => {
-      const [htmlProps, rest] = partitionHTMLProps(
+    test('split aria props by default to restProps when disabled', () => {
+      const [htmlProps, restProps] = partitionHTMLProps(
         {
           'aria-atomic': false,
           'aria-busy': true,
@@ -61,7 +61,7 @@ describe('partitionHTMLProps', () => {
       )
 
       expect(htmlProps).toEqual({})
-      expect(rest).toEqual({
+      expect(restProps).toEqual({
         'aria-atomic': false,
         'aria-busy': true,
         className: 'foo',


### PR DESCRIPTION
Fixes #176 

This PR refactors the use of `rest` variable name.  Patterns followed:

### getUnhandledProps()

Return result now named `unhandledProps`.

```diff
-const rest = getUnhandledProps()
+const unhandledProps = getUnhandledProps()
```

### renderComponent()

The `rest` option is now `unhandledProps`, from `getUnhandledProps` above.

```diff
-renderComponent({ rest }: RenderResultConfig) { ... }
+renderComponent({ unhandledProps }: RenderResultConfig) { ... }
```

### Component Props

Cases where all remaining props are gathered using the rest operator is now `restProps`.

```diff
-const Button = ({ disabled, ...rest }) => { ... }
+const Button = ({ disabled, ...restProps }) => { ... }
```

### Function Arguments

Cases using the rest operator to gather function arguments use `args`.

```diff
-const apply = (context, fn, ...rest) => { ... }
+const apply = (context, fn, ...args) => { ... }
```

