### PR TITLE
refactor(Dropdown): rename DropdownLabel to DropdownSelectedItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Rename `DropdownLabel` to `DropdownSelectedItem` and extract styles @layershifter ([#725](https://github.com/stardust-ui/react/pull/725))
+
 ### Documentation
 - Fix ignored initial state of knobs @layershifter ([#720](https://github.com/stardust-ui/react/pull/720))
 - Fix unclearable example's code @layershifter ([#720](https://github.com/stardust-ui/react/pull/720))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Fixes
+### BREAKING
 - Rename `DropdownLabel` to `DropdownSelectedItem` and extract styles @layershifter ([#725](https://github.com/stardust-ui/react/pull/725))
 
 ### Documentation

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -70,7 +70,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
    */
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<ShorthandValue>) => string
 
-  /** Array of props for generating list options (Dropdown.Item[]) and selected item labels(Dropdown.Label[]), if it's a multiple selection. */
+  /** Array of props for generating list options (Dropdown.Item[]) and selected item labels(Dropdown.SelectedItem[]), if it's a multiple selection. */
   items?: ShorthandValue[]
 
   /**
@@ -252,7 +252,7 @@ export default class Dropdown extends AutoControlledComponent<
                   className={classes.container}
                   onClick={multiple ? this.handleContainerClick.bind(this, isOpen) : undefined}
                 >
-                  {multiple && this.renderSelectedItems(styles)}
+                  {multiple && this.renderSelectedItems()}
                   {search
                     ? this.renderSearchInput(
                         accessibilityRootPropsRest,
@@ -442,7 +442,7 @@ export default class Dropdown extends AutoControlledComponent<
     ]
   }
 
-  private renderSelectedItems(styles: ComponentSlotStylesInput) {
+  private renderSelectedItems() {
     const value = this.state.value as ShorthandValue[]
 
     if (value.length === 0) {
@@ -452,7 +452,6 @@ export default class Dropdown extends AutoControlledComponent<
     return value.map(item =>
       DropdownSelectedItem.create(item, {
         defaultProps: {
-          styles: styles.label,
           ...(typeof item === 'object' &&
             !item.hasOwnProperty('key') && {
               key: (item as any).header,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -31,7 +31,7 @@ import Text from '../Text/Text'
 import Ref from '../Ref/Ref'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import DropdownItem from './DropdownItem'
-import DropdownLabel, { DropdownLabelProps } from './DropdownLabel'
+import DropdownSelectedItem, { DropdownSelectedItemProps } from './DropdownSelectedItem'
 import DropdownSearchInput, { DropdownSearchInputProps } from './DropdownSearchInput'
 import Button from '../Button/Button'
 
@@ -191,8 +191,8 @@ export default class Dropdown extends AutoControlledComponent<
   static autoControlledProps = ['searchQuery', 'value']
 
   static Item = DropdownItem
-  static Label = DropdownLabel
   static SearchInput = DropdownSearchInput
+  static SelectedItem = DropdownSelectedItem
 
   getInitialAutoControlledState({ multiple, search }: DropdownProps): DropdownState {
     return {
@@ -450,7 +450,7 @@ export default class Dropdown extends AutoControlledComponent<
     }
 
     return value.map(item =>
-      DropdownLabel.create(item, {
+      DropdownSelectedItem.create(item, {
         defaultProps: {
           styles: styles.label,
           ...(typeof item === 'object' &&
@@ -458,7 +458,7 @@ export default class Dropdown extends AutoControlledComponent<
               key: (item as any).header,
             }),
         },
-        overrideProps: (predefinedProps: DropdownLabelProps) =>
+        overrideProps: (predefinedProps: DropdownSelectedItemProps) =>
           this.handleSelectedItemOverrides(predefinedProps, item),
       }),
     )
@@ -552,16 +552,16 @@ export default class Dropdown extends AutoControlledComponent<
   })
 
   private handleSelectedItemOverrides = (
-    predefinedProps: DropdownLabelProps,
+    predefinedProps: DropdownSelectedItemProps,
     item: ShorthandValue,
   ) => ({
-    onRemove: (e: React.SyntheticEvent, dropdownLabelProps: DropdownLabelProps) => {
+    onRemove: (e: React.SyntheticEvent, DropdownSelectedItemProps: DropdownSelectedItemProps) => {
       this.handleSelectedItemRemove(e, item)
-      _.invoke(predefinedProps, 'onRemove', e, dropdownLabelProps)
+      _.invoke(predefinedProps, 'onRemove', e, DropdownSelectedItemProps)
     },
-    onClick: (e: React.SyntheticEvent, dropdownLabelProps: DropdownLabelProps) => {
+    onClick: (e: React.SyntheticEvent, DropdownSelectedItemProps: DropdownSelectedItemProps) => {
       e.stopPropagation()
-      _.invoke(predefinedProps, 'onClick', e, dropdownLabelProps)
+      _.invoke(predefinedProps, 'onClick', e, DropdownSelectedItemProps)
     },
   })
 

--- a/src/components/Dropdown/DropdownLabel.tsx
+++ b/src/components/Dropdown/DropdownLabel.tsx
@@ -47,11 +47,11 @@ export interface DropdownLabelProps extends UIComponentProps<DropdownLabelProps>
  * It is used to display selected item.
  */
 class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
-  displayName = 'DropdownLabel'
+  static displayName = 'DropdownLabel'
 
   static create: Function
 
-  className = 'ui-dropdown__label'
+  static className = 'ui-dropdown__label'
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/src/components/Dropdown/DropdownLabel.tsx
+++ b/src/components/Dropdown/DropdownLabel.tsx
@@ -100,7 +100,7 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
     )
   }
 
-  private handleIconOverrides = (predefinedProps: DropdownLabelProps) => ({
+  private handleIconOverrides = (predefinedProps: IconProps) => ({
     onClick: (e: React.SyntheticEvent, iconProps: IconProps) => {
       e.stopPropagation()
       _.invoke(this.props, 'onRemove', e, this.props)

--- a/src/components/Dropdown/DropdownLabel.tsx
+++ b/src/components/Dropdown/DropdownLabel.tsx
@@ -75,6 +75,20 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
   public renderComponent({ unhandledProps, styles }: RenderResultConfig<DropdownLabelProps>) {
     const { header, icon, image } = this.props
 
+    const iconElement = Icon.create(icon, {
+      defaultProps: {
+        'aria-label': `Remove ${header} from selection.`, // TODO: Extract this in a behaviour.
+        'aria-hidden': false,
+        role: 'button',
+      },
+      overrideProps: this.handleIconOverrides,
+    })
+    const imageElement = Image.create(image, {
+      defaultProps: {
+        avatar: true,
+      },
+    })
+
     return (
       <Label
         styles={styles.root}
@@ -82,19 +96,8 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
         circular
         onClick={this.handleClick}
         content={header}
-        icon={Icon.create(icon, {
-          defaultProps: {
-            'aria-label': `Remove ${header} from selection.`, // TODO: Extract this in a behaviour.
-            'aria-hidden': false,
-            role: 'button',
-          },
-          overrideProps: this.handleIconOverrides,
-        })}
-        image={Image.create(image, {
-          defaultProps: {
-            avatar: true,
-          },
-        })}
+        icon={iconElement}
+        image={imageElement}
         {...unhandledProps}
       />
     )

--- a/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -15,7 +15,7 @@ import {
 import { Image, Icon, Label } from '../..'
 import { IconProps } from '../Icon/Icon'
 
-export interface DropdownLabelProps extends UIComponentProps<DropdownLabelProps> {
+export interface DropdownSelectedItemProps extends UIComponentProps<DropdownSelectedItemProps> {
   /** Header of the selected item. */
   header?: string
 
@@ -31,7 +31,7 @@ export interface DropdownLabelProps extends UIComponentProps<DropdownLabelProps>
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props and proposed value.
    */
-  onClick?: ComponentEventHandler<DropdownLabelProps>
+  onClick?: ComponentEventHandler<DropdownSelectedItemProps>
 
   /**
    * Called when item is removed from the selection list.
@@ -39,15 +39,15 @@ export interface DropdownLabelProps extends UIComponentProps<DropdownLabelProps>
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props and proposed value.
    */
-  onRemove?: ComponentEventHandler<DropdownLabelProps>
+  onRemove?: ComponentEventHandler<DropdownSelectedItemProps>
 }
 
 /**
- * A DropdownLabel is a sub-component of a multiple selection Dropdown.
+ * A DropdownSelectedItem is a sub-component of a multiple selection Dropdown.
  * It is used to display selected item.
  */
-class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
-  static displayName = 'DropdownLabel'
+class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemProps>, any> {
+  static displayName = 'DropdownSelectedItem'
 
   static create: Function
 
@@ -72,7 +72,10 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  public renderComponent({ unhandledProps, styles }: RenderResultConfig<DropdownLabelProps>) {
+  public renderComponent({
+    unhandledProps,
+    styles,
+  }: RenderResultConfig<DropdownSelectedItemProps>) {
     const { header, icon, image } = this.props
 
     const iconElement = Icon.create(icon, {
@@ -119,6 +122,6 @@ class DropdownLabel extends UIComponent<ReactProps<DropdownLabelProps>, any> {
   })
 }
 
-DropdownLabel.create = createShorthandFactory(DropdownLabel, 'header')
+DropdownSelectedItem.create = createShorthandFactory(DropdownSelectedItem, 'header')
 
-export default DropdownLabel
+export default DropdownSelectedItem

--- a/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -72,6 +72,21 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
+  private handleIconOverrides = (predefinedProps: IconProps) => ({
+    onClick: (e: React.SyntheticEvent, iconProps: IconProps) => {
+      e.stopPropagation()
+      _.invoke(this.props, 'onRemove', e, this.props)
+      _.invoke(predefinedProps, 'onClick', e, iconProps)
+    },
+    onKeyDown: (e: React.SyntheticEvent, iconProps: IconProps) => {
+      e.stopPropagation()
+      if (keyboardKey.getCode(e) === keyboardKey.Enter) {
+        _.invoke(this.props, 'onRemove', e, this.props)
+      }
+      _.invoke(predefinedProps, 'onKeyDown', e, iconProps)
+    },
+  })
+
   public renderComponent({
     unhandledProps,
     styles,
@@ -105,21 +120,6 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
       />
     )
   }
-
-  private handleIconOverrides = (predefinedProps: IconProps) => ({
-    onClick: (e: React.SyntheticEvent, iconProps: IconProps) => {
-      e.stopPropagation()
-      _.invoke(this.props, 'onRemove', e, this.props)
-      _.invoke(predefinedProps, 'onClick', e, iconProps)
-    },
-    onKeyDown: (e: React.SyntheticEvent, iconProps: IconProps) => {
-      e.stopPropagation()
-      if (keyboardKey.getCode(e) === keyboardKey.Enter) {
-        _.invoke(this.props, 'onRemove', e, this.props)
-      }
-      _.invoke(predefinedProps, 'onKeyDown', e, iconProps)
-    },
-  })
 }
 
 DropdownSelectedItem.create = createShorthandFactory(DropdownSelectedItem, 'header')

--- a/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -51,7 +51,7 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
 
   static create: Function
 
-  static className = 'ui-dropdown__label'
+  static className = 'ui-dropdown__selected-item'
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,10 @@ export {
 
 export { default as DropdownItem, DropdownItemProps } from './components/Dropdown/DropdownItem'
 
-export { default as DropdownLabel, DropdownLabelProps } from './components/Dropdown/DropdownLabel'
+export {
+  default as DropdownSelectedItem,
+  DropdownSelectedItemProps,
+} from './components/Dropdown/DropdownSelectedItem'
 
 export {
   default as DropdownSearchInput,

--- a/src/themes/teams/componentStyles.ts
+++ b/src/themes/teams/componentStyles.ts
@@ -17,6 +17,7 @@ export { default as Divider } from './components/Divider/dividerStyles'
 
 export { default as Dropdown } from './components/Dropdown/dropdownStyles'
 export { default as DropdownSearchInput } from './components/Dropdown/dropdownSearchInputStyles'
+export { default as DropdownSelectedItem } from './components/Dropdown/dropdownSelectedItemStyles'
 export { default as DropdownItem } from './components/Dropdown/dropdownItemStyles'
 
 export { default as Form } from './components/Form/formStyles'

--- a/src/themes/teams/components/Dropdown/dropdownSelectedItemStyles.ts
+++ b/src/themes/teams/components/Dropdown/dropdownSelectedItemStyles.ts
@@ -1,0 +1,10 @@
+import { DropdownSelectedItemProps } from '../../../../components/Dropdown/DropdownSelectedItem'
+import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
+
+const dropdownSelectedItemStyles: ComponentSlotStylesInput<DropdownSelectedItemProps> = {
+  root: (): ICSSInJSStyle => ({
+    margin: '.4rem 0 0 .4rem',
+  }),
+}
+
+export default dropdownSelectedItemStyles

--- a/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -60,10 +60,6 @@ const dropdownStyles: ComponentSlotStylesInput<DropdownProps, DropdownVariables>
     }
   },
 
-  label: (): ICSSInJSStyle => ({
-    margin: '.4rem 0 0 .4rem',
-  }),
-
   list: ({
     variables: { listMaxHeight, width, listBackgroundColor },
     props: { fluid },


### PR DESCRIPTION
Refs #560.

# BREAKING

- adds `static` for `displayName` and `className`
- use correct type in `handleIconOverrides`
- extracts `DropdownSelectedItem` styles to a separate file

### Before

`dropdownStyles.ts`
```
{
  label: // label styles
}
```

### After

`dropdownSelectedItem.ts`
```
{
  root: // selected item styles
}
```
