### PR TITLE
fix(factories): remove `render` from default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING
 - Rename `DropdownLabel` to `DropdownSelectedItem` and extract styles @layershifter ([#725](https://github.com/stardust-ui/react/pull/725))
 
+### Fixes
+- Fix remove `render` from default factories options @layershifter ([#735](https://github.com/stardust-ui/react/pull/735))
+
 ### Documentation
 - Fix ignored initial state of knobs @layershifter ([#720](https://github.com/stardust-ui/react/pull/720))
 - Fix unclearable example's code @layershifter ([#720](https://github.com/stardust-ui/react/pull/720))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Rename `DropdownLabel` to `DropdownSelectedItem` and extract styles @layershifter ([#725](https://github.com/stardust-ui/react/pull/725))
 
 ### Fixes
-- Fix remove `render` from default factories options @layershifter ([#735](https://github.com/stardust-ui/react/pull/735))
+- Remove `render` from default factories options @layershifter ([#735](https://github.com/stardust-ui/react/pull/735))
 
 ### Documentation
 - Fix ignored initial state of knobs @layershifter ([#720](https://github.com/stardust-ui/react/pull/720))

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -32,7 +32,6 @@ const CREATE_SHORTHAND_DEFAULT_OPTIONS: CreateShorthandOptions = {
   defaultProps: {},
   overrideProps: {},
   generateKey: true,
-  render: (Component, props) => React.createElement(Component, props),
 }
 
 // It's only necessary to map props that don't use 'children' as value ('children' is the default)
@@ -49,7 +48,7 @@ const mappedProps: { [key in HTMLTag]: ShorthandProp } = {
 /** A more robust React.createElement. It can create elements from primitive values. */
 export function createShorthand(
   Component: React.ReactType,
-  mappedProp: string,
+  mappedProp?: string,
   valueOrRenderCallback?: ShorthandValue | ShorthandRenderCallback,
   options: CreateShorthandOptions = CREATE_SHORTHAND_DEFAULT_OPTIONS,
 ): React.ReactElement<Props> | null | undefined {
@@ -58,8 +57,8 @@ export function createShorthand(
   if (valIsRenderFunction) {
     return createShorthandFromRenderCallback(
       Component,
-      mappedProp,
       valueOrRenderCallback as ShorthandRenderCallback,
+      mappedProp,
       options,
     )
   }
@@ -97,9 +96,9 @@ export function createShorthandFactory<T extends React.ReactType>(
 
 function createShorthandFromValue(
   Component: React.ReactType,
-  mappedProp: string,
+  mappedProp?: string,
   value?: ShorthandValue,
-  options: CreateShorthandOptions = CREATE_SHORTHAND_DEFAULT_OPTIONS,
+  options?: CreateShorthandOptions,
 ) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
     throw new Error('createShorthand() Component must be a string or function.')
@@ -207,9 +206,9 @@ function createShorthandFromValue(
 
 function createShorthandFromRenderCallback(
   Component: React.ReactType,
-  mappedProp: string,
   renderCallback: ShorthandRenderCallback,
-  options: CreateShorthandOptions = CREATE_SHORTHAND_DEFAULT_OPTIONS,
+  mappedProp?: string,
+  options?: CreateShorthandOptions,
 ) {
   const render: ShorthandRenderer = (shorthandValue, renderTree) => {
     return createShorthandFromValue(Component, mappedProp, shorthandValue, {

--- a/test/specs/lib/factories-test.tsx
+++ b/test/specs/lib/factories-test.tsx
@@ -164,6 +164,12 @@ describe('factories', () => {
       expect(goodUsage).not.toThrowError()
     })
 
+    test('does not throw if do not passed `mappedProp`', () => {
+      const goodUsage = () => createShorthandFactory(() => <div />)
+
+      expect(goodUsage).not.toThrowError()
+    })
+
     test('throw if passed Component that is not a string nor function', () => {
       consoleUtil.disableOnce()
       const badComponents: any = [undefined, null, true, false, [], {}, 123]


### PR DESCRIPTION
This PR fixes issue with always present `render()` function, this breaks passing `isNoop` check in `factories.tsx` and disallows to hide/skip element renders.