### PR TITLE
fix(typings): synthetic event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING
 - Rename `DropdownLabel` to `DropdownSelectedItem` and extract styles @layershifter ([#725](https://github.com/stardust-ui/react/pull/725))
+- Make element type of component's event handler to be `HTMLElement` @kuzhelov ([#740](https://github.com/stardust-ui/react/pull/740))
 
 ### Fixes
 - Remove `render` from default factories options @layershifter ([#735](https://github.com/stardust-ui/react/pull/735))

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -31,7 +31,10 @@ export type ReactChildren = React.ReactNodeArray | React.ReactNode
 export type ReactPropsStrict<T> = { [K in keyof T]: NullableIfUndefined<T[K]> }
 export type ReactProps<T> = Extendable<ReactPropsStrict<T>>
 
-export type ComponentEventHandler<TProps> = (event: React.SyntheticEvent, data: TProps) => void
+export type ComponentEventHandler<TProps> = (
+  event: React.SyntheticEvent<HTMLElement>,
+  data: TProps,
+) => void
 
 type ChildrenProps = { children: any }
 export type PropsOf<T> = T extends React.ComponentClass<Extendable<infer TProps>>


### PR DESCRIPTION
This PR explicitly specifies generic param (as `HTMLElement`) of type that is used for synthetic event arg in component's event handlers. 

This is necessary for client libraries to avoid explicit cast from `Element` (currently provided by Stardust) to `HTMLElement` which is expected by client's code.

## TODO
- [x] add changelog entry