### PR TITLE
fix(docs): avatar size example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix focus outline visible only during keyboard navigation in `ListItem` @layershifter ([#727](https://github.com/stardust-ui/react/pull/727))
+- Fix Avatar's size example @mnajdova ()
 
 <!--------------------------------[ v0.17.0 ]------------------------------- -->
 ## [v0.17.0](https://github.com/stardust-ui/react/tree/v0.17.0) (2019-01-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix focus outline visible only during keyboard navigation in `ListItem` @layershifter ([#727](https://github.com/stardust-ui/react/pull/727))
-- Fix Avatar's size example @mnajdova ()
+- Fix Avatar's size example @mnajdova ([#745](https://github.com/stardust-ui/react/pull/745))
 
 <!--------------------------------[ v0.17.0 ]------------------------------- -->
 ## [v0.17.0](https://github.com/stardust-ui/react/tree/v0.17.0) (2019-01-17)

--- a/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
+++ b/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
@@ -10,7 +10,7 @@ const AvatarExampleSizeShorthand = () =>
     const status = { ...statusProps, size: size * 0.3125 }
 
     return (
-      <p key={size}>
+      <div key={size}>
         <strong>{size}</strong>
         &emsp;
         <Avatar size={size} image="public/images/avatar/small/matt.jpg" status={status} />
@@ -18,7 +18,7 @@ const AvatarExampleSizeShorthand = () =>
         <Avatar size={size} name="John Doe" status={status} />
         &emsp;
         <Avatar size={size} image="public/images/avatar/small/matt.jpg" />
-      </p>
+      </div>
     )
   })
 


### PR DESCRIPTION
This PR fixes: https://github.com/stardust-ui/react/issues/744