### PR TITLE
fix(Popup): Do not stop propagation when pressing Esc on trigger element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix focus outline visible only during keyboard navigation in `ListItem` @layershifter ([#727](https://github.com/stardust-ui/react/pull/727))
 - Pass `jest --detectLeaks` tests @miroslavstastny ([#718](https://github.com/stardust-ui/react/pull/718))
 - Fix Avatar's size example @mnajdova ([#745](https://github.com/stardust-ui/react/pull/745))
+- Fix `Popup` - do not stop event propagation when pressing Esc on trigger element @sophieH29 ([#750](https://github.com/stardust-ui/react/pull/750))
 
 ### Features
 - Rename `Slot` component to `Box` and export it @Bugaa92 ([#713](https://github.com/stardust-ui/react/pull/713))

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -175,10 +175,7 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
       this.close(e, () => _.invoke(this.triggerDomElement, 'focus'))
       e.stopPropagation()
     },
-    close: e => {
-      this.close(e)
-      e.stopPropagation()
-    },
+    close: e => this.close(e),
   }
 
   public componentDidMount() {


### PR DESCRIPTION
Bug reported:
- Chat Message with popover prototype (keyboard nav):
   - pressing 'Esc' when focus is on the ellipsis button ('...') does not move the focus back to the chat item
   - repro GIF: http://g.recordit.co/kaccQlETAv.gif

Fix: 
There shouldn't be `e.stopPropagation` for `close` action in `Popup` component. `e.stopPropagation` was added initially for `closeAndFocusTrigger` actions based on reasons described in this PR https://github.com/stardust-ui/react/pull/515/, but it wasn't needed when pressing `Esc` just on trigger button, what was added here https://github.com/stardust-ui/react/pull/622
