### PR TITLE
feat: remove props from variables function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Update variable names in themes, add missing sizes @layershifter ([#762](https://github.com/stardust-ui/react/pull/762))
 - Rename `toggleButton` prop to `toggleIndicator` and make it visible by default @layershifter ([#729](https://github.com/stardust-ui/react/pull/729))
+- Remove `props` from variables resolution process @kuzhelov ([#770](https://github.com/stardust-ui/react/pull/770))
 
 ### Features
 - Add `loading` prop for `Dropdown` @layershifter ([#729](https://github.com/stardust-ui/react/pull/729))

--- a/docs/src/examples/components/RadioGroup/Types/RadioGroupColorPickerExample.shorthand.tsx
+++ b/docs/src/examples/components/RadioGroup/Types/RadioGroupColorPickerExample.shorthand.tsx
@@ -30,18 +30,16 @@ class RadioGroupColorPickerExample extends React.Component {
     const isSelected = selectedValue === value
 
     return {
-      variables: {
-        backgroundColor: value,
-        borderColor: 'white',
-        ...(isSelected && {
-          borderColor: 'black',
-        }),
-      },
       styles: {
+        backgroundColor: value,
+        border: '1px solid white',
+        ...(isSelected && {
+          border: '1px solid black',
+        }),
         borderRadius: '3px',
         ...(isSelected && {
           backgroundClip: 'content-box',
-          padding: '2px',
+          padding: '5px',
         }),
       },
     }

--- a/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/src/components/RadioGroup/RadioGroupItem.tsx
@@ -143,7 +143,7 @@ class RadioGroupItem extends AutoControlledComponent<
     this.elementRef = ReactDOM.findDOMNode(this) as HTMLElement
   }
 
-  renderComponent({ ElementType, classes, unhandledProps, styles, variables, accessibility }) {
+  renderComponent({ ElementType, classes, unhandledProps, styles, accessibility }) {
     const { label, icon } = this.props
 
     return (
@@ -161,7 +161,6 @@ class RadioGroupItem extends AutoControlledComponent<
             defaultProps: {
               circular: true,
               size: 'smaller',
-              variables: variables.icon,
               styles: styles.icon,
             },
           })}

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -180,7 +180,7 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>): React.ReactElem
         const resolvedVariables: ComponentVariablesObject = mergeComponentVariables(
           componentVariables[displayName],
           props.variables,
-        )(siteVariables, stateAndProps)
+        )(siteVariables)
 
         const animationCSSProp = props.animation
           ? createAnimationStyles(props.animation, theme)

--- a/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -29,23 +29,18 @@ const radioStyles: ComponentSlotStylesInput<
     }),
   }),
 
-  icon: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
-    const { siteVariables: siteVars } = theme
+  icon: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    margin: `0 ${pxToRem(10)} 0 0`,
+    color: p.checked ? v.colorChecked : v.color,
+    backgroundColor: p.checked ? v.colorBackgroundChecked : v.colorBackground,
+    borderColor: p.checked ? v.colorBorderChecked : v.colorBorder,
+    outlineColor: v.color,
 
-    return {
-      margin: `0 ${pxToRem(10)} 0 0`,
-      color: p.checked ? v.colorChecked : v.color,
-      backgroundColor: p.checked ? v.colorBackgroundChecked : v.colorBackground,
-      borderColor: p.checked ? v.colorBorderChecked : v.colorBorder,
-      outlineColor: siteVars.brand,
-
-      ...(p.isFromKeyboard && {
-        // this creates both inset and outset box shadow that some readers (NVDA) show when radio is not checked but it is focused
-        boxShadow:
-          `0 0 0 ${pxToRem(1)} ${siteVars.brand},` + `0 0 0 ${pxToRem(2)} ${siteVars.brand} inset`,
-      }),
-    }
-  },
+    ...(p.isFromKeyboard && {
+      // this creates both inset and outset box shadow that some readers (NVDA) show when radio is not checked but it is focused
+      boxShadow: `0 0 0 ${pxToRem(1)} ${v.color},` + `0 0 0 ${pxToRem(2)} ${v.color} inset`,
+    }),
+  }),
 }
 
 export default radioStyles

--- a/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -3,9 +3,13 @@ import {
   RadioGroupItemProps,
   RadioGroupItemState,
 } from '../../../../components/RadioGroup/RadioGroupItem'
+import { RadioGroupItemVariables } from './radioGroupItemVariables'
 import { pxToRem } from '../../../../lib'
 
-const radioStyles: ComponentSlotStylesInput<RadioGroupItemProps & RadioGroupItemState, any> = {
+const radioStyles: ComponentSlotStylesInput<
+  RadioGroupItemProps & RadioGroupItemState,
+  RadioGroupItemVariables
+> = {
   root: ({ props }): ICSSInJSStyle => ({
     outline: 0,
     ...(!props.vertical && {
@@ -13,26 +17,35 @@ const radioStyles: ComponentSlotStylesInput<RadioGroupItemProps & RadioGroupItem
     }),
   }),
 
-  label: ({ props, variables }): ICSSInJSStyle => ({
+  label: ({ props: p, variables: v }): ICSSInJSStyle => ({
     cursor: 'pointer',
     display: 'inline-flex',
     alignItems: 'baseline',
-    fontWeight: variables.fontWeight,
+    fontWeight: 400,
     minHeight: '2.5rem',
     backgroundColor: 'transparent',
-    ...(props.disabled && {
-      color: variables.disabledColor,
+    ...(p.disabled && {
+      color: v.colorDisabled,
     }),
   }),
 
-  icon: ({ props, variables }): ICSSInJSStyle => ({
-    ...(props.isFromKeyboard && {
-      // this creates both inset and outset box shadow that some readers (NVDA) show when radio is not checked but it is focused
-      boxShadow:
-        `0 0 0 ${pxToRem(1)} ${variables.icon.outlineColor},` +
-        `0 0 0 ${pxToRem(2)} ${variables.icon.outlineColor} inset`,
-    }),
-  }),
+  icon: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
+    const { siteVariables: siteVars } = theme
+
+    return {
+      margin: `0 ${pxToRem(10)} 0 0`,
+      color: p.checked ? v.colorChecked : v.color,
+      backgroundColor: p.checked ? v.colorBackgroundChecked : v.colorBackground,
+      borderColor: p.checked ? v.colorBorderChecked : v.colorBorder,
+      outlineColor: siteVars.brand,
+
+      ...(p.isFromKeyboard && {
+        // this creates both inset and outset box shadow that some readers (NVDA) show when radio is not checked but it is focused
+        boxShadow:
+          `0 0 0 ${pxToRem(1)} ${siteVars.brand},` + `0 0 0 ${pxToRem(2)} ${siteVars.brand} inset`,
+      }),
+    }
+  },
 }
 
 export default radioStyles

--- a/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
+++ b/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
@@ -1,21 +1,23 @@
-import { pxToRem } from '../../../../lib'
-import { RadioGroupItemProps } from '../../../../components/RadioGroup/RadioGroupItem'
+export type RadioGroupItemVariables = {
+  color: string
+  colorChecked: string
+  colorDisabled: string
 
-export default (siteVars: any, props: RadioGroupItemProps) => {
-  const { checked } = props
+  colorBorder: string
+  colorBorderChecked: string
 
-  return {
-    fontWeight: 400,
-    radioMargin: `${pxToRem(10)}`,
-    disabledColor: siteVars.gray06,
-
-    // variables for the icon part
-    icon: {
-      margin: `0 ${pxToRem(10)} 0 0`,
-      color: checked ? siteVars.white : siteVars.brand,
-      backgroundColor: checked ? siteVars.brand : siteVars.white,
-      borderColor: checked ? siteVars.white : siteVars.brand,
-      outlineColor: siteVars.brand,
-    },
-  }
+  colorBackground: string
+  colorBackgroundChecked: string
 }
+
+export default (siteVars: any): RadioGroupItemVariables => ({
+  color: siteVars.brand,
+  colorChecked: siteVars.white,
+  colorDisabled: siteVars.gray06,
+
+  colorBorder: siteVars.brand,
+  colorBorderChecked: siteVars.white,
+
+  colorBackground: siteVars.white,
+  colorBackgroundChecked: siteVars.brand,
+})


### PR DESCRIPTION
### TODO
- [x] introduce BREAKING CHANGE entry to changelog

-----

We've agreed to move from providing `props` as an argument to variables function - leaving `siteVariables` being the only one provided. This move will make order of styles resolution (as well as list of dependencies used on each stage) much cleaner and reasonable:
```
siteVariables -> variables(siteVariables) -> styles(props, variables, [siteVariables])    
```

