### PR TITLE
fix(createRenderer): set `devMode` if ENV is not production

### DIFF
--- a/src/lib/felaRenderer.tsx
+++ b/src/lib/felaRenderer.tsx
@@ -8,6 +8,7 @@ import rtl from 'fela-plugin-rtl'
 import { Renderer } from '../themes/types'
 
 const createRendererConfig = (options: any = {}) => ({
+  devMode: process.env.NODE_ENV !== 'production',
   plugins: [
     // is necessary to prevent accidental style typos
     // from breaking ALL the styles on the page


### PR DESCRIPTION
Fixes a small regression after #768 with uneditable styles.

---

### Before

![image](https://user-images.githubusercontent.com/14183168/51833522-5ab08200-2300-11e9-8ecd-0cf1462e98ca.png)

### After 

![image](https://user-images.githubusercontent.com/14183168/51833468-394f9600-2300-11e9-9db9-4623339c4d91.png)
