### PR TITLE
feat(Icon): add chevron icons for expand/collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Features
+- Export `triangle-left` and `triangle-right` icons in Teams theme @codepretty ([#785](https://github.com/stardust-ui/react/pull/785))
+
 <!--------------------------------[ v0.19.1 ]------------------------------- -->
 ## [v0.19.1](https://github.com/stardust-ui/react/tree/v0.19.1) (2019-01-29)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.19.0...v0.19.1)
@@ -24,9 +27,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix layout of `Accordion` panel's title @kuzhelov ([#780](https://github.com/stardust-ui/react/pull/780))
 - Allow to use `createRef()` API with `triggerRef` prop in `Portal` component @layershifter ([#787](https://github.com/stardust-ui/react/pull/787))
-
-### Features
-- Export `triangle-left` and `triangle-right` icons in Teams theme @codepretty ([#785](https://github.com/stardust-ui/react/pull/785))
 
 <!--------------------------------[ v0.19.0 ]------------------------------- -->
 ## [v0.19.0](https://github.com/stardust-ui/react/tree/v0.19.0) (2019-01-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix layout of `Accordion` panel's title @kuzhelov ([#780](https://github.com/stardust-ui/react/pull/780))
 - Allow to use `createRef()` API with `triggerRef` prop in `Portal` component @layershifter ([#787](https://github.com/stardust-ui/react/pull/787))
 
+### Features
+- Export `triangle-left` and `triangle-right` icons in Teams theme @codepretty ([#785](https://github.com/stardust-ui/react/pull/785))
+
 <!--------------------------------[ v0.19.0 ]------------------------------- -->
 ## [v0.19.0](https://github.com/stardust-ui/react/tree/v0.19.0) (2019-01-28)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.18.0...v0.19.0)

--- a/docs/src/examples/components/Menu/Usages/MenuExampleToolbar.shorthand.tsx
+++ b/docs/src/examples/components/Menu/Usages/MenuExampleToolbar.shorthand.tsx
@@ -69,8 +69,7 @@ const items = [
     key: 'menuButton',
     icon: {
       name: 'more',
-      circular: true,
-      size: 'small',
+      variables: { outline: true },
     },
     accessibility: toolbarButtonBehavior,
     'aria-label': 'More options',

--- a/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-right-small.tsx
+++ b/src/themes/teams/components/Icon/svg/ProcessedIcons/icons-triangle-right-small.tsx
@@ -8,4 +8,5 @@ export default {
     </svg>
   ),
   styles: {},
+  exportedAs: 'triangle-right',
 } as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/icons/index.ts
+++ b/src/themes/teams/components/Icon/svg/icons/index.ts
@@ -59,6 +59,8 @@ import teamCreate from './teamCreate'
 import teams from './teams'
 import translation from './translation'
 import trashCan from './trashCan'
+import triangleDown from './triangleDown'
+import triangleRight from './triangleRight'
 import underline from './underline'
 import undo from './undo'
 import videoCameraEmphasis from './videoCameraEmphasis'
@@ -122,6 +124,8 @@ export default {
   teams,
   translation,
   'trash-can': trashCan,
+  'triangle-down': triangleDown,
+  'triangle-right': triangleRight,
   'team-create': teamCreate,
   underline,
   undo,

--- a/src/themes/teams/components/Icon/svg/icons/more.tsx
+++ b/src/themes/teams/components/Icon/svg/icons/more.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react'
+import cx from 'classnames'
 import { TeamsSvgIconSpec } from '../types'
 
 export default {
   icon: ({ classes }) => (
     <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
-      <g className={classes.filledPart}>
+      <g className={cx('ui-icon__filled', classes.filledPart)}>
         <circle cx="22" cy="16" r="2" />
         <circle cx="16" cy="16" r="2" />
         <circle cx="10" cy="16" r="2" />
       </g>
-      <g className={classes.outlinePart}>
+      <g className={cx('ui-icon__outline', classes.outlinePart)}>
         <circle cx="22" cy="16" r="1.5" />
         <circle cx="16" cy="16" r="1.5" />
         <circle cx="10" cy="16" r="1.5" />

--- a/src/themes/teams/components/Icon/svg/icons/triangleDown.tsx
+++ b/src/themes/teams/components/Icon/svg/icons/triangleDown.tsx
@@ -8,5 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-  exportedAs: 'triangle-down',
 } as TeamsProcessedSvgIconSpec

--- a/src/themes/teams/components/Icon/svg/icons/triangleRight.tsx
+++ b/src/themes/teams/components/Icon/svg/icons/triangleRight.tsx
@@ -4,9 +4,8 @@ import { TeamsProcessedSvgIconSpec } from '../types'
 export default {
   icon: ({ classes }) => (
     <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
-      <path d="M16 19l3.5-4h-7z" />
+      <path d="M19 16l-4-3.5v7z" />
     </svg>
   ),
   styles: {},
-  exportedAs: 'triangle-down',
 } as TeamsProcessedSvgIconSpec


### PR DESCRIPTION
**Two chevron icons are needed for expanding / collapsing control messages**
![image](https://user-images.githubusercontent.com/828692/51876132-64e07980-231c-11e9-8550-4456db517ed8.png)


**I also did a quick fix on the menu toolbar more icon**
_**Before**_
![image](https://user-images.githubusercontent.com/828692/51876269-e59f7580-231c-11e9-90c3-3853aed7ceeb.png)

_**After**_
![image](https://user-images.githubusercontent.com/828692/51876260-dae4e080-231c-11e9-812f-7aafc4e8b67c.png)

