### PR TITLE
feat(accessibility): remove handledProps from behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add RTL examples for `Button` and `Divider` components @mnajdova ([#792](https://github.com/stardust-ui/react/pull/792))
 - Add mechanism for marking icons that should rotate in RTL in Teams theme; marked icons: `send`, `bullets`, `leave`, `outdent`, `redo`, `undo`, `send` @mnajdova ([#788](https://github.com/stardust-ui/react/pull/788))
 - Remove ability to introduce global style overrides for HTML document from `pxToRem` @kuzhelov ([#789](https://github.com/stardust-ui/react/pull/789))
+- Remove handledProps from behaviors @jurokapsiar ([#805](https://github.com/stardust-ui/react/pull/805))
 
 ### Fixes
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))

--- a/src/lib/accessibility/Behaviors/Menu/menuItemBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Menu/menuItemBehavior.ts
@@ -48,15 +48,6 @@ const menuItemBehavior: Accessibility = (props: any) => ({
     },
   },
 
-  handledProps: [
-    'aria-label',
-    'aria-labelledby',
-    'aria-describedby',
-    'aria-expanded',
-    'aria-haspopup',
-    'aria-disabled',
-  ],
-
   keyActions: {
     wrapper: {
       performClick: {

--- a/src/lib/accessibility/Behaviors/Tab/tabBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Tab/tabBehavior.ts
@@ -40,14 +40,7 @@ const tabBehavior: Accessibility = (props: any) => ({
       [IS_FOCUSABLE_ATTRIBUTE]: !props['disabled'],
     },
   },
-  handledProps: [
-    'aria-label',
-    'aria-labelledby',
-    'aria-describedby',
-    'aria-controls',
-    'aria-selected',
-    'aria-disabled',
-  ],
+
   keyActions: {
     wrapper: {
       performClick: {

--- a/src/lib/accessibility/Behaviors/Toolbar/toolbarButtonBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Toolbar/toolbarButtonBehavior.ts
@@ -42,15 +42,6 @@ const toolbarButtonBehavior: Accessibility = (props: any) => ({
     },
   },
 
-  handledProps: [
-    'aria-label',
-    'aria-labelledby',
-    'aria-describedby',
-    'aria-disabled',
-    'aria-expanded',
-    'aria-haspopup',
-  ],
-
   keyActions: {
     wrapper: {
       performClick: {

--- a/src/lib/accessibility/types.ts
+++ b/src/lib/accessibility/types.ts
@@ -148,7 +148,6 @@ export type KeyActions = { [partName: string]: { [actionName: string]: KeyAction
 export interface AccessibilityDefinition {
   attributes?: AccessibilityAttributesBySlot
   keyActions?: KeyActions
-  handledProps?: (keyof AccessibilityAttributes)[]
   focusZone?: FocusZoneDefinition
   focusTrap?: FocusTrapDefinition
 }

--- a/src/lib/renderComponent.tsx
+++ b/src/lib/renderComponent.tsx
@@ -200,10 +200,7 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>): React.ReactElem
           rtl,
         )
 
-        const unhandledProps = getUnhandledProps(
-          { handledProps: [...handledProps, ...accessibility.handledProps] },
-          props,
-        )
+        const unhandledProps = getUnhandledProps({ handledProps }, props)
 
         const colors = generateColorScheme(stateAndProps.color, resolvedVariables.colorScheme)
 


### PR DESCRIPTION
Remove handledProps from behaviors as they are not needed once we have wrapper concept.
Props are correctly applied to the root and the user is able to specifically target wrapper if needed.