### PR TITLE
fix(acc): Remove popup trigger button role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))
+- Remove popup trigger button default role @jurokapsiar ([#806](https://github.com/stardust-ui/react/pull/806))
 
 <!--------------------------------[ v0.19.1 ]------------------------------- -->
 ## [v0.19.1](https://github.com/stardust-ui/react/tree/v0.19.1) (2019-01-29)

--- a/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
+++ b/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
@@ -4,7 +4,6 @@ import * as _ from 'lodash'
 
 /**
  * @description
- * Adds role='button' to 'trigger' component's part, if it is not focusable element and no role attribute provided.
  * Adds tabIndex='0' to 'trigger' component's part, if it is not tabbable element and no tabIndex attribute provided.
  *
  * @specification
@@ -14,7 +13,6 @@ const popupBehavior: Accessibility = (props: any) => {
   return {
     attributes: {
       trigger: {
-        role: getAriaAttributeFromProps('role', props, 'button'),
         tabIndex: getAriaAttributeFromProps('tabIndex', props, '0'),
         'aria-disabled': !_.isNil(props['aria-disabled'])
           ? props['aria-disabled']


### PR DESCRIPTION
Popup trigger can be a button, menu item or other components. It should be the consumers responsibility to provide appropriate role.

This fix is based on requirements for the chat header prototype.