### PR TITLE
feat(menu): Padding variables for horizontal menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add RTL examples for `Button` and `Divider` components @mnajdova ([#792](https://github.com/stardust-ui/react/pull/792))
 - Add mechanism for marking icons that should rotate in RTL in Teams theme; marked icons: `send`, `bullets`, `leave`, `outdent`, `redo`, `undo`, `send` @mnajdova ([#788](https://github.com/stardust-ui/react/pull/788))
 - Remove ability to introduce global style overrides for HTML document from `pxToRem` @kuzhelov ([#789](https://github.com/stardust-ui/react/pull/789))
+- Padding variable for horizontal menu @jurokapsiar ([#808](https://github.com/stardust-ui/react/pull/808))
 
 ### Fixes
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -298,10 +298,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
         : pointing && vertical
         ? { padding: `${pxToRem(8)} ${pxToRem(18)}` }
         : {
-            paddingTop: v.horizontalPaddingTop,
-            paddingBottom: v.horizontalPaddingBottom,
-            paddingLeft: v.horizontalPaddingLeft,
-            paddingRight: v.horizontalPaddingRight,
+            padding: v.horizontalPadding,
           }),
 
       ...(iconOnly && {

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -297,7 +297,12 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
         ? { padding: `${pxToRem(4)} 0` }
         : pointing && vertical
         ? { padding: `${pxToRem(8)} ${pxToRem(18)}` }
-        : { padding: `${pxToRem(14)} ${pxToRem(18)}` }),
+        : {
+            paddingTop: v.horizontalPaddingTop,
+            paddingBottom: v.horizontalPaddingBottom,
+            paddingLeft: v.horizontalPaddingLeft,
+            paddingRight: v.horizontalPaddingRight,
+          }),
 
       ...(iconOnly && {
         margin: pxToRem(1),

--- a/src/themes/teams/components/Menu/menuVariables.ts
+++ b/src/themes/teams/components/Menu/menuVariables.ts
@@ -24,10 +24,7 @@ export interface MenuVariables {
 
   lineHeightBase: string
 
-  horizontalPaddingLeft: string
-  horizontalPaddingRight: string
-  horizontalPaddingTop: string
-  horizontalPaddingBottom: string
+  horizontalPadding: string
 }
 
 export default (siteVars: any): MenuVariables => {
@@ -56,9 +53,6 @@ export default (siteVars: any): MenuVariables => {
 
     lineHeightBase: siteVars.lineHeightMedium,
 
-    horizontalPaddingLeft: pxToRem(18),
-    horizontalPaddingRight: pxToRem(18),
-    horizontalPaddingTop: pxToRem(14),
-    horizontalPaddingBottom: pxToRem(14),
+    horizontalPadding: `${pxToRem(14)} ${pxToRem(18)} ${pxToRem(14)} ${pxToRem(18)}`,
   }
 }

--- a/src/themes/teams/components/Menu/menuVariables.ts
+++ b/src/themes/teams/components/Menu/menuVariables.ts
@@ -1,3 +1,5 @@
+import { pxToRem } from '../../../../lib'
+
 export interface MenuVariables {
   color: string
 
@@ -21,6 +23,11 @@ export interface MenuVariables {
   disabledColor: string
 
   lineHeightBase: string
+
+  horizontalPaddingLeft: string
+  horizontalPaddingRight: string
+  horizontalPaddingTop: string
+  horizontalPaddingBottom: string
 }
 
 export default (siteVars: any): MenuVariables => {
@@ -48,5 +55,10 @@ export default (siteVars: any): MenuVariables => {
     disabledColor: siteVars.gray06,
 
     lineHeightBase: siteVars.lineHeightMedium,
+
+    horizontalPaddingLeft: pxToRem(18),
+    horizontalPaddingRight: pxToRem(18),
+    horizontalPaddingTop: pxToRem(14),
+    horizontalPaddingBottom: pxToRem(14),
   }
 }


### PR DESCRIPTION
Consumer needs to be able to customize padding in the menu. This PR adds variables that allow to do this for the vertical variant.

I'm not sure if this is the right API as the variable names are bound to the variant (horizontal), so any feedback would be appreciated