### PR TITLE
feat(Header): add create() factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add RTL examples for `Button` and `Divider` components @mnajdova ([#792](https://github.com/stardust-ui/react/pull/792))
 - Add mechanism for marking icons that should rotate in RTL in Teams theme; marked icons: `send`, `bullets`, `leave`, `outdent`, `redo`, `undo`, `send` @mnajdova ([#788](https://github.com/stardust-ui/react/pull/788))
 - Remove ability to introduce global style overrides for HTML document from `pxToRem` @kuzhelov ([#789](https://github.com/stardust-ui/react/pull/789))
+- Add `create` shorthand factory to `Header` component @layershifter ([#809](https://github.com/stardust-ui/react/pull/809))
 
 ### Fixes
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import {
   childrenExist,
+  createShorthandFactory,
   customPropTypes,
   UIComponent,
   UIComponentProps,
@@ -38,6 +39,8 @@ export interface HeaderProps
  *    In addition to that, both will be displayed in the list of headings.
  */
 class Header extends UIComponent<ReactProps<HeaderProps>, any> {
+  static create: Function
+
   static className = 'ui-header'
 
   static displayName = 'Header'
@@ -83,5 +86,7 @@ class Header extends UIComponent<ReactProps<HeaderProps>, any> {
     )
   }
 }
+
+Header.create = createShorthandFactory(Header, 'content')
 
 export default Header


### PR DESCRIPTION
This PR allows to use `Header.create()` factory 🚌 