### PR TITLE
fix(MenuDivider): not shown when used on horizontal menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))
 - Remove popup trigger button default role @jurokapsiar ([#806](https://github.com/stardust-ui/react/pull/806))
 - Improve `Dropdown` component styles @Bugaa92 ([#786](https://github.com/stardust-ui/react/pull/786))
+- `MenuDivider` not shown on horizontal `Menu` @mnajdova ([#813](https://github.com/stardust-ui/react/pull/813))
 
 <!--------------------------------[ v0.19.1 ]------------------------------- -->
 ## [v0.19.1](https://github.com/stardust-ui/react/tree/v0.19.1) (2019-01-29)

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -17,7 +17,7 @@ import MenuItem from './MenuItem'
 import { menuBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 
-import { ComponentVariablesObject } from '../../themes/types'
+import { ComponentVariablesObject, ComponentSlotStylesPrepared } from '../../themes/types'
 import { ReactProps, ShorthandCollection, ShorthandValue } from '../../../types/utils'
 import MenuDivider from './MenuDivider'
 
@@ -139,7 +139,7 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
     },
   })
 
-  renderItems = (variables: ComponentVariablesObject) => {
+  renderItems = (styles: ComponentSlotStylesPrepared, variables: ComponentVariablesObject) => {
     const {
       iconOnly,
       items,
@@ -166,6 +166,7 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
             secondary,
             vertical,
             variables,
+            styles: styles.divider,
           },
         })
       }
@@ -190,7 +191,7 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
     })
   }
 
-  renderComponent({ ElementType, classes, accessibility, variables, unhandledProps }) {
+  renderComponent({ ElementType, classes, accessibility, styles, variables, unhandledProps }) {
     const { children } = this.props
     return (
       <ElementType
@@ -199,7 +200,7 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
         {...unhandledProps}
         className={classes.root}
       >
-        {childrenExist(children) ? children : this.renderItems(variables)}
+        {childrenExist(children) ? children : this.renderItems(styles, variables)}
       </ElementType>
     )
   }

--- a/src/components/Menu/MenuDivider.tsx
+++ b/src/components/Menu/MenuDivider.tsx
@@ -26,6 +26,10 @@ class MenuDivider extends UIComponent<ReactProps<MenuDividerProps>, any> {
 
   static className = 'ui-menu__divider'
 
+  static defaultProps = {
+    as: 'li',
+  }
+
   static propTypes = {
     ...commonPropTypes.createCommon({ content: false, children: false, color: true }),
     primary: PropTypes.bool,

--- a/src/themes/teams/components/Menu/menuDividerStyles.ts
+++ b/src/themes/teams/components/Menu/menuDividerStyles.ts
@@ -7,7 +7,6 @@ const menuDividerStyles: ComponentSlotStylesInput<MenuDividerProps, MenuVariable
     const borderColor = p.primary ? v.primaryBorderColor : v.borderColor
     const borderType = p.vertical ? 'borderTop' : 'borderLeft'
 
-    // TODO add margins depending on the type of the Menu
     return {
       [borderType]: `1px solid ${borderColor}`,
       ...(!p.vertical && {

--- a/src/themes/teams/components/Menu/menuDividerStyles.ts
+++ b/src/themes/teams/components/Menu/menuDividerStyles.ts
@@ -1,6 +1,7 @@
 import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { MenuDividerProps } from '../../../../components/Menu/MenuDivider'
 import { MenuVariables } from './menuVariables'
+import { pxToRem } from '../../../../lib'
 
 const menuDividerStyles: ComponentSlotStylesInput<MenuDividerProps, MenuVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => {
@@ -9,6 +10,7 @@ const menuDividerStyles: ComponentSlotStylesInput<MenuDividerProps, MenuVariable
 
     return {
       [borderType]: `1px solid ${borderColor}`,
+      height: p.vertical ? 0 : pxToRem(32),
     }
   },
 }

--- a/src/themes/teams/components/Menu/menuDividerStyles.ts
+++ b/src/themes/teams/components/Menu/menuDividerStyles.ts
@@ -1,16 +1,18 @@
 import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { MenuDividerProps } from '../../../../components/Menu/MenuDivider'
 import { MenuVariables } from './menuVariables'
-import { pxToRem } from '../../../../lib'
 
 const menuDividerStyles: ComponentSlotStylesInput<MenuDividerProps, MenuVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => {
     const borderColor = p.primary ? v.primaryBorderColor : v.borderColor
     const borderType = p.vertical ? 'borderTop' : 'borderLeft'
 
+    // TODO add margins depending on the type of the Menu
     return {
       [borderType]: `1px solid ${borderColor}`,
-      height: p.vertical ? 0 : pxToRem(32),
+      ...(!p.vertical && {
+        alignSelf: 'stretch',
+      }),
     }
   },
 }

--- a/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -5,6 +5,10 @@ import { MenuItemProps, MenuItemState } from '../../../../components/Menu/MenuIt
 
 type MenuItemPropsAndState = MenuItemProps & MenuItemState
 
+export const verticalPillsBottomMargin = pxToRem(5)
+export const horizontalPillsRightMargin = pxToRem(8)
+export const verticalPointingBottomMargin = pxToRem(12)
+
 const underlinedItem = (color: string): ICSSInJSStyle => ({
   paddingBottom: 0,
   borderBottom: `solid ${pxToRem(4)} ${color}`,
@@ -164,7 +168,9 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
       }),
 
       ...(pills && {
-        ...(vertical ? { margin: `0 0 ${pxToRem(5)} 0` } : { margin: `0 ${pxToRem(8)} 0 0` }),
+        ...(vertical
+          ? { margin: `0 0 ${verticalPillsBottomMargin} 0` }
+          : { margin: `0 ${horizontalPillsRightMargin} 0 0` }),
         borderRadius: pxToRem(5),
       }),
 
@@ -188,7 +194,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
           ...(pointing === 'end'
             ? { borderRight: `${pxToRem(3)} solid transparent` }
             : { borderLeft: `${pxToRem(3)} solid transparent` }),
-          marginBottom: `${pxToRem(12)}`,
+          marginBottom: verticalPointingBottomMargin,
         }),
 
       ...itemSeparator({ props, variables: v, theme, colors }),

--- a/src/themes/teams/components/Menu/menuStyles.ts
+++ b/src/themes/teams/components/Menu/menuStyles.ts
@@ -42,4 +42,13 @@ export default {
       listStyleType: 'none',
     }
   },
+  divider: ({ props: { pointing, vertical, pills, underlined } }) => ({
+    ...(pointing &&
+      vertical && {
+        marginBottom: `${pxToRem(12)}`,
+      }),
+    ...(pills && {
+      ...(vertical ? { margin: `0 0 ${pxToRem(5)} 0` } : { margin: `0 ${pxToRem(8)} 0 0` }),
+    }),
+  }),
 } as ComponentSlotStylesInput<MenuPropsAndState, MenuVariables>

--- a/src/themes/teams/components/Menu/menuStyles.ts
+++ b/src/themes/teams/components/Menu/menuStyles.ts
@@ -2,6 +2,11 @@ import { pxToRem } from '../../../../lib'
 import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { MenuProps, MenuState } from '../../../../components/Menu/Menu'
 import { MenuVariables } from './menuVariables'
+import {
+  verticalPillsBottomMargin,
+  horizontalPillsRightMargin,
+  verticalPointingBottomMargin,
+} from './menuItemStyles'
 
 type MenuPropsAndState = MenuProps & MenuState
 
@@ -45,10 +50,12 @@ export default {
   divider: ({ props: { pointing, vertical, pills, underlined } }) => ({
     ...(pointing &&
       vertical && {
-        marginBottom: `${pxToRem(12)}`,
+        marginBottom: verticalPointingBottomMargin,
       }),
     ...(pills && {
-      ...(vertical ? { margin: `0 0 ${pxToRem(5)} 0` } : { margin: `0 ${pxToRem(8)} 0 0` }),
+      ...(vertical
+        ? { margin: `0 0 ${verticalPillsBottomMargin} 0` }
+        : { margin: `0 ${horizontalPillsRightMargin} 0 0` }),
     }),
   }),
 } as ComponentSlotStylesInput<MenuPropsAndState, MenuVariables>

--- a/src/themes/teams/components/Menu/menuStyles.ts
+++ b/src/themes/teams/components/Menu/menuStyles.ts
@@ -47,7 +47,7 @@ export default {
       listStyleType: 'none',
     }
   },
-  divider: ({ props: { pointing, vertical, pills, underlined } }) => ({
+  divider: ({ props: { pointing, vertical, pills } }) => ({
     ...(pointing &&
       vertical && {
         marginBottom: verticalPointingBottomMargin,


### PR DESCRIPTION
This PR fixes https://github.com/stardust-ui/react/issues/722 The Divider is not shown on all menus, and the margins on different menus are fixed.

![image](https://user-images.githubusercontent.com/4512430/52056324-39e76700-2562-11e9-880e-01b9312a5126.png)

![image](https://user-images.githubusercontent.com/4512430/52056340-42d83880-2562-11e9-8938-b6af72d87295.png)


