### PR TITLE
fix(MenuItem | MenuDivider): export Menu's Variables as MenuItem and MenuDivider's variables in Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))
 - Remove popup trigger button default role @jurokapsiar ([#806](https://github.com/stardust-ui/react/pull/806))
 - Improve `Dropdown` component styles @Bugaa92 ([#786](https://github.com/stardust-ui/react/pull/786))
+- exports `Menu`'s variables as `MenuItem` and `MenuDivider`'s variables in `Teams` theme @mnajdova ([#814](https://github.com/stardust-ui/react/pull/814))
 
 <!--------------------------------[ v0.19.1 ]------------------------------- -->
 ## [v0.19.1](https://github.com/stardust-ui/react/tree/v0.19.1) (2019-01-29)

--- a/src/themes/teams/componentVariables.ts
+++ b/src/themes/teams/componentVariables.ts
@@ -35,6 +35,8 @@ export { default as ItemLayout } from './components/ItemLayout/itemLayoutVariabl
 export { default as ListItem } from './components/List/listItemVariables'
 
 export { default as Menu } from './components/Menu/menuVariables'
+export { default as MenuItem } from './components/Menu/menuItemVariables'
+export { default as MenuDivider } from './components/Menu/menuDividerVariables'
 
 export { default as Popup } from './components/Popup/popupVariables'
 export { default as PopupContent } from './components/Popup/popupContentVariables'

--- a/src/themes/teams/components/Menu/menuDividerVariables.ts
+++ b/src/themes/teams/components/Menu/menuDividerVariables.ts
@@ -1,0 +1,2 @@
+import menuVariables from './menuVariables'
+export default menuVariables

--- a/src/themes/teams/components/Menu/menuItemVariables.ts
+++ b/src/themes/teams/components/Menu/menuItemVariables.ts
@@ -1,0 +1,2 @@
+import menuVariables from './menuVariables'
+export default menuVariables


### PR DESCRIPTION
This PR exports Menu's Variables as MenuItem and MenuDivider's variables in Teams theme