### PR TITLE
feat(dropdown): refactor triggerButton to accept shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `create` shorthand factory to `Header` component @layershifter ([#809](https://github.com/stardust-ui/react/pull/809))
 - Add `keyframeParams` prop in the `Animation` component and the `animation` prop @mnajdova ([#794](https://github.com/stardust-ui/react/pull/794))
 - Add `Dialog` component @layershifter ([#790](https://github.com/stardust-ui/react/pull/790))
+- Add shorthand support for `triggerButton` in `Dropdown` @silviuavram ([#815](https://github.com/stardust-ui/react/pull/815))
 
 ### Fixes
 - Handle `onClick` and `onFocus` on ListItems correctly @layershifter ([#779](https://github.com/stardust-ui/react/pull/779))

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -136,6 +136,9 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   /** Controls appearance of toggle indicator that shows/hides items list. */
   toggleIndicator?: ShorthandValue
 
+  /** Controls appearance of the trigger button if it's a selection dropdown and not a search. */
+  triggerButton?: ShorthandValue
+
   /** Sets currently selected value(s) (controlled mode). */
   value?: ShorthandValue | ShorthandValue[]
 }
@@ -196,6 +199,7 @@ export default class Dropdown extends AutoControlledComponent<
     searchQuery: PropTypes.string,
     searchInput: customPropTypes.itemShorthand,
     toggleIndicator: customPropTypes.itemShorthand,
+    triggerButton: customPropTypes.itemShorthand,
     value: PropTypes.oneOfType([
       customPropTypes.itemShorthand,
       customPropTypes.collectionShorthand,
@@ -217,6 +221,7 @@ export default class Dropdown extends AutoControlledComponent<
       return `${item}`
     },
     toggleIndicator: {},
+    triggerButton: {},
   }
 
   static autoControlledProps = ['searchQuery', 'value']
@@ -328,26 +333,27 @@ export default class Dropdown extends AutoControlledComponent<
     styles: ComponentSlotStylesInput,
     getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any,
   ): JSX.Element {
-    const { placeholder, itemToString, multiple } = this.props
+    const { placeholder, itemToString, multiple, triggerButton } = this.props
     const { value } = this.state
     const content = value && !multiple ? itemToString(value) : placeholder
-
     return (
       <Ref innerRef={this.buttonRef}>
-        <Button
-          content={content}
-          fluid
-          styles={styles.button}
-          {...getToggleButtonProps({
-            onFocus: () => {
-              this.setState({ focused: true })
-            },
-            onBlur: () => {
-              this.setState({ focused: false })
-            },
-            'aria-label': content,
-          })}
-        />
+        {Button.create(triggerButton, {
+          defaultProps: {
+            content,
+            fluid: true,
+            styles: styles.button,
+            ...getToggleButtonProps({
+              onFocus: () => {
+                this.setState({ focused: true })
+              },
+              onBlur: () => {
+                this.setState({ focused: false })
+              },
+              'aria-label': content,
+            }),
+          },
+        })}
       </Ref>
     )
   }


### PR DESCRIPTION
Added changes for Dropdown trigger button as shorthand in this separate PR.

