### PR TITLE
chore(package): remove "leven" from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "jest": "^23.6.0",
     "jest-axe": "^3.1.0",
     "json-stable-stringify-without-jsonify": "^1.0.1",
-    "leven": "^2.1.0",
     "lint-staged": "^7.0.2",
     "merge2": "^1.2.2",
     "normalize.css": "^8.0.0",

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -7,6 +7,7 @@ import {
   UIComponent,
   childrenExist,
   commonPropTypes,
+  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   rtlTextContainer,
@@ -14,7 +15,6 @@ import {
 import { ShorthandValue, ShorthandRenderFunction, ReactProps } from '../../types'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import * as customPropTypes from '../../lib/customPropTypes'
 
 export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
   /**

--- a/packages/react/src/lib/index.ts
+++ b/packages/react/src/lib/index.ts
@@ -30,7 +30,6 @@ export {
 
 export { default as isBrowser } from './isBrowser'
 export { default as doesNodeContainClick } from './doesNodeContainClick'
-export { default as leven } from './leven'
 
 export { pxToRem } from './fontSizeUtility'
 export { customPropTypes }


### PR DESCRIPTION
This PR:
- removes `leven()` export from lib, it's not exported as public API and used only in `customPropTypes`
- removes `leven` package as dependency