### PR TITLE
fix(chore): wrap error messages of docs code editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Dropdown` component styles regression @Bugaa92 ([#824](https://github.com/stardust-ui/react/pull/824))
 - Update vulnerable version of `lodash` dependency  @kuzhelov ([#840](https://github.com/stardust-ui/react/pull/840))
 - Add `displayName` property to `Ref` and `Provider` components @layershifter ([#836](https://github.com/stardust-ui/react/pull/836))
+- Wrap error text of docs code editor @kuzhelov ([#843](https://github.com/stardust-ui/react/pull/843))
 
 <!--------------------------------[ v0.19.2 ]------------------------------- -->
 ## [v0.19.2](https://github.com/stardust-ui/react/tree/v0.19.2) (2019-02-01)

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -415,7 +415,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
         {({ error }) =>
           error && (
             <Segment size="small" color="red" basic inverted padded secondary>
-              <pre>{error.toString()}</pre>
+              <pre style={{ whiteSpace: 'pre-wrap' }}>{error.toString()}</pre>
             </Segment>
           )
         }


### PR DESCRIPTION
Styles for wrapping Docs editor's error message text were introduced.

## Was
![image](https://user-images.githubusercontent.com/9024564/52274057-dedfb680-294b-11e9-9a08-6b72b1a76805.png)

## Now

![image](https://user-images.githubusercontent.com/9024564/52274067-e606c480-294b-11e9-992a-511b302b004e.png)
