### PR TITLE
fix(tests): Disable `jest --detectLeaks` in CI as it is unstable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,9 @@ jobs:
       - run:
           name: Prettier
           command: yarn prettier
-      # weak package is required for --detectLeaks in Unit tests
-      # it is not in package.json as it would require Python on Windows
-      - run:
-          name: Install weak
-          command: yarn add --dev weak
       - run:
           name: Unit Tests
-          command: yarn test --strict --maxWorkers=4 --detectLeaks
+          command: yarn test --strict --maxWorkers=4
       - run:
           name: Report coverage
           command: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
`jest --detectLeaks` is unstable and randomly fails.
This PR disables the leak detector in CI.
Once our consumers report a problem related to this, we will reconsider running the test in CI.