### PR TITLE
docs(screener-io): added documentation on how to write tests with steps

### DIFF
--- a/.github/test-a-feature.md
+++ b/.github/test-a-feature.md
@@ -113,14 +113,14 @@ yarn test:watch
 
 ## Screener Tests
 
-For some components, it is necessary to write screenshot tests in order to check they render properly. For each component example added to the docsite a screenshot test is automatically created. This checks if that the component is rendered in a consistent way, as it checks the visual differences between the previous and the current rendering. We use [screener-io](https://screener.io/) to achieve this.
+For some components, it is necessary to write screenshot tests in order to check that they render properly. For each component example added to the docsite a screenshot test is automatically created. This checks if that the component is rendered in a consistent way, as it looks for visual differences between the previous rendering and the current one. We use [screener-io](https://screener.io/) to achieve screenshot testing.
 
 ### Tests with Steps API
 
-This default test only checks the rendering for the component in its initial state. In order to test the rendering of more complex components, such as a `Dropdown`, screener provides an [api](https://www.npmjs.com/package/screener-runner) to execute actions on the DOM, in a way similar to end-to-end tests. These tests are automatically sent to Screener in our test runs, as long as the tests and their files respect the conventions:
-- the test file should be placed at the same location as the tested component in the docs.
-- the test file should be named exactly as the component file. If `DropdownExample.shorthand.tsx` is to be tested, the screener test file should be `DropdownExample.shorthand.steps.ts`.
-- the tests should be written as an array of callbacks that accept a `steps` parameter, as they will be chained in `screener.config` automatically. The `steps` parameter is actually the `Steps` object from screener, instantiated in `screener.config`.
+This default test only checks the rendering for the component in its initial state. In order to test the rendering of more complex components, such as a `Dropdown`, screener provides an [api](https://www.npmjs.com/package/screener-runner) to execute actions on the DOM, in a way similar to end-to-end tests. These tests are executed by Screener as long as both the tests and their files respect the conventions:
+- the test file should be placed at the same location as the component example under test.
+- the test file should be named exactly as the component example file. If `DropdownExample.shorthand.tsx` is to be tested, the screener test file should be named `DropdownExample.shorthand.steps.ts`.
+- the tests should be written as an array of callbacks that accept a `steps` parameter, as all of them will be chained in `screener.config`. The `steps` parameter is actually the `Steps` object from screener, instantiated in `screener.config`.
 
 #### Example for a test file:
 
@@ -129,9 +129,9 @@ import { Dropdown } from '@stardust-ui/react'
 
 const steps = [
   steps => steps.click(`.${Dropdown.slotClassNames.triggerButton}`)
-    .snapshot('Opens with selected item highlighted'),
+    .snapshot('Opens dropdown list'),
   steps => steps.hover(`.${Dropdown.slotClassNames.itemsList} li:nth-child(2)`)
-    .snapshot('Highlights another item'),
+    .snapshot('Highlights an item'),
 ]
 
 export default steps

--- a/.github/test-a-feature.md
+++ b/.github/test-a-feature.md
@@ -113,7 +113,7 @@ yarn test:watch
 
 ## Screener Tests
 
-For some components, it is necessary to write screenshot tests in order to check they render properly. For each component added to the docsite, a screenshot test is automatically created. This checks if that the component is rendered in a consistent way, as it checks the visual differences between the previous and the current rendering. We use [screener-io](https://screener.io/) to achieve this.
+For some components, it is necessary to write screenshot tests in order to check they render properly. For each component example added to the docsite a screenshot test is automatically created. This checks if that the component is rendered in a consistent way, as it checks the visual differences between the previous and the current rendering. We use [screener-io](https://screener.io/) to achieve this.
 
 ### Tests with Steps API
 

--- a/.github/test-a-feature.md
+++ b/.github/test-a-feature.md
@@ -11,6 +11,12 @@ Test a feature
   - [isConformant (required)](#isconformant-required)
   - [Writing tests](#writing-tests)
   - [Running tests](#running-tests)
+- [Screener Tests](#screener-tests)
+  - [Tests with Steps API](#tests-with-steps-api)
+    - [Example for a test file:](#example-for-a-test-file)
+    - [Important mentions:](#important-mentions)
+  - [Run Screener tests](#run-screener-tests)
+    - [Local run command](#local-run-command)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add single search flavor for `Dropdown` component @Bugaa92 ([#839](https://github.com/stardust-ui/react/pull/839))
 - Add multiple selection flavor for `Dropdown` component @Bugaa92 ([#845](https://github.com/stardust-ui/react/pull/845))
 
+### Documentation
+- Add screener with steps testing documentation @silviuavram ([#856](https://github.com/stardust-ui/react/pull/856))
+
 <!--------------------------------[ v0.20.0 ]------------------------------- -->
 ## [v0.20.0](https://github.com/stardust-ui/react/tree/v0.20.0) (2019-02-06)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.19.2...v0.20.0)


### PR DESCRIPTION
Added documentation on how to write tests with the Screener Steps.

At the moment I added a draft change, and I think I can have some feedback while I also look to improve it.