### PR TITLE
fix(themes): do not define fontFaces in Teams theme by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Do not define `fontFaces` in Teams theme by default @layershifter ([#859](https://github.com/stardust-ui/react/pull/859))
+
 ### Features
 - Add single search flavor for `Dropdown` component @Bugaa92 ([#839](https://github.com/stardust-ui/react/pull/839))
 - Add multiple selection flavor for `Dropdown` component @Bugaa92 ([#845](https://github.com/stardust-ui/react/pull/845))

--- a/docs/src/index.ejs
+++ b/docs/src/index.ejs
@@ -122,6 +122,24 @@
     .hidden {
       display: none;
     }
+
+    /* Teams fonts */
+
+    @font-face {
+      font-family: 'Segoe UI';
+      font-weight: 400;
+      src: url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.woff2') format('woff2')
+    }
+    @font-face {
+      font-family: 'Segoe UI';
+      font-weight: 600;
+      src: url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.woff2') format('woff2')
+    }
+    @font-face {
+      font-family: 'Segoe UI';
+      font-weight: 700;
+      src: url('https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-bold.woff2') format('woff2')
+    }
   </style>
 </body>
 </html>

--- a/packages/react/src/themes/teams/fontFaces.ts
+++ b/packages/react/src/themes/teams/fontFaces.ts
@@ -1,27 +1,5 @@
 import { FontFaces } from '../types'
 
-const fontFaces: FontFaces = [
-  {
-    name: 'Segoe UI',
-    paths: [
-      'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.woff2',
-    ],
-    style: { fontWeight: 400 },
-  },
-  {
-    name: 'Segoe UI',
-    paths: [
-      'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.woff2',
-    ],
-    style: { fontWeight: 600 },
-  },
-  {
-    name: 'Segoe UI',
-    paths: [
-      'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-bold.woff2',
-    ],
-    style: { fontWeight: 700 },
-  },
-]
+const fontFaces: FontFaces = []
 
 export default fontFaces


### PR DESCRIPTION
Fixes #692.

# BREAKING CHANGES

Teams theme will not import Segoe UI font by default now, please import it manually if you need it.

```jsx
import React from 'react'
import ReactDOM from 'react-dom'
import { Provider, themes } from '@stardust-ui/react'

import App from './App'

const themeWithFonts = {
  ...themes.teams,
  // <=== Fonts definition is here
  fontFaces: [
    {
      name: 'Segoe UI',
      paths: [
        'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.woff2',
      ],
      style: { fontWeight: 400 },
    },
    {
      name: 'Segoe UI',
      paths: [
        'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.woff2',
      ],
      style: { fontWeight: 600 },
    },
    {
      name: 'Segoe UI',
      paths: [
        'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-bold.woff2',
      ],
      style: { fontWeight: 700 },
    },
  ],
}

ReactDOM.render(
  <Provider theme={themeWithFonts}>
    <App />
  </Provider>,
  document.getElementById('root'),
)

```