### PR TITLE
fix(Popup): Focus the last focused element outside Popup on ESC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add single search flavor for `Dropdown` component @Bugaa92 ([#839](https://github.com/stardust-ui/react/pull/839))
 - Add multiple selection flavor for `Dropdown` component @Bugaa92 ([#845](https://github.com/stardust-ui/react/pull/845))
 
+### Fixes
+- Focus the last focused element which triggered `Popup` on ESC @sophieH29 ([#861](https://github.com/stardust-ui/react/pull/861))
+
 <!--------------------------------[ v0.20.0 ]------------------------------- -->
 ## [v0.20.0](https://github.com/stardust-ui/react/tree/v0.20.0) (2019-02-06)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.19.2...v0.20.0)

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -166,13 +166,15 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
   private outsideClickSubscription = EventStack.noSubscription
 
   private triggerDomElement = null
+  // focusable element which has triggered Popup, can be either triggerDomElement or the element inside it
+  private triggerFocusableDomElement = null
   private popupDomElement = null
 
   private closeTimeoutId
 
   protected actionHandlers: AccessibilityActionHandlers = {
     closeAndFocusTrigger: e => {
-      this.close(e, () => _.invoke(this.triggerDomElement, 'focus'))
+      this.close(e, () => _.invoke(this.triggerFocusableDomElement, 'focus'))
       e.stopPropagation()
     },
     close: e => this.close(e),
@@ -474,6 +476,8 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
   }
 
   private trySetOpen(newValue: boolean, eventArgs: any) {
+    // when new state 'open' === 'true', save the last focused element
+    newValue && this.updateTriggerFocusableDomElement()
     this.trySetState({ open: newValue })
     _.invoke(this.props, 'onOpenChange', eventArgs, { ...this.props, ...{ open: newValue } })
   }
@@ -496,5 +500,15 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
       this.trySetOpen(false, e)
       onClose && onClose()
     }
+  }
+
+  /**
+   * Save DOM element which had focus before Popup opens.
+   * Can be either trigger DOM element itself or the element inside it.
+   */
+  private updateTriggerFocusableDomElement() {
+    this.triggerFocusableDomElement = this.triggerDomElement.contains(document.activeElement)
+      ? document.activeElement
+      : this.triggerDomElement
   }
 }

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -477,7 +477,9 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
 
   private trySetOpen(newValue: boolean, eventArgs: any) {
     // when new state 'open' === 'true', save the last focused element
-    newValue && this.updateTriggerFocusableDomElement()
+    if (newValue) {
+      this.updateTriggerFocusableDomElement()
+    }
     this.trySetState({ open: newValue })
     _.invoke(this.props, 'onOpenChange', eventArgs, { ...this.props, ...{ open: newValue } })
   }


### PR DESCRIPTION
This PR fixes the issue when a complex component is used as a trigger for Popup, but actually, the inner element of that component triggers the Popup. So when press ESC on Popup, the focus should go to the actual focusable element which triggered the Popup, not the whole component itself.

In the next example, `MenuItem` is a trigger for the Popup and this component has this structure
```jsx
<li> - wrapper
   <a></a> // focusable element which actually triggers Popup
</li>

```

```jsx
const items = [
  {
    key: 'editorials',
    content: 'Editorials',
  },
  {
    key: 'review',
    content: 'Reviews',
  },
  {
    key: 'events',
    content: 'Upcoming Events',
  },
].map(item => render => render(item, renderIten))

const renderIten = (MenuItem, props) =>
  <Popup
    content={{ content: <Button content="Click me" /> }}
    trigger={<MenuItem {...props}/>}
  />

const MenuExample = () => <Menu defaultActiveIndex={0} items={items} />
```

So when press ESC, `MenuItem`'s wrapper `<li>` element will receive focus, instead of `<a>`, what breaks focus management on the page.



Closes https://github.com/stardust-ui/react/issues/831
