### PR TITLE
fix(pxToRem): update rem size on static styles render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Properly handle falsy values provided as `Flex` and `Flex.Item` children @kuzhelov ([#890](https://github.com/stardust-ui/react/pull/890))
+- Update cached `rem` size value of `pxToRem` on theme static styles render @kuzhelov ([#883](https://github.com/stardust-ui/react/pull/883))
 
 <!--------------------------------[ v0.21.0 ]------------------------------- -->
 ## [v0.21.0](https://github.com/stardust-ui/react/tree/v0.21.0) (2019-02-12)

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -5,7 +5,12 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import { RendererProvider, ThemeProvider } from 'react-fela'
 
-import { felaRenderer as felaLtrRenderer, isBrowser, mergeThemes } from '../../lib'
+import {
+  felaRenderer as felaLtrRenderer,
+  isBrowser,
+  mergeThemes,
+  updateCachedRemSize,
+} from '../../lib'
 import {
   ThemePrepared,
   ThemeInput,
@@ -150,6 +155,8 @@ class Provider extends React.Component<ProviderProps> {
     if (!this.staticStylesRendered && staticStyles) {
       this.renderStaticStyles(mergedTheme)
       this.staticStylesRendered = true
+
+      updateCachedRemSize()
     }
   }
 }

--- a/packages/react/src/lib/fontSizeUtility.ts
+++ b/packages/react/src/lib/fontSizeUtility.ts
@@ -16,6 +16,10 @@ const getFontSizeValue = (size?: string | null): number | null => {
   return (size && parseFloat(size)) || null
 }
 
+export const updateCachedRemSize = () => {
+  _documentRemSize = null
+}
+
 /**
  * Converts the provided px size to rem based on the default font size of 10px unless
  * the HTML font size has been previously defined with setHTMLFontSize().

--- a/packages/react/src/lib/index.ts
+++ b/packages/react/src/lib/index.ts
@@ -35,7 +35,7 @@ export {
 export { default as isBrowser } from './isBrowser'
 export { default as doesNodeContainClick } from './doesNodeContainClick'
 
-export { pxToRem } from './fontSizeUtility'
+export { pxToRem, updateCachedRemSize } from './fontSizeUtility'
 export { customPropTypes }
 export { default as createAnimationStyles } from './createAnimationStyles'
 export { default as createComponent } from './createStardustComponent'


### PR DESCRIPTION
### TODO
- [x] update changelog

----

This PR introduces logic that is necessary to update base rem value of `pxToRem` utility (that was previously cached forever on page load) once newly loaded theme is applying static styles.

This PR leaves it to be a separate discussion whether static styles should be allowed for Stardust themes - the sole purpose of these changes is to address the problem of page font size updates after theme load that we currently have.