### PR TITLE
fix(color palette): Move Color Palette sidebar link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Focus the last focused element which triggered `Popup` on ESC @sophieH29 ([#861](https://github.com/stardust-ui/react/pull/861))
 - Changing the focus zone to embed for gridBehavior @kolaps33 ([#844] (https://github.com/stardust-ui/react/pull/844))
 - Add polyfills to correctly work in IE11 @layershifter ([#868](https://github.com/stardust-ui/react/pull/868))
+- Move color palette link to prototypes section @codepretty ([#884](https://github.com/stardust-ui/react/pull/884))
 
 ### Documentation
 - Add screener with steps testing documentation @silviuavram ([#856](https://github.com/stardust-ui/react/pull/856))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Focus the last focused element which triggered `Popup` on ESC @sophieH29 ([#861](https://github.com/stardust-ui/react/pull/861))
 - Changing the focus zone to embed for gridBehavior @kolaps33 ([#844] (https://github.com/stardust-ui/react/pull/844))
 - Add polyfills to correctly work in IE11 @layershifter ([#868](https://github.com/stardust-ui/react/pull/868))
-- Move color palette link to prototypes section @codepretty ([#884](https://github.com/stardust-ui/react/pull/884))
 
 ### Documentation
 - Add screener with steps testing documentation @silviuavram ([#856](https://github.com/stardust-ui/react/pull/856))
+- Move color palette link to prototypes section @codepretty ([#884](https://github.com/stardust-ui/react/pull/884))
 
 <!--------------------------------[ v0.20.0 ]------------------------------- -->
 ## [v0.20.0](https://github.com/stardust-ui/react/tree/v0.20.0) (2019-02-06)

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -225,9 +225,6 @@ class Sidebar extends React.Component<any, any> {
                 <Menu.Item as={NavLink} exact to="/" activeClassName="active">
                   Introduction
                 </Menu.Item>
-                <Menu.Item as={NavLink} exact to="/color-palette" activeClassName="active">
-                  Color Palette
-                </Menu.Item>
                 <Menu.Item as={NavLink} exact to="/shorthand-props" activeClassName="active">
                   Shorthand Props
                 </Menu.Item>
@@ -326,6 +323,9 @@ class Sidebar extends React.Component<any, any> {
                     activeClassName="active"
                   >
                     Important and mention messages
+                  </Menu.Item>
+                  <Menu.Item as={NavLink} exact to="/color-palette" activeClassName="active">
+                    Color Palette
                   </Menu.Item>
                 </Menu.Menu>
               </Menu.Item>


### PR DESCRIPTION
The color palette isn't ready yet and is causing some confusion for some of the designers who are finding it. After discussing, we decided to just move the Color Palette link in the sidebar to the prototypes section to make it "invisible" (undiscoverable) until the color palette work is done!

![image](https://user-images.githubusercontent.com/828692/52603573-397d8480-2e1c-11e9-81e6-1b403d29cbe6.png)

