### PR TITLE
fix(build): handle exceptions in `build:docs:example-sources`

### DIFF
--- a/build/gulp/plugins/gulp-example-source.ts
+++ b/build/gulp/plugins/gulp-example-source.ts
@@ -42,15 +42,19 @@ export default () =>
       return
     }
 
-    const sourcePath = getRelativePathToSourceFile(file.path)
-    const source = createExampleSourceCode(file)
+    try {
+      const sourcePath = getRelativePathToSourceFile(file.path)
+      const source = createExampleSourceCode(file)
 
-    const sourceFile = new Vinyl({
-      path: sourcePath,
-      contents: Buffer.from(JSON.stringify(source, null, 2)),
-    })
-    // `gulp-cache` relies on this private entry
-    sourceFile._cachedKey = file._cachedKey
+      const sourceFile = new Vinyl({
+        path: sourcePath,
+        contents: Buffer.from(JSON.stringify(source, null, 2)),
+      })
+      // `gulp-cache` relies on this private entry
+      sourceFile._cachedKey = file._cachedKey
 
-    cb(null, sourceFile)
+      cb(null, sourceFile)
+    } catch (e) {
+      cb(e)
+    }
   })


### PR DESCRIPTION
Fixes an issue with local development, previously:

1. Open `DropdownExample.shorthand.tsx`
2. Add a weird change, like this: 
```diff
-const inputItems = [
+const inputItems: t\ = [
```
3. Watch task will crash and all other changes will be ignored, you should to run `yarn start` again