### PR TITLE
chore: add @types/jest-diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/gulp-load-plugins": "^0.0.31",
     "@types/jest": "^23.3.9",
     "@types/jest-axe": "^2.2.2",
+    "@types/jest-diff": "^20.0.0",
     "@types/lodash": "^4.14.118",
     "@types/node": "^10.3.2",
     "@types/puppeteer": "^1.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,6 +321,11 @@
     "@types/jest" "*"
     axe-core "^3.0.3"
 
+"@types/jest-diff@^20.0.0":
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.0.tgz#3d1acf8d25d878c3566cd13b4e4e1f4fd6640111"
+  integrity sha512-9wBX/SsB0M3Zptv/5yV1BNa7B/YIEhJRzK/cd7s2/uPzdRhg8gjDsJNzMubPPLK+0ZWE7eRd+bEQAnaWAGekrw==
+
 "@types/jest@*", "@types/jest@^23.3.9":
   version "23.3.9"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.9.tgz#c16b55186ee73ae65e001fbee69d392c51337ad1"


### PR DESCRIPTION
This move is necessary to address TS issue of compiling `create-react-app` project - the issue has appeared after `create-react-app` has started to use TS compiler of v3.3.3

![image](https://user-images.githubusercontent.com/9024564/52674370-b21b3880-2f23-11e9-80fd-f624a5f486d6.png)
