### PR TITLE
fix(chore): use '--typescript' flag in create-react-app project tests

### DIFF
--- a/build/gulp/tasks/test-projects.tsx
+++ b/build/gulp/tasks/test-projects.tsx
@@ -41,9 +41,7 @@ const createReactApp = async (atTempDirectory: string, appName: string): Promise
 
     // create test project with util's create-react-app
     fs.mkdirSync(appProjectPath)
-    await runIn(tempUtilProjectPath)(
-      `yarn create-react-app ${appProjectPath} --scripts-version=react-scripts-ts`,
-    )
+    await runIn(tempUtilProjectPath)(`yarn create-react-app ${appProjectPath} --typescript`)
   } finally {
     // remove temp util directory
     rimraf.sync(tempUtilProjectPath)


### PR DESCRIPTION
This PR introduce changes that swicth from using additional dependency (`react-scripts-ts`) in `create-react-app` project tests - with `--typescript` flag for `create-react-app` utility being used instead.

This move solves the following problems:
- removes dependency on`react-scripts-ts` dependency
- follows suggested approach to create TS projects: https://facebook.github.io/create-react-app/docs/adding-typescript
- fixes problem that has been introduced by recent dependency updates of `react-scripts-ts` - this one has resulted in failed builds even for clean TS-based `create-react-app` project, and, in particular, has failed corresponding Stardust tests

![image](https://user-images.githubusercontent.com/9024564/52676617-0675e680-2f2b-11e9-972d-77258bdaa407.png)
