### PR TITLE
feat(dropdown): autocontrolled mode for open state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adding status behavior @kolaps33 ([#880](https://github.com/stardust-ui/react/pull/880))
 - Add basic animation library for Teams theme @bhamlefty @mnajdova ([#871](https://github.com/stardust-ui/react/pull/871)
 - Export `accept` and `urgent` SVG icons to the Teams Theme @joheredi([#929](https://github.com/stardust-ui/react/pull/929))
+- Add `open`, `defaultOpen` and `onOpenChange` props for `Dropdown` component (controlled mode) @Bugaa92 ([#900](https://github.com/stardust-ui/react/pull/900))
 
 ### Fixes
 - Display correctly images in portrait mode inside `Avatar` @layershifter ([#899](https://github.com/stardust-ui/react/pull/899))

--- a/docs/src/examples/components/Dropdown/Usage/DropdownExampleControlled.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Usage/DropdownExampleControlled.shorthand.tsx
@@ -6,6 +6,10 @@ const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange', 'Alfred
 class DropdownExampleControlled extends React.Component {
   state = { open: false }
 
+  handleOpenChange = (e, { open }) => {
+    this.setState({ open })
+  }
+
   render() {
     const open = this.state.open
     return (
@@ -19,10 +23,6 @@ class DropdownExampleControlled extends React.Component {
         <Text weight="semibold" content={`Dropdown open state is: "${open}"`} />
       </Flex>
     )
-  }
-
-  handleOpenChange = (e, { open }) => {
-    this.setState({ open })
   }
 }
 

--- a/docs/src/examples/components/Dropdown/Usage/DropdownExampleControlled.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Usage/DropdownExampleControlled.shorthand.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Dropdown, Flex, Text } from '@stardust-ui/react'
+
+const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange', 'Alfred Pennyworth']
+
+class DropdownExampleControlled extends React.Component {
+  state = { open: false }
+
+  render() {
+    const open = this.state.open
+    return (
+      <Flex gap="gap.large" vAlign="center">
+        <Dropdown
+          open={open}
+          onOpenChange={this.handleOpenChange}
+          items={inputItems}
+          placeholder="Select your hero"
+        />
+        <Text weight="semibold" content={`Dropdown open state is: "${open}"`} />
+      </Flex>
+    )
+  }
+
+  handleOpenChange = (e, { open }) => {
+    this.setState({ open })
+  }
+}
+
+export default DropdownExampleControlled

--- a/docs/src/examples/components/Dropdown/Usage/index.tsx
+++ b/docs/src/examples/components/Dropdown/Usage/index.tsx
@@ -2,8 +2,13 @@ import * as React from 'react'
 import ComponentExample from 'docs/src/components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
-const Variations = () => (
-  <ExampleSection title="Variations">
+const Usage = () => (
+  <ExampleSection title="Usage">
+    <ComponentExample
+      title="Controlled"
+      description="A dropdown can handle open state in controlled mode."
+      examplePath="components/Dropdown/Usage/DropdownExampleControlled"
+    />
     <ComponentExample
       title="Render callbacks"
       description="You can customize rendered elements with render callbacks."
@@ -12,4 +17,4 @@ const Variations = () => (
   </ExampleSection>
 )
 
-export default Variations
+export default Usage

--- a/docs/src/examples/components/Popup/Types/index.tsx
+++ b/docs/src/examples/components/Popup/Types/index.tsx
@@ -12,7 +12,7 @@ const Types = () => (
     />
     <ComponentExample
       title="Controlled"
-      description="Note that if Popup is controlled, then its 'open' prop value could be changed either by parent component, or by user actions (e.g. key press) - thus it is necessary to handle 'onOpenChanged' event. Try to type some text into popup's input field and press ESC to see the effect."
+      description="Note that if Popup is controlled, then its 'open' prop value could be changed either by parent component, or by user actions (e.g. key press) - thus it is necessary to handle 'onOpenChange' event. Try to type some text into popup's input field and press ESC to see the effect."
       examplePath="components/Popup/Types/PopupControlledExample"
     />
     <ComponentExample

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -384,7 +384,6 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
                   {this.renderItemsList(
                     styles,
                     variables,
-                    open,
                     highlightedIndex,
                     toggleMenu,
                     selectItemAtIndex,
@@ -475,7 +474,6 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   private renderItemsList(
     styles: ComponentSlotStylesInput,
     variables: ComponentVariablesInput,
-    open: boolean,
     highlightedIndex: number,
     toggleMenu: () => void,
     selectItemAtIndex: (index: number) => void,
@@ -484,6 +482,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     getInputProps: (options?: GetInputPropsOptions) => any,
   ) {
     const { search } = this.props
+    const { open } = this.state
     const { innerRef, ...accessibilityMenuProps } = getMenuProps(
       { refKey: 'innerRef' },
       { suppressRefError: true },

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -593,7 +593,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   }
 
   private handleSearchQueryChange = (searchQuery: string) => {
-    this.setStateAndInvokeHandler({ searchQuery }, 'onSearchQueryChange')
+    this.trySetStateAndInvokeHandler('onSearchQueryChange', null, { searchQuery })
   }
 
   private handleDownshiftStateChanges = (
@@ -614,7 +614,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
   private handleStateChange = (changes: StateChangeOptions<ShorthandValue>) => {
     if (changes.isOpen !== undefined && changes.isOpen !== this.state.open) {
-      this.setStateAndInvokeHandler({ open: changes.isOpen }, 'onOpenChange')
+      this.trySetStateAndInvokeHandler('onOpenChange', null, { open: changes.isOpen })
     }
 
     if (changes.isOpen && !this.props.search) {
@@ -857,13 +857,10 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   private handleSelectedChange = (item: ShorthandValue) => {
     const { items, multiple, getA11ySelectionMessage } = this.props
 
-    this.setStateAndInvokeHandler(
-      {
-        value: multiple ? [...(this.state.value as ShorthandCollection), item] : item,
-        searchQuery: this.getSelectedItemAsString(item),
-      },
-      'onSelectedChange',
-    )
+    this.trySetStateAndInvokeHandler('onSelectedChange', null, {
+      value: multiple ? [...(this.state.value as ShorthandCollection), item] : item,
+      searchQuery: this.getSelectedItemAsString(item),
+    })
 
     if (!multiple) {
       this.setState({ defaultHighlightedIndex: items.indexOf(item) })
@@ -958,7 +955,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
       this.setA11yStatus(getA11ySelectionMessage.onRemove(poppedItem))
     }
 
-    this.setStateAndInvokeHandler({ value }, 'onSelectedChange')
+    this.trySetStateAndInvokeHandler('onSelectedChange', null, { value })
   }
 
   /**
@@ -966,9 +963,13 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
    * We don't have the event object for most events coming from Downshift se we send an empty event
    * because we want to keep the event handling interface
    */
-  private setStateAndInvokeHandler = (newState: Partial<DropdownState>, eventName: string) => {
+  private trySetStateAndInvokeHandler = (
+    handlerName: keyof DropdownProps,
+    event: React.SyntheticEvent<HTMLElement>,
+    newState: Partial<DropdownState>,
+  ) => {
     this.trySetState(newState)
-    _.invoke(this.props, eventName, {}, { ...this.props, ...newState })
+    _.invoke(this.props, handlerName, event, { ...this.props, ...newState })
   }
 
   private tryFocusTriggerButton = () => {

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -122,7 +122,7 @@ const dropdownStyles: ComponentSlotStylesInput<DropdownPropsAndState, DropdownVa
     width: getWidth(p, v),
     top: 'calc(100% + 2px)', // leave room for container + its border
     background: v.listBackgroundColor,
-    ...(p.isOpen && {
+    ...(p.open && {
       boxShadow: v.listBoxShadow,
       padding: v.listPadding,
     }),


### PR DESCRIPTION
# feat(dropdown): autocontrolled mode for open state

## Description:
- introduced `open`, `defaultOpen` props
- introduced `onOpenChange` event handler

## API:
```jsx
<Dropdown
  open={open}
  onOpenChange={handleOpenChange}
  items={inputItems}
/>
```

where `open` value is part of the state of HOC and `handleOpenChange` is the entry for internal changes of `open`.

## Screenshot:

![screen recording 2019-02-14 at 15 06 47](https://user-images.githubusercontent.com/5442794/52792059-c289fb00-306a-11e9-9b61-11e87d7171a0.gif)

## [Blockers:](#description-blockers)

Currently blocked by possible `Downshift` issue related to internal state handling when `isOpen` prop is used in controlled mode.

The `Dropdown` still works but there is a regression when opening the list of items: 

### The first/last item is not highlighted by default anymore after introducing `open` prop.

[**Here**](https://screener.io/v2/states/rkGqtccHX.stardust-ui-react/feat%2Fdropdown-open-prop/1024x768/Chrome/dropdownexampleshorthandtsx-opens-with-selected-item-highlighted-0) is the expected  screener regression

@silviuavram has more details