### PR TITLE
fix(docs): new theme from switcher not applied when the page is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix theme switcher not applying the new theme when the component's page is changed @mnajdova ([#911](https://github.com/stardust-ui/react/pull/911))
+
 <!--------------------------------[ v0.21.1 ]------------------------------- -->
 ## [v0.21.1](https://github.com/stardust-ui/react/tree/v0.21.1) (2019-02-14)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.21.0...v0.21.1)

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -63,15 +63,15 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
   constructor(props) {
     super(props)
 
-    const { examplePath } = props
+    const { examplePath, themeName } = props
 
     this.anchorName = examplePathToHash(examplePath)
     this.state = {
+      themeName,
       handleMouseLeave: this.handleMouseLeave,
       handleMouseMove: this.handleMouseMove,
       knobs: this.getDefaultKnobsValue(),
       showCode: this.isActiveHash(),
-      themeName: 'teams',
       componentVariables: {},
       showRtl: examplePath && examplePath.endsWith('rtl') ? true : false,
       showTransparent: false,


### PR DESCRIPTION
This PR fixed the issue for the new theme chosen from the theme switcher not being applied when the component page is changed.

## Before
![theme-switching-broken](https://user-images.githubusercontent.com/4512430/52861855-04cb3f00-3134-11e9-849a-f15aa51baaa4.gif)

## After
![theme-switching-fixed](https://user-images.githubusercontent.com/4512430/52861870-0c8ae380-3134-11e9-8401-9cb912d6a490.gif)

