### PR TITLE
fix: (temporarily) remove mdn-polyfills dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Temporarily remove `mdn-polyfills` dependency @miroslavstastny ([#912](https://github.com/stardust-ui/react/pull/912))
+
 <!--------------------------------[ v0.21.1 ]------------------------------- -->
 ## [v0.21.1](https://github.com/stardust-ui/react/tree/v0.21.1) (2019-02-14)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.21.0...v0.21.1)

--- a/docs/src/index.ejs
+++ b/docs/src/index.ejs
@@ -26,7 +26,6 @@
   </script>
 </head>
 <body>
-  <script src="https://cdn.jsdelivr.net/npm/@babel/polyfill@7/dist/polyfill.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.1/anchor.min.js"></script>
   <script
     crossOrigin="anonymous"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,7 +33,6 @@
     "fela-plugin-rtl": "^10.2.0",
     "keyboard-key": "^1.0.1",
     "lodash": "^4.17.11",
-    "mdn-polyfills": "^5.15.0",
     "prop-types": "^15.6.1",
     "react-fela": "^10.2.0",
     "react-is": "^16.6.3",

--- a/packages/react/src/lib/index.ts
+++ b/packages/react/src/lib/index.ts
@@ -1,7 +1,3 @@
-// TODO: remove after switch to Babel
-import 'mdn-polyfills/Object.assign'
-import 'mdn-polyfills/String.prototype.includes'
-
 import * as customPropTypes from './customPropTypes'
 import * as commonPropTypes from './commonPropTypes'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8140,11 +8140,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-mdn-polyfills@^5.15.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/mdn-polyfills/-/mdn-polyfills-5.15.0.tgz#ee0812604b1f922a6b83ee879e3466483b394bb1"
-  integrity sha512-xnHoz63bS0IpyRwmSFAUEHnx8g2nuC7TbavgtoJYVStg2i32gHnD9o8orjMuQsvltANt+2xPHWGeKgyXWCZV3g==
-
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
Temporarily removes dependency on `mdn-polyfills`.

*Warning:* This PR breaks IE 11 compatibility.