### PR TITLE
fix(Teams-HOC-theme): added missing white color

### DIFF
--- a/packages/react/src/themes/teams-high-contrast/siteVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/siteVariables.ts
@@ -4,6 +4,7 @@ import { colors, naturalColors } from '../teams/siteVariables'
 // COLORS
 //
 export const black = '#000'
+export const white = '#fff'
 
 export const accessibleYellow = '#ffff01'
 export const accessibleGreen = '#3ff23f'


### PR DESCRIPTION
Added white color in the site variables for HOC theme.