### PR TITLE
chore: add `packages` prefix to codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   ignore:
     - docs/*
-    - src/lib/*
-    - src/themes/*
-    - src/styles/*
-    - test/*
+    - packges/react/src/lib/*
+    - packges/react/src/themes/*
+    - packges/react/src/styles/*
+    - packges/react/test/*


### PR DESCRIPTION
PRs are failing Codecov checks on style changes.  This is because the restructure to a monorepo missed the Codecov config paths.