### PR TITLE
fix(docs): html attribute typo

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -112,7 +112,7 @@ class ComponentDoc extends React.Component<any, any> {
                 <Flex.Item>
                   <Header
                     as="h1"
-                    aria-leve="2"
+                    aria-level="2"
                     content={info.displayName}
                     variables={{ color: 'black' }}
                   />


### PR DESCRIPTION
## fix(docs): html attribute typo

### Description

typo from #679 ~~`aria-leve`~~ -> `aria-level`

![screenshot 2019-02-19 at 14 05 32](https://user-images.githubusercontent.com/5442794/53017373-18d2b180-3450-11e9-9d73-96e2d1505972.png)
