### PR TITLE
chore(dangerjs): check dependency changes

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -3,29 +3,87 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as _ from 'lodash'
 
+const CHANGELOG_FILE = 'CHANGELOG.md'
+
+/**
+ * This function asserts that added entries into the changelog file are placed in the right section.
+ */
+const hasAddedLinesAfterVersionInChangelog = async (): Promise<boolean> => {
+  const changelogContent = fs.readFileSync(path.resolve(__dirname, CHANGELOG_FILE)).toString()
+  const versionLineNumber = changelogContent
+    .split('\n')
+    .findIndex(line => line.startsWith('<!--') && line.endsWith('-->'))
+
+  const changelogDiff = await danger.git.structuredDiffForFile(CHANGELOG_FILE)
+  const addedLines = changelogDiff.chunks.reduce((acc, chunk) => {
+    const filteredLines = chunk.changes.filter(change => change.type === 'add')
+
+    return acc.concat(filteredLines)
+  }, [])
+
+  return addedLines.some(line => line.ln >= versionLineNumber)
+}
+
+async function getChangedDependencies(filepath, dependenciesKey = 'dependencies') {
+  const diff = await danger.git.JSONDiffForFile(filepath)
+  if (!diff[dependenciesKey]) {
+    return {}
+  }
+
+  const before = { ...diff[dependenciesKey].before, ..._.zipObject(diff[dependenciesKey].added) }
+  const after = diff[dependenciesKey].after || {}
+  return _.reduce(
+    before,
+    (result, value, key) => {
+      return value === after[key] || !after[key]
+        ? result
+        : { ...result, [key]: { before: value, after: after[key] } }
+    },
+    {},
+  )
+}
+
+function markdownChangedDependencies(
+  filepath,
+  changedDependencies,
+  dependenciesKey = 'dependencies',
+) {
+  markdown(
+    [
+      `Changed ${dependenciesKey} in \`${filepath}\``,
+      '',
+      'package | before | after',
+      '--- | --- | ---',
+      ..._.map(
+        changedDependencies,
+        (value, key) => `${key} | ${value['before'] || '-'} | ${value['after']}`,
+      ),
+    ].join('\n'),
+  )
+}
+
+async function checkDependencyChanges(modifiedFiles) {
+  return modifiedFiles
+    .filter(filepath => filepath.match(/\bpackage\.json$/))
+    .reduce(async (hasWarning, filepath) => {
+      const changedDependencies = await getChangedDependencies(filepath)
+      const changedPeerDependencies = await getChangedDependencies(filepath, 'peerDependencies')
+
+      let shouldLogWarning = hasWarning
+      if (!_.isEmpty(changedDependencies)) {
+        markdownChangedDependencies(filepath, changedDependencies)
+        shouldLogWarning = true
+      }
+      if (!_.isEmpty(changedPeerDependencies)) {
+        markdownChangedDependencies(filepath, changedPeerDependencies, 'peerDependencies')
+        shouldLogWarning = true
+      }
+      return shouldLogWarning
+    }, false)
+}
+
 export default async () => {
   /* === CHANGELOG ==================================================================================================== */
-
-  const CHANGELOG_FILE = 'CHANGELOG.md'
-
-  /**
-   * This function asserts that added entries into the changelog file are placed in the right section.
-   */
-  const hasAddedLinesAfterVersionInChangelog = async (): Promise<boolean> => {
-    const changelogContent = fs.readFileSync(path.resolve(__dirname, CHANGELOG_FILE)).toString()
-    const versionLineNumber = changelogContent
-      .split('\n')
-      .findIndex(line => line.startsWith('<!--') && line.endsWith('-->'))
-
-    const changelogDiff = await danger.git.structuredDiffForFile(CHANGELOG_FILE)
-    const addedLines = changelogDiff.chunks.reduce((acc, chunk) => {
-      const filteredLines = chunk.changes.filter(change => change.type === 'add')
-
-      return acc.concat(filteredLines)
-    }, [])
-
-    return addedLines.some(line => line.ln >= versionLineNumber)
-  }
 
   // Check for a CHANGELOG entry
   const hasChangelog = danger.git.modified_files.some(f => f === CHANGELOG_FILE)
@@ -49,64 +107,6 @@ export default async () => {
     .forEach(filepath => {
       warn(`New package.json added: ${filepath}. Make sure you have approval before merging!`)
     })
-
-  async function getChangedDependencies(filepath, dependenciesKey = 'dependencies') {
-    const diff = await danger.git.JSONDiffForFile(filepath)
-    if (!diff[dependenciesKey]) {
-      return {}
-    }
-
-    const before = { ...diff[dependenciesKey].before, ..._.zipObject(diff[dependenciesKey].added) }
-    const after = diff[dependenciesKey].after || {}
-    return _.reduce(
-      before,
-      (result, value, key) => {
-        return value === after[key] || !after[key]
-          ? result
-          : { ...result, [key]: { before: value, after: after[key] } }
-      },
-      {},
-    )
-  }
-
-  function markdownChangedDependencies(
-    filepath,
-    changedDependencies,
-    dependenciesKey = 'dependencies',
-  ) {
-    markdown(
-      [
-        `Changed ${dependenciesKey} in \`${filepath}\``,
-        '',
-        'package | before | after',
-        '--- | --- | ---',
-        ..._.map(
-          changedDependencies,
-          (value, key) => `${key} | ${value['before'] || '-'} | ${value['after']}`,
-        ),
-      ].join('\n'),
-    )
-  }
-
-  async function checkDependencyChanges(modifiedFiles) {
-    return modifiedFiles
-      .filter(filepath => filepath.match(/\bpackage\.json$/))
-      .reduce(async (hasWarning, filepath) => {
-        const changedDependencies = await getChangedDependencies(filepath)
-        const changedPeerDependencies = await getChangedDependencies(filepath, 'peerDependencies')
-
-        let shouldLogWarning = hasWarning
-        if (!_.isEmpty(changedDependencies)) {
-          markdownChangedDependencies(filepath, changedDependencies)
-          shouldLogWarning = true
-        }
-        if (!_.isEmpty(changedPeerDependencies)) {
-          markdownChangedDependencies(filepath, changedPeerDependencies, 'peerDependencies')
-          shouldLogWarning = true
-        }
-        return shouldLogWarning
-      }, false)
-  }
 
   const dependenciesChanged = await checkDependencyChanges(danger.git.modified_files)
   if (dependenciesChanged) {

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,6 +1,9 @@
-import { danger, fail, warn } from 'danger'
+import { danger, fail, markdown, warn } from 'danger'
 import * as fs from 'fs'
 import * as path from 'path'
+import * as _ from 'lodash'
+
+/* === CHANGELOG ==================================================================================================== */
 
 const CHANGELOG_FILE = 'CHANGELOG.md'
 
@@ -37,3 +40,53 @@ if (!hasChangelog) {
     }
   })
 }
+
+/* === Package dependencies ========================================================================================= */
+
+let dependenciesChangedLogged = false
+
+function logDependenciesChanged() {
+  if (!dependenciesChangedLogged) {
+    dependenciesChangedLogged = true
+    warn('Package dependencies changed. Make sure you have OSS approval before merging!')
+  }
+}
+
+danger.git.created_files
+  .filter(filepath => filepath.match(/\bpackage\.json$/))
+  .forEach(filepath => {
+    warn(`New package added: ${filepath}. Make sure you have OSS approval before merging!`)
+  })
+
+danger.git.modified_files
+  .filter(filepath => filepath.match(/\bpackage\.json$/))
+  .forEach(async filepath => {
+    const diff = await danger.git.JSONDiffForFile(filepath)
+    if (diff.dependencies) {
+      const before = { ...diff.dependencies.before, ..._.zipObject(diff.dependencies.added) }
+      const after = diff.dependencies.after || {}
+      const changedDependencies = _.reduce(
+        before,
+        (result, value, key) => {
+          return value === after[key] || !after[key]
+            ? result
+            : { ...result, [key]: { before: value, after: after[key] } }
+        },
+        {},
+      )
+      if (!_.isEmpty(changedDependencies)) {
+        const md = [
+          `Changed dependencies in \`${filepath}\``,
+          '',
+          'package | before | after',
+          '--- | --- | ---',
+          ..._.map(
+            changedDependencies,
+            (value, key) => `${key} | ${value['before'] || '-'} | ${value['after']}`,
+          ),
+        ].join('\n')
+        logDependenciesChanged()
+        markdown(md)
+      }
+    }
+  })

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -3,90 +3,102 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as _ from 'lodash'
 
-/* === CHANGELOG ==================================================================================================== */
+export default async () => {
+  /* === CHANGELOG ==================================================================================================== */
 
-const CHANGELOG_FILE = 'CHANGELOG.md'
+  const CHANGELOG_FILE = 'CHANGELOG.md'
 
-/**
- * This function asserts that added entries into the changelog file are placed in the right section.
- */
-const hasAddedLinesAfterVersionInChangelog = async (): Promise<boolean> => {
-  const changelogContent = fs.readFileSync(path.resolve(__dirname, CHANGELOG_FILE)).toString()
-  const versionLineNumber = changelogContent
-    .split('\n')
-    .findIndex(line => line.startsWith('<!--') && line.endsWith('-->'))
+  /**
+   * This function asserts that added entries into the changelog file are placed in the right section.
+   */
+  const hasAddedLinesAfterVersionInChangelog = async (): Promise<boolean> => {
+    const changelogContent = fs.readFileSync(path.resolve(__dirname, CHANGELOG_FILE)).toString()
+    const versionLineNumber = changelogContent
+      .split('\n')
+      .findIndex(line => line.startsWith('<!--') && line.endsWith('-->'))
 
-  const changelogDiff = await danger.git.structuredDiffForFile(CHANGELOG_FILE)
-  const addedLines = changelogDiff.chunks.reduce((acc, chunk) => {
-    const filteredLines = chunk.changes.filter(change => change.type === 'add')
+    const changelogDiff = await danger.git.structuredDiffForFile(CHANGELOG_FILE)
+    const addedLines = changelogDiff.chunks.reduce((acc, chunk) => {
+      const filteredLines = chunk.changes.filter(change => change.type === 'add')
 
-    return acc.concat(filteredLines)
-  }, [])
+      return acc.concat(filteredLines)
+    }, [])
 
-  return addedLines.some(line => line.ln >= versionLineNumber)
-}
+    return addedLines.some(line => line.ln >= versionLineNumber)
+  }
 
-// Check for a CHANGELOG entry
-const hasChangelog = danger.git.modified_files.some(f => f === CHANGELOG_FILE)
+  // Check for a CHANGELOG entry
+  const hasChangelog = danger.git.modified_files.some(f => f === CHANGELOG_FILE)
 
-if (!hasChangelog) {
-  warn(
-    'There are no updates provided to CHANGELOG. Ensure there are no publicly visible changes introduced by this PR.',
-  )
-} else {
-  hasAddedLinesAfterVersionInChangelog().then(hasLine => {
-    if (hasLine) {
-      fail(`All of your entries in ${CHANGELOG_FILE} should be in the **Unreleased** section!`)
+  if (!hasChangelog) {
+    warn(
+      'There are no updates provided to CHANGELOG. Ensure there are no publicly visible changes introduced by this PR.',
+    )
+  } else {
+    hasAddedLinesAfterVersionInChangelog().then(hasLine => {
+      if (hasLine) {
+        fail(`All of your entries in ${CHANGELOG_FILE} should be in the **Unreleased** section!`)
+      }
+    })
+  }
+
+  /* === Package dependencies ========================================================================================= */
+
+  danger.git.created_files
+    .filter(filepath => filepath.match(/\bpackage\.json$/))
+    .forEach(filepath => {
+      warn(`New package added: ${filepath}. Make sure you have approval before merging!`)
+    })
+
+  async function getChangedDependencies(filepath) {
+    const diff = await danger.git.JSONDiffForFile(filepath)
+    if (!diff.dependencies) {
+      return {}
     }
-  })
-}
 
-/* === Package dependencies ========================================================================================= */
+    const before = { ...diff.dependencies.before, ..._.zipObject(diff.dependencies.added) }
+    const after = diff.dependencies.after || {}
+    return _.reduce(
+      before,
+      (result, value, key) => {
+        return value === after[key] || !after[key]
+          ? result
+          : { ...result, [key]: { before: value, after: after[key] } }
+      },
+      {},
+    )
+  }
 
-let dependenciesChangedLogged = false
+  function markdownChangedDependencies(filepath, changedDependencies) {
+    markdown(
+      [
+        `Changed dependencies in \`${filepath}\``,
+        '',
+        'package | before | after',
+        '--- | --- | ---',
+        ..._.map(
+          changedDependencies,
+          (value, key) => `${key} | ${value['before'] || '-'} | ${value['after']}`,
+        ),
+      ].join('\n'),
+    )
+  }
 
-function logDependenciesChanged() {
-  if (!dependenciesChangedLogged) {
-    dependenciesChangedLogged = true
-    warn('Package dependencies changed. Make sure you have OSS approval before merging!')
+  async function checkDependencyChanges(modifiedFiles) {
+    return modifiedFiles
+      .filter(filepath => filepath.match(/\bpackage\.json$/))
+      .reduce(async (hasWarning, filepath) => {
+        const changedDependencies = await getChangedDependencies(filepath)
+        if (_.isEmpty(changedDependencies)) {
+          return hasWarning
+        }
+        markdownChangedDependencies(filepath, changedDependencies)
+        return true
+      }, false)
+  }
+
+  const dependenciesChanged = await checkDependencyChanges(danger.git.modified_files)
+  if (dependenciesChanged) {
+    warn('Package dependencies changed. Make sure you have approval before merging!')
   }
 }
-
-danger.git.created_files
-  .filter(filepath => filepath.match(/\bpackage\.json$/))
-  .forEach(filepath => {
-    warn(`New package added: ${filepath}. Make sure you have OSS approval before merging!`)
-  })
-
-danger.git.modified_files
-  .filter(filepath => filepath.match(/\bpackage\.json$/))
-  .forEach(async filepath => {
-    const diff = await danger.git.JSONDiffForFile(filepath)
-    if (diff.dependencies) {
-      const before = { ...diff.dependencies.before, ..._.zipObject(diff.dependencies.added) }
-      const after = diff.dependencies.after || {}
-      const changedDependencies = _.reduce(
-        before,
-        (result, value, key) => {
-          return value === after[key] || !after[key]
-            ? result
-            : { ...result, [key]: { before: value, after: after[key] } }
-        },
-        {},
-      )
-      if (!_.isEmpty(changedDependencies)) {
-        const md = [
-          `Changed dependencies in \`${filepath}\``,
-          '',
-          'package | before | after',
-          '--- | --- | ---',
-          ..._.map(
-            changedDependencies,
-            (value, key) => `${key} | ${value['before'] || '-'} | ${value['after']}`,
-          ),
-        ].join('\n')
-        logDependenciesChanged()
-        markdown(md)
-      }
-    }
-  })


### PR DESCRIPTION
As part of CI, package dependencies are verified - if relevant change is detected (new `package.json` added, new dependency added, version of existing dependency changed in any `package.json`) warning is added to the PR.

### Example

![image](https://user-images.githubusercontent.com/9615899/53048349-d2ec0c80-3494-11e9-9d63-9e77f3713359.png)
