### PR TITLE
feat(FocusZone): Export FocusZone types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Export `accept` and `urgent` SVG icons to the Teams Theme @joheredi([#929](https://github.com/stardust-ui/react/pull/929))
 - Add `open`, `defaultOpen` and `onOpenChange` props for `Dropdown` component (controlled mode) @Bugaa92 ([#900](https://github.com/stardust-ui/react/pull/900))
 - Add `accessibility` prop to all components that supports it @layershifter ([#927](https://github.com/stardust-ui/react/pull/927))
+- Export `FocusZone` types @sophieH29 ([#943](https://github.com/stardust-ui/react/pull/943/))
 
 ### Fixes
 - Display correctly images in portrait mode inside `Avatar` @layershifter ([#899](https://github.com/stardust-ui/react/pull/899))

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -203,5 +203,9 @@ export {
 } from './lib'
 export { ShorthandRenderer } from './types'
 
+//
+// FocusZone
+//
 import { getFirstTabbable, getLastTabbable } from './lib/accessibility/FocusZone/focusUtilities'
-export const focusZoneUtilities = { getFirstTabbable, getLastTabbable }
+export const FocusZoneUtilities = { getFirstTabbable, getLastTabbable }
+export { FocusZoneDirection, FocusZoneProps } from './lib/accessibility/FocusZone/FocusZone.types'


### PR DESCRIPTION
As per request, export FocusZone types, so that users can refer to them if they want to override the focus zone in accessibility behaviors.