### PR TITLE
fix(styles): removed redundant margins from components and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Call callbacks after the clear action in `Input` and `Dropdown` @layershifter ([#956](https://github.com/stardust-ui/react/pull/956))
 - Fix `ChatMessage` styles for Teams theme @kuzhelov ([#962](https://github.com/stardust-ui/react/pull/962))
 - Fix the order of applied props in `Status` component @layershifter ([#961](https://github.com/stardust-ui/react/pull/961))
+- Remove redundant margins for `Button` and `Icon` components and fix layout of `Dialog` component and affected examples @Bugaa92 ([#945](https://github.com/stardust-ui/react/pull/945))
 
 ### Documentation
 - Add `Editable Area with Dropdown` prototype for mentioning people using `@` character (only available in development mode) @Bugaa92 ([#931](https://github.com/stardust-ui/react/pull/931))

--- a/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
+++ b/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
@@ -9,7 +9,7 @@ class AccordionPanelCustomContentExample extends React.Component {
         content: {
           key: 'animals',
           content: (
-            <Flex gap="gap.small">
+            <Flex gap="gap.smaller">
               <Button primary>Add pet</Button>
               <Button>Remove pet</Button>
             </Flex>

--- a/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
+++ b/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Accordion, Button } from '@stardust-ui/react'
+import { Accordion, Button, Flex } from '@stardust-ui/react'
 
 class AccordionPanelCustomContentExample extends React.Component {
   render() {
@@ -9,10 +9,10 @@ class AccordionPanelCustomContentExample extends React.Component {
         content: {
           key: 'animals',
           content: (
-            <div>
+            <Flex gap="gap.small">
               <Button primary>Add pet</Button>
               <Button>Remove pet</Button>
-            </div>
+            </Flex>
           ),
         },
       },

--- a/docs/src/examples/components/Animation/Types/AnimationExampleKeyframeParams.tsx
+++ b/docs/src/examples/components/Animation/Types/AnimationExampleKeyframeParams.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Animation, Icon, Provider, ThemeAnimation } from '@stardust-ui/react'
+import { Animation, Flex, Icon, Provider, ThemeAnimation } from '@stardust-ui/react'
 
 const colorChanger: ThemeAnimation<{ fromColor: string; toColor: string }> = {
   keyframe: ({ fromColor, toColor }) => ({
@@ -17,7 +17,7 @@ const colorChanger: ThemeAnimation<{ fromColor: string; toColor: string }> = {
 
 const AnimationExample = () => (
   <Provider theme={{ animations: { colorChanger } }}>
-    <div>
+    <Flex gap="gap.smaller">
       <Animation name="colorChanger">
         <Icon name="umbrella" circular bordered />
       </Animation>
@@ -27,7 +27,7 @@ const AnimationExample = () => (
       <Animation name="colorChanger" keyframeParams={{ toColor: 'black' }}>
         <Icon name="umbrella" circular bordered />
       </Animation>
-    </div>
+    </Flex>
   </Provider>
 )
 

--- a/docs/src/examples/components/Button/Rtl/ButtonExample.rtl.tsx
+++ b/docs/src/examples/components/Button/Rtl/ButtonExample.rtl.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleRtl = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button content="مرحبا" />
     <Button content="عالم" primary />
   </Flex>

--- a/docs/src/examples/components/Button/Rtl/ButtonExample.rtl.tsx
+++ b/docs/src/examples/components/Button/Rtl/ButtonExample.rtl.tsx
@@ -1,11 +1,11 @@
-import { Button } from '@stardust-ui/react'
 import * as React from 'react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleRtl = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button content="مرحبا" />
     <Button content="عالم" primary />
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleRtl

--- a/docs/src/examples/components/Button/States/ButtonExampleDisabled.shorthand.tsx
+++ b/docs/src/examples/components/Button/States/ButtonExampleDisabled.shorthand.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleDisabled = () => (
-  <Flex column gap="gap.small">
-    <Flex gap="gap.small">
+  <Flex column gap="gap.smaller">
+    <Flex gap="gap.smaller">
       <Button disabled content="Default" />
       <Button disabled content="Primary" primary />
       <Button disabled content="Secondary" secondary />

--- a/docs/src/examples/components/Button/States/ButtonExampleDisabled.shorthand.tsx
+++ b/docs/src/examples/components/Button/States/ButtonExampleDisabled.shorthand.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleDisabled = () => (
-  <div>
-    <Button disabled content="Default" />
-    <Button disabled content="Primary" primary />
-    <Button disabled content="Secondary" secondary />
-    <Button disabled icon="book" content="Click me" iconPosition="before" primary />
-    <Button disabled circular icon="coffee" />
-    <br />
-    <br />
+  <Flex column gap="gap.small">
+    <Flex gap="gap.small">
+      <Button disabled content="Default" />
+      <Button disabled content="Primary" primary />
+      <Button disabled content="Secondary" secondary />
+      <Button disabled icon="book" content="Click me" iconPosition="before" primary />
+      <Button disabled circular icon="coffee" />
+    </Flex>
     <Button disabled fluid content="Fluid" />
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleDisabled

--- a/docs/src/examples/components/Button/States/ButtonExampleDisabled.tsx
+++ b/docs/src/examples/components/Button/States/ButtonExampleDisabled.tsx
@@ -1,28 +1,28 @@
 import * as React from 'react'
-import { Button, Icon, Text } from '@stardust-ui/react'
+import { Button, Flex, Icon, Text } from '@stardust-ui/react'
 
 const ButtonExampleDisabled = () => (
-  <div>
-    <Button disabled>Default</Button>
-    <Button disabled primary>
-      Primary
-    </Button>
-    <Button disabled secondary>
-      Secondary
-    </Button>
-    <Button disabled icon iconPosition="before" primary>
-      <Icon name="book" xSpacing="after" />
-      <Text content="Click me" />
-    </Button>
-    <Button disabled circular>
-      <Icon name="coffee" xSpacing="none" />
-    </Button>
-    <br />
-    <br />
+  <Flex column gap="gap.small">
+    <Flex gap="gap.small">
+      <Button disabled>Default</Button>
+      <Button disabled primary>
+        Primary
+      </Button>
+      <Button disabled secondary>
+        Secondary
+      </Button>
+      <Button disabled icon iconPosition="before" primary>
+        <Icon name="book" xSpacing="after" />
+        <Text content="Click me" />
+      </Button>
+      <Button disabled circular>
+        <Icon name="coffee" xSpacing="none" />
+      </Button>
+    </Flex>
     <Button disabled fluid>
       Fluid
     </Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleDisabled

--- a/docs/src/examples/components/Button/States/ButtonExampleDisabled.tsx
+++ b/docs/src/examples/components/Button/States/ButtonExampleDisabled.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { Button, Flex, Icon, Text } from '@stardust-ui/react'
 
 const ButtonExampleDisabled = () => (
-  <Flex column gap="gap.small">
-    <Flex gap="gap.small">
+  <Flex column gap="gap.smaller">
+    <Flex gap="gap.smaller">
       <Button disabled>Default</Button>
       <Button disabled primary>
         Primary

--- a/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExample = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button content="Click here" />
     <Button content="See how this very long text shows up on the button" />
   </Flex>

--- a/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExample = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button content="Click here" />
     <Button content="See how this very long text shows up on the button" />
-  </div>
+  </Flex>
 )
 
 export default ButtonExample

--- a/docs/src/examples/components/Button/Types/ButtonExample.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExample = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button>Click here</Button>
     <Button>See how this very long text shows up on the button</Button>
   </Flex>

--- a/docs/src/examples/components/Button/Types/ButtonExample.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExample = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button>Click here</Button>
     <Button>See how this very long text shows up on the button</Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExample

--- a/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.shorthand.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleContentAndIcon = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button icon="book" content="Click me before" iconPosition="before" primary />
     <Button icon="coffee" content="Click me after" iconPosition="after" secondary />
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleContentAndIcon

--- a/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleContentAndIcon = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button icon="book" content="Click me before" iconPosition="before" primary />
     <Button icon="coffee" content="Click me after" iconPosition="after" secondary />
   </Flex>

--- a/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Icon, Text } from '@stardust-ui/react'
 
 const ButtonExampleContentAndIcon = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button icon iconPosition="before" primary>
       <Icon name="book" xSpacing="after" variables={{ color: 'white' }} />
       <Text content="Click me before" />

--- a/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleContentAndIcon.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Button, Icon, Text } from '@stardust-ui/react'
+import { Button, Flex, Icon, Text } from '@stardust-ui/react'
 
 const ButtonExampleContentAndIcon = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button icon iconPosition="before" primary>
       <Icon name="book" xSpacing="after" variables={{ color: 'white' }} />
       <Text content="Click me before" />
@@ -11,7 +11,7 @@ const ButtonExampleContentAndIcon = () => (
       <Text content="Click me after" />
       <Icon name="coffee" xSpacing="before" />
     </Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleContentAndIcon

--- a/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleEmphasis = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button content="Primary" primary />
     <Button content="Secondary" secondary />
   </Flex>

--- a/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.shorthand.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleEmphasis = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button content="Primary" primary />
     <Button content="Secondary" secondary />
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleEmphasis

--- a/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleEmphasis = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button primary>Primary</Button>
     <Button secondary>Secondary</Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleEmphasis

--- a/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleEmphasis = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button primary>Primary</Button>
     <Button secondary>Secondary</Button>
   </Flex>

--- a/docs/src/examples/components/Button/Variations/ButtonExampleCircular.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleCircular.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleCircular = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button circular content="C" />
     <Button circular icon="book" />
   </Flex>

--- a/docs/src/examples/components/Button/Variations/ButtonExampleCircular.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleCircular.shorthand.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleCircular = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button circular content="C" />
     <Button circular icon="book" />
-  </div>
+  </Flex>
 )
 export default ButtonExampleCircular

--- a/docs/src/examples/components/Button/Variations/ButtonExampleCircular.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleCircular.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Icon } from '@stardust-ui/react'
 
 const ButtonExampleCircular = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button circular>C</Button>
     <Button circular icon>
       <Icon name="book" xSpacing="none" />

--- a/docs/src/examples/components/Button/Variations/ButtonExampleCircular.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleCircular.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
-import { Button, Icon } from '@stardust-ui/react'
+import { Button, Flex, Icon } from '@stardust-ui/react'
 
 const ButtonExampleCircular = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button circular>C</Button>
     <Button circular icon>
       <Icon name="book" xSpacing="none" />
     </Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleCircular

--- a/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.shorthand.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleEmphasisCircular = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button circular icon="coffee" primary />
     <Button circular icon="book" secondary />
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleEmphasisCircular

--- a/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleEmphasisCircular = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button circular icon="coffee" primary />
     <Button circular icon="book" secondary />
   </Flex>

--- a/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Icon } from '@stardust-ui/react'
 
 const ButtonExampleEmphasisCircular = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button circular icon primary>
       <Icon name="coffee" xSpacing="none" />
     </Button>

--- a/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleEmphasisCircular.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
-import { Button, Icon } from '@stardust-ui/react'
+import { Button, Flex, Icon } from '@stardust-ui/react'
 
 const ButtonExampleEmphasisCircular = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button circular icon primary>
       <Icon name="coffee" xSpacing="none" />
     </Button>
     <Button circular icon secondary>
       <Icon name="book" xSpacing="none" />
     </Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleEmphasisCircular

--- a/docs/src/examples/components/Button/Variations/ButtonExampleText.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleText.shorthand.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleTextShorthand = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button text icon="book" content="Default" iconPosition="before" />
     <Button text content="Primary" primary />
     <Button text content="Secondary" secondary />
     <Button text iconOnly icon="compass outline" />
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleTextShorthand

--- a/docs/src/examples/components/Button/Variations/ButtonExampleText.shorthand.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleText.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex } from '@stardust-ui/react'
 
 const ButtonExampleTextShorthand = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button text icon="book" content="Default" iconPosition="before" />
     <Button text content="Primary" primary />
     <Button text content="Secondary" secondary />

--- a/docs/src/examples/components/Button/Variations/ButtonExampleText.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleText.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Icon, Text } from '@stardust-ui/react'
 
 const ButtonExampleText = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Button text>
       <Icon name="book" xSpacing="after" />
       <Text content="Default" />

--- a/docs/src/examples/components/Button/Variations/ButtonExampleText.tsx
+++ b/docs/src/examples/components/Button/Variations/ButtonExampleText.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Button, Icon, Text } from '@stardust-ui/react'
+import { Button, Flex, Icon, Text } from '@stardust-ui/react'
 
 const ButtonExampleText = () => (
-  <div>
+  <Flex gap="gap.small">
     <Button text>
       <Icon name="book" xSpacing="after" />
       <Text content="Default" />
@@ -16,7 +16,7 @@ const ButtonExampleText = () => (
     <Button text circular>
       <Icon name="compass outline" xSpacing="none" />
     </Button>
-  </div>
+  </Flex>
 )
 
 export default ButtonExampleText

--- a/docs/src/examples/components/Icon/Types/IconExample.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Types/IconExample.shorthand.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
-import { Icon } from '@stardust-ui/react'
+import { Flex, Icon } from '@stardust-ui/react'
 
 const IconExample = () => (
-  <div>
+  <Flex gap="gap.small">
     <Icon name="call-video" />
     <Icon name="chess rook" />
     <Icon name="book" />
     <Icon name="circle" />
-  </div>
+  </Flex>
 )
 
 export default IconExample

--- a/docs/src/examples/components/Icon/Types/IconExample.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Types/IconExample.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Flex, Icon } from '@stardust-ui/react'
 
 const IconExample = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Icon name="call-video" />
     <Icon name="chess rook" />
     <Icon name="book" />

--- a/docs/src/examples/components/Icon/Variations/IconExampleBordered.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleBordered.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Flex, Icon } from '@stardust-ui/react'
 
 const IconExampleBordered = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Icon name="chess rook" bordered />
     <Icon name="book" bordered />
     <Icon name="expand" bordered />

--- a/docs/src/examples/components/Icon/Variations/IconExampleBordered.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleBordered.shorthand.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Icon } from '@stardust-ui/react'
+import { Flex, Icon } from '@stardust-ui/react'
 
 const IconExampleBordered = () => (
-  <div>
+  <Flex gap="gap.small">
     <Icon name="chess rook" bordered />
     <Icon name="book" bordered />
     <Icon name="expand" bordered />
@@ -14,7 +14,7 @@ const IconExampleBordered = () => (
     <Icon name="coffee" bordered />
     <Icon name="compass outline" bordered />
     <Icon name="area chart" bordered />
-  </div>
+  </Flex>
 )
 
 export default IconExampleBordered

--- a/docs/src/examples/components/Icon/Variations/IconExampleCircular.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleCircular.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Flex, Icon } from '@stardust-ui/react'
 
 const IconExampleCircular = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Icon name="chess rook" circular bordered />
     <Icon name="book" circular bordered />
     <Icon name="expand" circular bordered />

--- a/docs/src/examples/components/Icon/Variations/IconExampleCircular.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleCircular.shorthand.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Icon } from '@stardust-ui/react'
+import { Flex, Icon } from '@stardust-ui/react'
 
 const IconExampleCircular = () => (
-  <div>
+  <Flex gap="gap.small">
     <Icon name="chess rook" circular bordered />
     <Icon name="book" circular bordered />
     <Icon name="expand" circular bordered />
@@ -14,7 +14,7 @@ const IconExampleCircular = () => (
     <Icon name="coffee" circular bordered />
     <Icon name="compass outline" circular bordered />
     <Icon name="area chart" circular bordered />
-  </div>
+  </Flex>
 )
 
 export default IconExampleCircular

--- a/docs/src/examples/components/Icon/Variations/IconExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleColor.shorthand.tsx
@@ -1,33 +1,33 @@
 import * as React from 'react'
 import * as _ from 'lodash'
-import { Icon, Grid, Text, ProviderConsumer } from '@stardust-ui/react'
+import { Flex, Icon, Grid, Text, ProviderConsumer } from '@stardust-ui/react'
 
 const IconExampleColor = () => (
   <Grid columns="repeat(4, auto)" styles={{ alignItems: 'center' }} variables={{ gridGap: '10px' }}>
     <Text content="INHERITED COLOR:" weight="bold" />
-    <div style={{ color: 'violet' }}>
+    <Flex gap="gap.small" style={{ color: 'violet' }}>
       <Icon name="calendar" bordered />
       <Icon name="call" bordered />
       <Icon name="call-video" bordered />
-    </div>
+    </Flex>
     <Text content="INHERITED COLOR FOR OUTLINED ICONS:" weight="bold" />
-    <div style={{ color: 'yellowgreen' }}>
+    <Flex gap="gap.small" style={{ color: 'yellowgreen' }}>
       <Icon name="calendar" bordered variables={{ outline: true }} />
       <Icon name="call" bordered variables={{ outline: true }} />
       <Icon name="call-video" bordered variables={{ outline: true }} />
-    </div>
+    </Flex>
     <Text weight="bold">
       USING THE <code>color</code> VARIABLE:
     </Text>
-    <div>
+    <Flex gap="gap.small">
       <Icon name="calendar" bordered variables={{ color: 'violet' }} />
       <Icon name="call" bordered variables={{ color: 'yellowgreen' }} />
       <Icon name="call-video" bordered variables={{ color: 'cornflowerblue' }} />
-    </div>
+    </Flex>
     <Text weight="bold">
       USING THE <code>borderColor</code> VARIABLE:
     </Text>
-    <div>
+    <Flex gap="gap.small">
       <Icon
         name="calendar"
         bordered
@@ -43,19 +43,19 @@ const IconExampleColor = () => (
         bordered
         variables={{ color: 'cornflowerblue', borderColor: 'orangered' }}
       />
-    </div>
+    </Flex>
     <Text weight="bold">
       USING THE <code>color</code> PROP:
     </Text>
-    <div>
-      <ProviderConsumer
-        render={({ siteVariables: { emphasisColors, naturalColors } }) =>
-          _.take(_.keys({ ...emphasisColors, ...naturalColors }), 3).map(color => (
+    <ProviderConsumer
+      render={({ siteVariables: { emphasisColors, naturalColors } }) => (
+        <Flex gap="gap.small">
+          {_.take(_.keys({ ...emphasisColors, ...naturalColors }), 3).map(color => (
             <Icon key={color} name="call" bordered color={color} />
-          ))
-        }
-      />
-    </div>
+          ))}
+        </Flex>
+      )}
+    />
   </Grid>
 )
 

--- a/docs/src/examples/components/Icon/Variations/IconExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Icon/Variations/IconExampleColor.shorthand.tsx
@@ -5,13 +5,13 @@ import { Flex, Icon, Grid, Text, ProviderConsumer } from '@stardust-ui/react'
 const IconExampleColor = () => (
   <Grid columns="repeat(4, auto)" styles={{ alignItems: 'center' }} variables={{ gridGap: '10px' }}>
     <Text content="INHERITED COLOR:" weight="bold" />
-    <Flex gap="gap.small" style={{ color: 'violet' }}>
+    <Flex gap="gap.smaller" style={{ color: 'violet' }}>
       <Icon name="calendar" bordered />
       <Icon name="call" bordered />
       <Icon name="call-video" bordered />
     </Flex>
     <Text content="INHERITED COLOR FOR OUTLINED ICONS:" weight="bold" />
-    <Flex gap="gap.small" style={{ color: 'yellowgreen' }}>
+    <Flex gap="gap.smaller" style={{ color: 'yellowgreen' }}>
       <Icon name="calendar" bordered variables={{ outline: true }} />
       <Icon name="call" bordered variables={{ outline: true }} />
       <Icon name="call-video" bordered variables={{ outline: true }} />
@@ -19,7 +19,7 @@ const IconExampleColor = () => (
     <Text weight="bold">
       USING THE <code>color</code> VARIABLE:
     </Text>
-    <Flex gap="gap.small">
+    <Flex gap="gap.smaller">
       <Icon name="calendar" bordered variables={{ color: 'violet' }} />
       <Icon name="call" bordered variables={{ color: 'yellowgreen' }} />
       <Icon name="call-video" bordered variables={{ color: 'cornflowerblue' }} />
@@ -27,7 +27,7 @@ const IconExampleColor = () => (
     <Text weight="bold">
       USING THE <code>borderColor</code> VARIABLE:
     </Text>
-    <Flex gap="gap.small">
+    <Flex gap="gap.smaller">
       <Icon
         name="calendar"
         bordered
@@ -49,7 +49,7 @@ const IconExampleColor = () => (
     </Text>
     <ProviderConsumer
       render={({ siteVariables: { emphasisColors, naturalColors } }) => (
-        <Flex gap="gap.small">
+        <Flex gap="gap.smaller">
           {_.take(_.keys({ ...emphasisColors, ...naturalColors }), 3).map(color => (
             <Icon key={color} name="call" bordered color={color} />
           ))}

--- a/docs/src/examples/components/Indicator/Types/IndicatorExampleDirection.shorthand.tsx
+++ b/docs/src/examples/components/Indicator/Types/IndicatorExampleDirection.shorthand.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Indicator } from '@stardust-ui/react'
+import { Indicator, Flex } from '@stardust-ui/react'
 
 const IndicatorExampleDirection = () => (
-  <>
-    <Indicator direction="end" /> <Indicator direction="bottom" /> <Indicator direction="start" />{' '}
-    <Indicator direction="top" />{' '}
-  </>
+  <Flex gap="gap.smaller">
+    <Indicator direction="end" /> <Indicator direction="bottom" /> <Indicator direction="start" />
+    <Indicator direction="top" />
+  </Flex>
 )
 
 export default IndicatorExampleDirection

--- a/docs/src/examples/components/Indicator/Types/IndicatorExampleIcon.shorthand.tsx
+++ b/docs/src/examples/components/Indicator/Types/IndicatorExampleIcon.shorthand.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
-import { Indicator } from '@stardust-ui/react'
+import { Indicator, Flex } from '@stardust-ui/react'
 
 const IndicatorExampleIcon = () => (
-  <>
-    <Indicator icon="chevron down" direction="end" />{' '}
-    <Indicator icon="chevron down" direction="bottom" />{' '}
-    <Indicator icon="chevron down" direction="start" />{' '}
-    <Indicator icon="chevron down" direction="top" />{' '}
-  </>
+  <Flex gap="gap.smaller">
+    <Indicator icon="chevron down" direction="end" />
+    <Indicator icon="chevron down" direction="bottom" />
+    <Indicator icon="chevron down" direction="start" />
+    <Indicator icon="chevron down" direction="top" />
+  </Flex>
 )
 export default IndicatorExampleIcon

--- a/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, Popup } from '@stardust-ui/react'
+import { Button, Flex, Popup } from '@stardust-ui/react'
 
 const PopupContentWrapperExample = () => {
   const plainContentStyle = {
@@ -8,7 +8,7 @@ const PopupContentWrapperExample = () => {
   }
 
   return (
-    <>
+    <Flex gap="gap.small">
       <Popup
         content={<p style={plainContentStyle}>Plain popup content rendered 'as is'.</p>}
         trigger={<Button icon="expand" content="Popup with plain content" />}
@@ -18,7 +18,7 @@ const PopupContentWrapperExample = () => {
         content={{ content: <p style={plainContentStyle}>Popup content rendered in wrapper.</p> }}
         trigger={<Button icon="expand" content="Popup with wrapped content" />}
       />
-    </>
+    </Flex>
   )
 }
 

--- a/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.shorthand.tsx
@@ -8,7 +8,7 @@ const PopupContentWrapperExample = () => {
   }
 
   return (
-    <Flex gap="gap.small">
+    <Flex gap="gap.smaller">
       <Popup
         content={<p style={plainContentStyle}>Plain popup content rendered 'as is'.</p>}
         trigger={<Button icon="expand" content="Popup with plain content" />}

--- a/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, Popup } from '@stardust-ui/react'
+import { Button, Flex, Popup } from '@stardust-ui/react'
 
 const PopupContentWrapperExample = () => {
   const plainContentStyle = {
@@ -8,7 +8,7 @@ const PopupContentWrapperExample = () => {
   }
 
   return (
-    <>
+    <Flex gap="gap.small">
       <Popup content={<p style={plainContentStyle}>Plain popup content rendered 'as is'.</p>}>
         <Button icon="expand" content="Popup with plain content" />
       </Popup>
@@ -18,7 +18,7 @@ const PopupContentWrapperExample = () => {
       >
         <Button icon="expand" content="Popup with wrapped content" />
       </Popup>
-    </>
+    </Flex>
   )
 }
 

--- a/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupContentWrapperExample.tsx
@@ -8,7 +8,7 @@ const PopupContentWrapperExample = () => {
   }
 
   return (
-    <Flex gap="gap.small">
+    <Flex gap="gap.smaller">
       <Popup content={<p style={plainContentStyle}>Plain popup content rendered 'as is'.</p>}>
         <Button icon="expand" content="Popup with plain content" />
       </Popup>

--- a/docs/src/examples/components/Popup/Types/PopupFocusTrapExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupFocusTrapExample.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Input, Header, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'
 
 const PopupFocusTrapExample = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Popup
       /** Provided behavior introduces focus trap to popup content. */
       accessibility={popupFocusTrapBehavior}

--- a/docs/src/examples/components/Popup/Types/PopupFocusTrapExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupFocusTrapExample.shorthand.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Button, Input, Header, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'
+import { Button, Flex, Input, Header, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'
 
 const PopupFocusTrapExample = () => (
-  <>
+  <Flex gap="gap.small">
     <Popup
       /** Provided behavior introduces focus trap to popup content. */
       accessibility={popupFocusTrapBehavior}
@@ -29,7 +29,7 @@ const PopupFocusTrapExample = () => (
         ),
       }}
     />
-  </>
+  </Flex>
 )
 
 export default PopupFocusTrapExample

--- a/docs/src/examples/components/Popup/Usage/PopupExampleOn.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Usage/PopupExampleOn.shorthand.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Button, Popup } from '@stardust-ui/react'
+import { Button, Flex, Popup } from '@stardust-ui/react'
 
 const PopupExampleOn = () => (
-  <div>
+  <Flex gap="gap.small">
     <Popup
       trigger={<Button icon="expand" content="Click" aria-label="Click button" />}
       content="Hello from popup on click!"
@@ -18,7 +18,7 @@ const PopupExampleOn = () => (
       content="Hello from popup on focus!"
       on="focus"
     />
-  </div>
+  </Flex>
 )
 
 export default PopupExampleOn

--- a/docs/src/examples/components/Popup/Usage/PopupExampleOn.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Usage/PopupExampleOn.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Popup } from '@stardust-ui/react'
 
 const PopupExampleOn = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Popup
       trigger={<Button icon="expand" content="Click" aria-label="Click button" />}
       content="Hello from popup on click!"

--- a/docs/src/examples/components/Popup/Usage/PopupExampleOnMultiple.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Usage/PopupExampleOnMultiple.shorthand.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { Button, Popup } from '@stardust-ui/react'
+import { Button, Flex, Popup } from '@stardust-ui/react'
 
 const PopupExampleOnMultiple = () => (
-  <div>
+  <Flex gap="gap.small">
     <Popup
       trigger={<Button icon="expand" content="Click + Focus" aria-label="Click or focus button" />}
       content="Hello from popup on click!"
@@ -13,7 +13,7 @@ const PopupExampleOnMultiple = () => (
       content="Hello from popup on hover!"
       on={['hover', 'focus']}
     />
-  </div>
+  </Flex>
 )
 
 export default PopupExampleOnMultiple

--- a/docs/src/examples/components/Popup/Usage/PopupExampleOnMultiple.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Usage/PopupExampleOnMultiple.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Button, Flex, Popup } from '@stardust-ui/react'
 
 const PopupExampleOnMultiple = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Popup
       trigger={<Button icon="expand" content="Click + Focus" aria-label="Click or focus button" />}
       content="Hello from popup on click!"

--- a/docs/src/examples/components/Popup/Usage/PopupExampleOnWithFocusTrap.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Usage/PopupExampleOnWithFocusTrap.shorthand.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react'
-import { Button, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'
+import { Button, Flex, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'
 
 const contentWithButtons = {
   content: (
-    <>
+    <Flex gap="gap.small">
       <Button>First</Button>
       <Button primary>Second</Button>
-    </>
+    </Flex>
   ),
 }
 
 const PopupExampleOnWithFocusTrap = () => (
-  <div>
+  <Flex gap="gap.small">
     <Popup
       trigger={<Button icon="expand" content="Click" aria-label="Click button" />}
       content={contentWithButtons}
@@ -30,7 +30,7 @@ const PopupExampleOnWithFocusTrap = () => (
       accessibility={popupFocusTrapBehavior}
       on="focus"
     />
-  </div>
+  </Flex>
 )
 
 export default PopupExampleOnWithFocusTrap

--- a/docs/src/examples/components/Popup/Usage/PopupExampleOnWithFocusTrap.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Usage/PopupExampleOnWithFocusTrap.shorthand.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'
 
 const contentWithButtons = {
   content: (
-    <Flex gap="gap.small">
+    <Flex gap="gap.smaller">
       <Button>First</Button>
       <Button primary>Second</Button>
     </Flex>
@@ -11,7 +11,7 @@ const contentWithButtons = {
 }
 
 const PopupExampleOnWithFocusTrap = () => (
-  <Flex gap="gap.small">
+  <Flex gap="gap.smaller">
     <Popup
       trigger={<Button icon="expand" content="Click" aria-label="Click button" />}
       content={contentWithButtons}

--- a/docs/src/examples/components/Ref/Types/RefExample.tsx
+++ b/docs/src/examples/components/Ref/Types/RefExample.tsx
@@ -23,7 +23,7 @@ class RefExample extends React.Component<{}, RefExampleState> {
     return (
       <Grid columns={2}>
         <Segment>
-          <Flex gap="gap.small">
+          <Flex gap="gap.smaller">
             <Ref innerRef={this.handleRef}>
               <Button primary>With functional ref</Button>
             </Ref>

--- a/docs/src/examples/components/Ref/Types/RefExample.tsx
+++ b/docs/src/examples/components/Ref/Types/RefExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, Grid, Ref, Segment } from '@stardust-ui/react'
+import { Button, Flex, Grid, Ref, Segment } from '@stardust-ui/react'
 
 type RefExampleState = {
   isMounted: boolean
@@ -23,14 +23,16 @@ class RefExample extends React.Component<{}, RefExampleState> {
     return (
       <Grid columns={2}>
         <Segment>
-          <Ref innerRef={this.handleRef}>
-            <Button primary>With functional ref</Button>
-          </Ref>
-          <Ref innerRef={this.createdRef}>
-            <Button>
-              With <code>createRef()</code>
-            </Button>
-          </Ref>
+          <Flex gap="gap.small">
+            <Ref innerRef={this.handleRef}>
+              <Button primary>With functional ref</Button>
+            </Ref>
+            <Ref innerRef={this.createdRef}>
+              <Button>
+                With <code>createRef()</code>
+              </Button>
+            </Ref>
+          </Flex>
         </Segment>
 
         {isMounted && (

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -16,6 +16,7 @@ import {
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 import Button from './Button'
+import Flex from '../Flex/Flex'
 
 export interface ButtonGroupProps
   extends UIComponentProps,
@@ -76,14 +77,16 @@ class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
 
     return (
       <ElementType {...unhandledProps} className={classes.root}>
-        {_.map(buttons, (button, idx) =>
-          Button.create(button, {
-            defaultProps: {
-              circular,
-              styles: this.getStyleForButtonIndex(styles, idx === 0, idx === buttons.length - 1),
-            },
-          }),
-        )}
+        <Flex gap="gap.smaller">
+          {_.map(buttons, (button, idx) =>
+            Button.create(button, {
+              defaultProps: {
+                circular,
+                styles: this.getStyleForButtonIndex(styles, idx === 0, idx === buttons.length - 1),
+              },
+            }),
+          )}
+        </Flex>
       </ElementType>
     )
   }

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -76,18 +76,16 @@ class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
     }
 
     return (
-      <ElementType {...unhandledProps} className={classes.root}>
-        <Flex gap="gap.smaller">
-          {_.map(buttons, (button, idx) =>
-            Button.create(button, {
-              defaultProps: {
-                circular,
-                styles: this.getStyleForButtonIndex(styles, idx === 0, idx === buttons.length - 1),
-              },
-            }),
-          )}
-        </Flex>
-      </ElementType>
+      <Flex as={ElementType} gap="gap.smaller" {...unhandledProps} className={classes.root}>
+        {_.map(buttons, (button, idx) =>
+          Button.create(button, {
+            defaultProps: {
+              circular,
+              styles: this.getStyleForButtonIndex(styles, idx === 0, idx === buttons.length - 1),
+            },
+          }),
+        )}
+      </Flex>
     )
   }
 

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -20,6 +20,7 @@ import Box, { BoxProps } from '../Box/Box'
 import Header from '../Header/Header'
 import Portal from '../Portal/Portal'
 import Ref from '../Ref/Ref'
+import Flex from '../Flex/Flex'
 
 export interface DialogProps extends UIComponentProps, ContentComponentProps, ColorComponentProps {
   /**
@@ -211,7 +212,7 @@ class Dialog extends AutoControlledComponent<ReactProps<DialogProps>, DialogStat
             },
             overrideProps: {
               content: (
-                <>
+                <Flex gap="gap.small" hAlign="end">
                   {Button.create(cancelButton, { overrideProps: this.handleCancelButtonOverrides })}
                   {Button.create(confirmButton, {
                     defaultProps: {
@@ -219,7 +220,7 @@ class Dialog extends AutoControlledComponent<ReactProps<DialogProps>, DialogStat
                     },
                     overrideProps: this.handleConfirmButtonOverrides,
                   })}
-                </>
+                </Flex>
               ),
             },
           })}

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -212,7 +212,7 @@ class Dialog extends AutoControlledComponent<ReactProps<DialogProps>, DialogStat
             },
             overrideProps: {
               content: (
-                <Flex gap="gap.small" hAlign="end">
+                <Flex gap="gap.smaller" hAlign="end">
                   {Button.create(cancelButton, { overrideProps: this.handleCancelButtonOverrides })}
                   {Button.create(confirmButton, {
                     defaultProps: {

--- a/packages/react/src/components/Flex/Flex.tsx
+++ b/packages/react/src/components/Flex/Flex.tsx
@@ -28,7 +28,7 @@ export interface FlexProps {
   space?: 'around' | 'between' | 'evenly'
 
   /** Defines gap between each two adjacent child items. */
-  gap?: 'gap.small' | 'gap.medium' | 'gap.large'
+  gap?: 'gap.smaller' | 'gap.small' | 'gap.medium' | 'gap.large'
 
   /** Defines container's padding. */
   padding?: 'padding.medium'
@@ -72,7 +72,7 @@ class Flex extends UIComponent<ReactProps<FlexProps>> {
 
     space: PropTypes.oneOf(['around', 'between', 'evenly']),
 
-    gap: PropTypes.oneOf(['gap.small', 'gap.medium', 'gap.large']),
+    gap: PropTypes.oneOf(['gap.smaller', 'gap.small', 'gap.medium', 'gap.large']),
 
     padding: PropTypes.oneOf(['padding.medium']),
     fill: PropTypes.bool,

--- a/packages/react/src/themes/teams/components/Attachment/attachmentStyles.ts
+++ b/packages/react/src/themes/teams/components/Attachment/attachmentStyles.ts
@@ -4,7 +4,7 @@ import { AttachmentVariables } from './attachmentVariables'
 import { pxToRem } from '../../../../lib'
 
 const attachmentStyles: ComponentSlotStylesInput<AttachmentProps, AttachmentVariables> = {
-  root: ({ props, variables: v }): ICSSInJSStyle => ({
+  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
@@ -18,13 +18,13 @@ const attachmentStyles: ComponentSlotStylesInput<AttachmentProps, AttachmentVari
 
     outline: 0,
 
-    ...(props.isFromKeyboard && {
+    ...(p.isFromKeyboard && {
       ':focus': {
         outline: `.2rem solid ${v.focusOutlineColor}`,
       },
     }),
 
-    ...((props.actionable || props.onClick) && {
+    ...((p.actionable || p.onClick) && {
       cursor: 'pointer',
 
       ':hover': {
@@ -60,13 +60,13 @@ const attachmentStyles: ComponentSlotStylesInput<AttachmentProps, AttachmentVari
     flex: '0 0 auto',
   }),
 
-  progress: ({ props, variables: v }): ICSSInJSStyle => ({
+  progress: ({ props: p, variables: v }): ICSSInJSStyle => ({
     transition: 'width 0.2s',
     position: 'absolute',
     display: 'block',
     bottom: 0,
     left: 0,
-    width: `${props.progress}%`,
+    width: `${p.progress}%`,
     maxWidth: '100%',
     height: pxToRem(v.progressHeight),
     background: v.progressColor,

--- a/packages/react/src/themes/teams/components/Attachment/attachmentStyles.ts
+++ b/packages/react/src/themes/teams/components/Attachment/attachmentStyles.ts
@@ -4,23 +4,23 @@ import { AttachmentVariables } from './attachmentVariables'
 import { pxToRem } from '../../../../lib'
 
 const attachmentStyles: ComponentSlotStylesInput<AttachmentProps, AttachmentVariables> = {
-  root: ({ props, variables }): ICSSInJSStyle => ({
+  root: ({ props, variables: v }): ICSSInJSStyle => ({
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
     width: pxToRem(300),
     minHeight: pxToRem(48),
-    padding: pxToRem(8),
+    padding: v.padding,
     marginBottom: pxToRem(2),
     marginRight: pxToRem(2),
-    background: variables.backgroundColor,
-    color: variables.textColor,
+    background: v.backgroundColor,
+    color: v.textColor,
 
     outline: 0,
 
     ...(props.isFromKeyboard && {
       ':focus': {
-        outline: `.2rem solid ${variables.focusOutlineColor}`,
+        outline: `.2rem solid ${v.focusOutlineColor}`,
       },
     }),
 
@@ -28,39 +28,39 @@ const attachmentStyles: ComponentSlotStylesInput<AttachmentProps, AttachmentVari
       cursor: 'pointer',
 
       ':hover': {
-        background: variables.backgroundColorHover,
+        background: v.backgroundColorHover,
       },
     }),
   }),
 
-  content: ({ props }): ICSSInJSStyle => ({
+  content: (): ICSSInJSStyle => ({
     flex: 1,
   }),
 
-  header: ({ props, variables }): ICSSInJSStyle => ({
-    fontSize: variables.headerFontSize,
-    fontWeight: variables.headerFontWeight,
-    lineHeight: variables.headerLineHeight,
+  header: ({ variables: v }): ICSSInJSStyle => ({
+    fontSize: v.headerFontSize,
+    fontWeight: v.headerFontWeight,
+    lineHeight: v.headerLineHeight,
   }),
 
-  description: ({ props, variables }): ICSSInJSStyle => ({
+  description: ({ variables: v }): ICSSInJSStyle => ({
     display: 'block',
     opacity: 0.5,
-    fontSize: variables.descriptionFontSize,
-    fontWeight: variables.descriptionFontWeight,
-    lineHeight: variables.descriptionLineHeight,
+    fontSize: v.descriptionFontSize,
+    fontWeight: v.descriptionFontWeight,
+    lineHeight: v.descriptionLineHeight,
   }),
 
-  icon: ({ props, variables }): ICSSInJSStyle => ({
+  icon: ({ variables: v }): ICSSInJSStyle => ({
     flex: '0 0 auto',
-    marginRight: variables.iconSpace,
+    marginRight: v.iconSpace,
   }),
 
-  action: ({ props }): ICSSInJSStyle => ({
+  action: (): ICSSInJSStyle => ({
     flex: '0 0 auto',
   }),
 
-  progress: ({ props, variables }): ICSSInJSStyle => ({
+  progress: ({ props, variables: v }): ICSSInJSStyle => ({
     transition: 'width 0.2s',
     position: 'absolute',
     display: 'block',
@@ -68,8 +68,8 @@ const attachmentStyles: ComponentSlotStylesInput<AttachmentProps, AttachmentVari
     left: 0,
     width: `${props.progress}%`,
     maxWidth: '100%',
-    height: pxToRem(variables.progressHeight),
-    background: variables.progressColor,
+    height: pxToRem(v.progressHeight),
+    background: v.progressColor,
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Attachment/attachmentVariables.ts
+++ b/packages/react/src/themes/teams/components/Attachment/attachmentVariables.ts
@@ -1,3 +1,5 @@
+import { pxToRem } from '../../../../lib'
+
 export type AttachmentVariables = {
   padding: number
   iconSpace: number
@@ -21,8 +23,8 @@ export type AttachmentVariables = {
 }
 
 export default siteVariables => ({
-  padding: 8,
-  iconSpace: 12,
+  padding: pxToRem(8),
+  iconSpace: pxToRem(12),
 
   backgroundColor: siteVariables.gray09,
   backgroundColorHover: siteVariables.gray08,

--- a/packages/react/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/react/src/themes/teams/components/Button/buttonStyles.ts
@@ -81,7 +81,6 @@ const buttonStyles: ComponentSlotStylesInput<ButtonProps & ButtonState, any> = {
       alignItems: 'center',
       position: 'relative',
       padding: `0 ${pxToRem(paddingLeftRightValue)}`,
-      margin: 0,
       verticalAlign: 'middle',
       cursor: 'pointer',
 

--- a/packages/react/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/react/src/themes/teams/components/Button/buttonStyles.ts
@@ -81,7 +81,7 @@ const buttonStyles: ComponentSlotStylesInput<ButtonProps & ButtonState, any> = {
       alignItems: 'center',
       position: 'relative',
       padding: `0 ${pxToRem(paddingLeftRightValue)}`,
-      margin: 0, // `0 ${pxToRem(8)} 0 0`,
+      margin: 0,
       verticalAlign: 'middle',
       cursor: 'pointer',
 

--- a/packages/react/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/react/src/themes/teams/components/Button/buttonStyles.ts
@@ -81,7 +81,7 @@ const buttonStyles: ComponentSlotStylesInput<ButtonProps & ButtonState, any> = {
       alignItems: 'center',
       position: 'relative',
       padding: `0 ${pxToRem(paddingLeftRightValue)}`,
-      margin: `0 ${pxToRem(8)} 0 0`,
+      margin: 0, // `0 ${pxToRem(8)} 0 0`,
       verticalAlign: 'middle',
       cursor: 'pointer',
 

--- a/packages/react/src/themes/teams/components/Flex/flexVariables.ts
+++ b/packages/react/src/themes/teams/components/Flex/flexVariables.ts
@@ -8,6 +8,7 @@ export type FlexVariables = GapValues & PaddingValues
 
 export default (): FlexVariables => ({
   // GAP VALUES
+  'gap.smaller': pxToRem(8),
   'gap.small': pxToRem(10),
   'gap.medium': pxToRem(15),
   'gap.large': pxToRem(30),

--- a/packages/react/src/themes/teams/components/Icon/iconStyles.ts
+++ b/packages/react/src/themes/teams/components/Icon/iconStyles.ts
@@ -101,7 +101,6 @@ const iconStyles: ComponentSlotStylesInput<IconProps, IconVariables> = {
     return {
       backgroundColor: v.backgroundColor,
       display: 'inline-block',
-      marginRight: v.marginRight,
       speak: 'none',
       verticalAlign: 'middle',
 

--- a/packages/react/src/themes/teams/components/Icon/iconVariables.ts
+++ b/packages/react/src/themes/teams/components/Icon/iconVariables.ts
@@ -16,7 +16,6 @@ export interface IconVariables {
   disabledColor: string
 
   horizontalSpace: string
-  marginRight: string
   outline?: boolean
   sizeModifier?: IconSizeModifier
 }
@@ -34,6 +33,5 @@ export default (siteVars): IconVariables => ({
   disabledColor: siteVars.gray06,
 
   horizontalSpace: pxToRem(10),
-  marginRight: pxToRem(8),
   outline: undefined,
 })

--- a/packages/react/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/react/src/themes/teams/components/Input/inputVariables.ts
@@ -26,7 +26,7 @@ export default (siteVars): InputVariables => ({
   fontSize: siteVars.fontSizes.medium,
 
   iconPosition: 'absolute',
-  iconRight: pxToRem(2),
+  iconRight: pxToRem(10),
   iconColor: siteVars.bodyColor,
   iconLeft: pxToRem(6),
   inputPaddingWithIconAtStart: `${pxToRem(7)} ${pxToRem(12)} ${pxToRem(7)} ${pxToRem(24)}`,


### PR DESCRIPTION
# fix(styles): removed redundant margins from components and examples

## Description

This PR is pretty straightforward. It:
- removes the `marginRight` styles from the following components:
  - Button
  - Icon
  - Dialog (as consequence, as it was using 2 `Button` components next to each other in the implementation)
- fixes all the examples grouping these components by using `Flex` to achieve the necessary spacing previously provided by `marginRight`

## Screenshots: 

These screenshot outline how spacing is achieved in `Button` examples where 2 `Button` components are placed next to each other

### Before (with `marginRight`):
![screenshot 2019-02-22 at 10 25 31](https://user-images.githubusercontent.com/5442794/53233175-06918700-368d-11e9-90d6-24b1920977b5.png)

### After (with `gap="gap.small"`):
![screenshot 2019-02-22 at 10 24 47](https://user-images.githubusercontent.com/5442794/53233184-0c876800-368d-11e9-8abb-e37bd6ee7ac1.png)
