### PR TITLE
fix(docs): Fela and fontAwesome classes conflict

### DIFF
--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -9,6 +9,7 @@ import { Renderer } from '../themes/types'
 
 const createRendererConfig = (options: any = {}) => ({
   devMode: process.env.NODE_ENV !== 'production',
+  selectorPrefix: '_', // https://github.com/rofrischmann/fela/issues/192
   plugins: [
     // is necessary to prevent accidental style typos
     // from breaking ALL the styles on the page


### PR DESCRIPTION
## fix(docs): Fela and fontAwesome classes conflict

Fixes #950 

Fix is proposed by @rofrischmann (creator of Fela) [here](https://github.com/rofrischmann/fela/issues/192#issuecomment-276111308)

### Downside:

The prefix is added to all class names:
![screenshot 2019-02-22 at 15 47 28](https://user-images.githubusercontent.com/5442794/53249798-4ff7cb80-36b9-11e9-822c-57ee469a71d8.png)


### EDIT:
Alternative to #951 