### PR TITLE
fix(button group): revert margin update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `createComponent()` typings and documentation examples @Bugaa92 ([#954](https://github.com/stardust-ui/react/pull/954))
+- Remove space between `Button.Group` items without `circular` prop @Bugaa92 ([#973](https://github.com/stardust-ui/react/pull/973))
 
 ### Documentation
 - Fix the sidebar missing items for docsite @alinais ([#971](https://github.com/stardust-ui/react/pull/971))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Remove space between `Button.Group` items without `circular` prop @Bugaa92 ([#973](https://github.com/stardust-ui/react/pull/973))
+
 <!--------------------------------[ v0.22.1 ]------------------------------- -->
 ## [v0.22.1](https://github.com/stardust-ui/react/tree/v0.22.1) (2019-02-26)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.22.0...v0.22.1)
 
 ### Fixes
 - Fix `createComponent()` typings and documentation examples @Bugaa92 ([#954](https://github.com/stardust-ui/react/pull/954))
-- Remove space between `Button.Group` items without `circular` prop @Bugaa92 ([#973](https://github.com/stardust-ui/react/pull/973))
 
 ### Documentation
 - Fix the sidebar missing items for docsite @alinais ([#971](https://github.com/stardust-ui/react/pull/971))

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -16,7 +16,6 @@ import {
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 import Button from './Button'
-import Flex from '../Flex/Flex'
 
 export interface ButtonGroupProps
   extends UIComponentProps,
@@ -76,7 +75,7 @@ class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
     }
 
     return (
-      <Flex as={ElementType} gap="gap.smaller" {...unhandledProps} className={classes.root}>
+      <ElementType {...unhandledProps} className={classes.root}>
         {_.map(buttons, (button, idx) =>
           Button.create(button, {
             defaultProps: {
@@ -85,7 +84,7 @@ class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
             },
           }),
         )}
-      </Flex>
+      </ElementType>
     )
   }
 

--- a/packages/react/src/themes/teams/components/Button/buttonGroupStyles.ts
+++ b/packages/react/src/themes/teams/components/Button/buttonGroupStyles.ts
@@ -1,12 +1,9 @@
+import { pxToRem } from '../../../../lib'
 import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { ButtonGroupProps } from '../../../../components/Button/ButtonGroup'
 
-const commonButtonsStyles = (circular: boolean) => ({
-  ...(!circular && {
-    margin: '0px',
-    borderRadius: '0px',
-  }),
-})
+const commonButtonsStyles = (circular: boolean) =>
+  circular ? { marginRight: pxToRem(8) } : { borderRadius: 0 }
 
 const buttonGroupStyles: ComponentSlotStylesInput<ButtonGroupProps, any> = {
   root: (): ICSSInJSStyle => ({}),


### PR DESCRIPTION
# fix(button group): revert margin update

## Description

This PR fixes a small regression in the spacing of `Button.Group` component items,  introduced  #945 

## Screenshots

### Before:
![screenshot 2019-02-26 at 16 22 02](https://user-images.githubusercontent.com/5442794/53424569-b34c6b00-39e3-11e9-9f50-4af08af2600f.png)

### After:
![screenshot 2019-02-26 at 16 22 12](https://user-images.githubusercontent.com/5442794/53424582-b8a9b580-39e3-11e9-957b-1894b63ed1e5.png)
