### PR TITLE
chore(screener): various improvements

### DIFF
--- a/.github/test-a-feature.md
+++ b/.github/test-a-feature.md
@@ -135,11 +135,14 @@ This default test only checks the rendering for the component in its initial sta
 ```tsx
 import { Dropdown } from '@stardust-ui/react'
 
-const steps = [
+const steps: ScreenerSteps = [
   steps => steps.click(`.${Dropdown.slotClassNames.triggerButton}`)
     .snapshot('Opens dropdown list'),
-  steps => steps.hover(`.${Dropdown.slotClassNames.itemsList} li:nth-child(2)`)
-    .snapshot('Highlights an item'),
+  steps => 
+    steps
+      .click(`.${Dropdown.slotClassNames.triggerButton}`)
+      .hover(`.${Dropdown.slotClassNames.itemsList} li:nth-child(2)`)
+      .snapshot('Highlights an item'),
 ]
 
 export default steps

--- a/build/gulp/tasks/screener.ts
+++ b/build/gulp/tasks/screener.ts
@@ -1,4 +1,5 @@
 import { task, series } from 'gulp'
+import { argv } from 'yargs'
 
 import sh from '../sh'
 import config from '../../../config'
@@ -10,6 +11,9 @@ const { paths } = config
 // ----------------------------------------
 
 task('screener:runner', cb => {
+  // screener-runner doesn't allow to pass custom options
+  if (argv.filter) process.env.SCREENER_FILTER = argv.filter
+
   // kill the server when done
   sh(`screener-runner --conf ${paths.base('screener.config.js')}`)
     .then(() => {

--- a/docs/src/components/ExternalExampleLayout.tsx
+++ b/docs/src/components/ExternalExampleLayout.tsx
@@ -1,7 +1,7 @@
 import { Provider } from '@stardust-ui/react'
 import * as _ from 'lodash'
-import * as PropTypes from 'prop-types'
 import * as React from 'react'
+import { match } from 'react-router'
 import SourceRender from 'react-source-render'
 
 import { ExampleSource } from 'docs/src/types'
@@ -15,53 +15,68 @@ import { babelConfig, importResolver } from './Playground/renderConfig'
 
 const examplePaths = exampleSourcesContext.keys()
 
-const ExternalExampleLayout: any = props => {
-  const { exampleName, rtl } = props.match.params
-  const exampleFilename = exampleKebabNameToSourceFilename(exampleName)
-
-  const examplePath = _.find(examplePaths, path => {
-    const { exampleName } = parseExamplePath(path)
-    return exampleFilename === exampleName
-  })
-
-  if (!examplePath) return <PageNotFound />
-  const exampleSource: ExampleSource = exampleSourcesContext(examplePath)
-
-  const isRtlEnabled = rtl === 'true'
-
-  return (
-    <Provider theme={{ rtl: isRtlEnabled }}>
-      <div dir={isRtlEnabled ? 'rtl' : undefined}>
-        <SourceRender
-          babelConfig={babelConfig}
-          source={exampleSource.js}
-          renderHtml={false}
-          resolver={importResolver}
-        >
-          <SourceRender.Consumer>
-            {({ element, error }) => (
-              <>
-                {element}
-                {/* This block allows to see issues with examples as visual regressions. */}
-                {error && <div style={{ fontSize: '5rem', color: 'red' }}>{error.toString()}</div>}
-              </>
-            )}
-          </SourceRender.Consumer>
-        </SourceRender>
-      </div>
-    </Provider>
-  )
+type ExternalExampleLayoutProps = {
+  match: match<{
+    exampleName: string
+    rtl: string
+  }>
 }
 
-ExternalExampleLayout.propTypes = {
-  children: PropTypes.node,
-  history: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      exampleName: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+type ExternalExampleLayoutState = {
+  renderId: number
+}
+
+class ExternalExampleLayout extends React.Component<
+  ExternalExampleLayoutProps,
+  ExternalExampleLayoutState
+> {
+  state = {
+    renderId: 0,
+  }
+
+  componentDidMount() {
+    window.resetExternalLayout = () =>
+      this.setState(prevState => ({ renderId: prevState.renderId + 1 }))
+  }
+
+  render() {
+    const { exampleName, rtl } = this.props.match.params
+    const exampleFilename = exampleKebabNameToSourceFilename(exampleName)
+
+    const examplePath = _.find(examplePaths, path => {
+      const { exampleName } = parseExamplePath(path)
+      return exampleFilename === exampleName
+    })
+
+    if (!examplePath) return <PageNotFound />
+    const exampleSource: ExampleSource = exampleSourcesContext(examplePath)
+    const isRtlEnabled = rtl === 'true'
+
+    return (
+      <Provider key={this.state.renderId} theme={{ rtl: isRtlEnabled }}>
+        <div dir={isRtlEnabled ? 'rtl' : undefined}>
+          <SourceRender
+            babelConfig={babelConfig}
+            source={exampleSource.js}
+            renderHtml={false}
+            resolver={importResolver}
+          >
+            <SourceRender.Consumer>
+              {({ element, error }) => (
+                <>
+                  {element}
+                  {/* This block allows to see issues with examples as visual regressions. */}
+                  {error && (
+                    <div style={{ fontSize: '5rem', color: 'red' }}>{error.toString()}</div>
+                  )}
+                </>
+              )}
+            </SourceRender.Consumer>
+          </SourceRender>
+        </div>
+      </Provider>
+    )
+  }
 }
 
 export default ExternalExampleLayout

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -5,7 +5,7 @@ const selectors = {
   item: (itemIndex: number) => `.${Dropdown.slotClassNames.itemsList} li:nth-child(${itemIndex})`,
 }
 
-const steps = [
+const steps: ScreenerSteps = [
   steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
   steps =>
     steps
@@ -20,6 +20,7 @@ const steps = [
       .snapshot('Opens with selected item highlighted'),
   steps =>
     steps
+      .click(selectors.triggerButton)
       .click(selectors.item(3))
       .click(selectors.triggerButton)
       .hover(selectors.item(2))

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -30,6 +30,7 @@ const steps: ScreenerSteps = [
       .click(selectors.triggerButton)
       .click(selectors.item(3))
       .click(selectors.triggerButton)
+      .click(selectors.triggerButton)
       .snapshot('Closes the list'),
 ]
 

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -5,12 +5,24 @@ const selectors = {
   item: (itemIndex: number) => `.${Dropdown.slotClassNames.itemsList} li:nth-child(${itemIndex})`,
 }
 
-const steps = [
+const steps: ScreenerSteps = [
   steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
-  steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .click(selectors.item(3))
+      .snapshot('Selects an item'),
   steps => steps.click(selectors.triggerButton).snapshot('Opens with selected item highlighted'),
-  steps => steps.hover(selectors.item(2)).snapshot('Highlights another item'),
-  steps => steps.click(selectors.triggerButton).snapshot('Closes the list'),
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .hover(selectors.item(2))
+      .snapshot('Highlights another item'),
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .click(selectors.triggerButton)
+      .snapshot('Closes the list'),
 ]
 
 export default steps

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -10,6 +10,7 @@ const steps = [
   steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
   steps =>
     steps
+      .click(selectors.triggerButton)
       .click(selectors.item(3))
       .click(selectors.triggerButton)
       .snapshot('Opens with selected item highlighted'),

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -7,7 +7,11 @@ const selectors = {
 
 const steps = [
   steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
-  steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .click(selectors.item(3))
+      .snapshot('Selects an item'),
   steps =>
     steps
       .click(selectors.triggerButton)

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -5,22 +5,24 @@ const selectors = {
   item: (itemIndex: number) => `.${Dropdown.slotClassNames.itemsList} li:nth-child(${itemIndex})`,
 }
 
-const steps: ScreenerSteps = [
+const steps = [
   steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
+  steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
   steps =>
     steps
-      .click(selectors.triggerButton)
       .click(selectors.item(3))
-      .snapshot('Selects an item'),
-  steps => steps.click(selectors.triggerButton).snapshot('Opens with selected item highlighted'),
+      .click(selectors.triggerButton)
+      .snapshot('Opens with selected item highlighted'),
   steps =>
     steps
+      .click(selectors.item(3))
       .click(selectors.triggerButton)
       .hover(selectors.item(2))
       .snapshot('Highlights another item'),
   steps =>
     steps
       .click(selectors.triggerButton)
+      .click(selectors.item(3))
       .click(selectors.triggerButton)
       .snapshot('Closes the list'),
 ]

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleClearable.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleClearable.shorthand.steps.ts
@@ -15,6 +15,7 @@ const steps: ScreenerSteps = [
   steps =>
     steps
       .click(selectors.triggerButton)
+      .click(selectors.item(3))
       .click(selectors.clearIndicator)
       .snapshot('Clears the value'),
 ]

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleClearable.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleClearable.shorthand.steps.ts
@@ -6,10 +6,17 @@ const selectors = {
   item: (itemIndex: number) => `.${Dropdown.slotClassNames.itemsList} li:nth-child(${itemIndex})`,
 }
 
-const steps = [
-  steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
-  steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
-  steps => steps.click(selectors.clearIndicator).snapshot('Clears the value'),
+const steps: ScreenerSteps = [
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .click(selectors.item(3))
+      .snapshot('Selects an item'),
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .click(selectors.clearIndicator)
+      .snapshot('Clears the value'),
 ]
 
 export default steps

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand.steps.ts
@@ -20,6 +20,11 @@ const steps: ScreenerSteps = [
       .snapshot('Opened dropdown with two items selected'),
   steps =>
     steps
+      .click(selectors.triggerButton)
+      .click(selectors.item(3))
+      .click(selectors.triggerButton)
+      .click(selectors.item(2))
+      .click(selectors.triggerButton)
       .click(selectors.removeItemIcon(1))
       .click(selectors.triggerButton)
       .click(selectors.removeItemIcon(1))

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand.steps.ts
@@ -9,7 +9,7 @@ const selectors = {
     }`,
 }
 
-const steps = [
+const steps: ScreenerSteps = [
   steps =>
     steps
       .click(selectors.triggerButton)

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleSearchMultiple.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleSearchMultiple.shorthand.steps.ts
@@ -9,9 +9,13 @@ const steps: ScreenerSteps = [
       .click(`.${List.className} li:nth-child(2)`)
       .keys(`.${Input.slotClassNames.input}`, keys.leftArrow)
       .snapshot('Selects last selected element'),
-  steps =>
+  (steps, keys) =>
     steps
       .click(`.${Dropdown.className} .${Indicator.className}`)
+      .click(`.${List.className} li:nth-child(2)`)
+      .click(`.${Dropdown.className} .${Indicator.className}`)
+      .click(`.${List.className} li:nth-child(2)`)
+      .keys(`.${Input.slotClassNames.input}`, keys.leftArrow)
       .hover(`.${Dropdown.slotClassNames.selectedItems} .${Label.className}:nth-child(1)`)
       .snapshot('Hovers first selected element'),
 ]

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleSearchMultiple.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleSearchMultiple.shorthand.steps.ts
@@ -1,17 +1,17 @@
-import { Dropdown, List, Indicator, Input, Label } from '../../../../../../packages/react/src'
-import * as Keys from 'screener-runner/src/keys'
+import { Dropdown, List, Indicator, Input, Label } from '@stardust-ui/react'
 
-const steps = [
-  steps =>
+const steps: ScreenerSteps = [
+  (steps, keys) =>
     steps
       .click(`.${Dropdown.className} .${Indicator.className}`)
       .click(`.${List.className} li:nth-child(2)`)
       .click(`.${Dropdown.className} .${Indicator.className}`)
       .click(`.${List.className} li:nth-child(2)`)
-      .keys(`.${Input.slotClassNames.input}`, Keys.leftArrow)
+      .keys(`.${Input.slotClassNames.input}`, keys.leftArrow)
       .snapshot('Selects last selected element'),
   steps =>
     steps
+      .click(`.${Dropdown.className} .${Indicator.className}`)
       .hover(`.${Dropdown.slotClassNames.selectedItems} .${Label.className}:nth-child(1)`)
       .snapshot('Hovers first selected element'),
 ]

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -17,4 +17,5 @@ declare module '*.json' {
 
 declare interface Window {
   prettierPlugins: any
+  resetExternalLayout: () => void
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -17,5 +17,5 @@ declare module '*.json' {
 
 declare interface Window {
   prettierPlugins: any
-  resetExternalLayout: () => void
+  resetExternalLayout?: () => void
 }

--- a/types/screener.d.ts
+++ b/types/screener.d.ts
@@ -21,7 +21,7 @@ type ScreenerRunnerSteps = {
   click(selector: string): ScreenerRunnerSteps
 
   /** This will capture a visual snapshot. */
-  snapshot(name: string): ScreenerRunnerSteps
+  snapshot(name: string, options?: any): ScreenerRunnerSteps
 
   /** this will move the mouse over the first element matching the provided css selector. */
   hover(selector: string): ScreenerRunnerSteps
@@ -36,7 +36,7 @@ type ScreenerRunnerSteps = {
   focus(selector: string): ScreenerRunnerSteps
 
   /** This will set the value of the input field matching the provided css selector. */
-  setValue(selector: string, value: string): ScreenerRunnerSteps
+  setValue(selector: string, value: string, options?: any): ScreenerRunnerSteps
 
   /** This will send the provided keys to the first element matching the provided css selector. */
   keys(selector: string, key: string): ScreenerRunnerSteps

--- a/types/screener.d.ts
+++ b/types/screener.d.ts
@@ -16,45 +16,48 @@ type ScreenerRunnerKeys = {
   downArrow: string
 }
 
-type ScreenerRunnerSteps = {
+type ScreenerStepBuilder = {
+  /** This executes custom JS code against the client browser the test is running in. */
+  executeScript(code): ScreenerStepBuilder
+
   /** This will click on the first element matching the provided css selector. */
-  click(selector: string): ScreenerRunnerSteps
+  click(selector: string): ScreenerStepBuilder
 
   /** This will capture a visual snapshot. */
-  snapshot(name: string, options?: any): ScreenerRunnerSteps
+  snapshot(name: string, options?: any): ScreenerStepBuilder
 
   /** this will move the mouse over the first element matching the provided css selector. */
-  hover(selector: string): ScreenerRunnerSteps
+  hover(selector: string): ScreenerStepBuilder
 
   /** This will press and hold the mouse button over the first element matching the provided css selector. */
-  mouseDown(selector: string): ScreenerRunnerSteps
+  mouseDown(selector: string): ScreenerStepBuilder
 
   /** This will release the mouse button. selector is optional. */
-  mouseUp(selector: string): ScreenerRunnerSteps
+  mouseUp(selector: string): ScreenerStepBuilder
 
   /** This will set cursor focus on the first element matching the provided css selector. */
-  focus(selector: string): ScreenerRunnerSteps
+  focus(selector: string): ScreenerStepBuilder
 
   /** This will set the value of the input field matching the provided css selector. */
-  setValue(selector: string, value: string, options?: any): ScreenerRunnerSteps
+  setValue(selector: string, value: string, options?: any): ScreenerStepBuilder
 
   /** This will send the provided keys to the first element matching the provided css selector. */
-  keys(selector: string, key: string): ScreenerRunnerSteps
+  keys(selector: string, key: string): ScreenerStepBuilder
 
   /** This will pause execution for the specified number of ms.*/
-  wait(ms: number): ScreenerRunnerSteps
+  wait(ms: number): ScreenerStepBuilder
 
   /** This will override the global cssAnimations option for the current UI state. Set to true to enable CSS Animations, and set to false to disable.*/
-  cssAnimations(isEnabled: boolean): ScreenerRunnerSteps
+  cssAnimations(isEnabled: boolean): ScreenerStepBuilder
 
   /** This will set the current UI state to right-to-left direction. */
-  rtl(): ScreenerRunnerSteps
+  rtl(): ScreenerStepBuilder
 
   /** This will set the current UI state to left-to-right direction. */
-  ltr(): ScreenerRunnerSteps
+  ltr(): ScreenerStepBuilder
 
   /** This will return the steps to be run. */
-  end(): ScreenerRunnerSteps
+  end(): ScreenerStepBuilder
 }
 
 //
@@ -63,4 +66,4 @@ type ScreenerRunnerSteps = {
 
 declare type ScreenerSteps = ScreenerStep[]
 
-type ScreenerStep = (steps: ScreenerRunnerSteps, keys: ScreenerRunnerKeys) => ScreenerRunnerSteps
+type ScreenerStep = (steps: ScreenerStepBuilder, keys: ScreenerRunnerKeys) => ScreenerStepBuilder

--- a/types/screener.d.ts
+++ b/types/screener.d.ts
@@ -1,0 +1,66 @@
+//
+// Typings for `screener-runner`
+//
+
+type ScreenerRunnerKeys = {
+  alt: string
+  control: string
+  enter: string
+  escape: string
+  return: string
+  shift: string
+  tab: string
+  leftArrow: string
+  upArrow: string
+  rightArrow: string
+  downArrow: string
+}
+
+type ScreenerRunnerSteps = {
+  /** This will click on the first element matching the provided css selector. */
+  click(selector: string): ScreenerRunnerSteps
+
+  /** This will capture a visual snapshot. */
+  snapshot(name: string): ScreenerRunnerSteps
+
+  /** this will move the mouse over the first element matching the provided css selector. */
+  hover(selector: string): ScreenerRunnerSteps
+
+  /** This will press and hold the mouse button over the first element matching the provided css selector. */
+  mouseDown(selector: string): ScreenerRunnerSteps
+
+  /** This will release the mouse button. selector is optional. */
+  mouseUp(selector: string): ScreenerRunnerSteps
+
+  /** This will set cursor focus on the first element matching the provided css selector. */
+  focus(selector: string): ScreenerRunnerSteps
+
+  /** This will set the value of the input field matching the provided css selector. */
+  setValue(selector: string, value: string): ScreenerRunnerSteps
+
+  /** This will send the provided keys to the first element matching the provided css selector. */
+  keys(selector: string, key: string): ScreenerRunnerSteps
+
+  /** This will pause execution for the specified number of ms.*/
+  wait(ms: number): ScreenerRunnerSteps
+
+  /** This will override the global cssAnimations option for the current UI state. Set to true to enable CSS Animations, and set to false to disable.*/
+  cssAnimations(isEnabled: boolean): ScreenerRunnerSteps
+
+  /** This will set the current UI state to right-to-left direction. */
+  rtl(): ScreenerRunnerSteps
+
+  /** This will set the current UI state to left-to-right direction. */
+  ltr(): ScreenerRunnerSteps
+
+  /** This will return the steps to be run. */
+  end(): ScreenerRunnerSteps
+}
+
+//
+// Typings for `*.steps.tsx`
+//
+
+declare type ScreenerSteps = ScreenerStep[]
+
+type ScreenerStep = (steps: ScreenerRunnerSteps, keys: ScreenerRunnerKeys) => ScreenerRunnerSteps


### PR DESCRIPTION
### Add `--filter` arg to `yarn test:visual`

![image](https://user-images.githubusercontent.com/14183168/53491042-03880380-3a9e-11e9-9f8f-4455a8646c23.png)

### Adds typings for steps

This simplify adding steps because you will have autocomplete 😺 

```tsx
const steps: ScreenerSteps = [
  steps =>
    steps
      .click(selectors.triggerButton)
      .click(selectors.item(3))
      .snapshot('Selects an item'),
]
```

### Adds automatic reset

The component will be automatically reset on each step, no confusions with steps more ⭐️ 