### PR TITLE
feat(lib): export `getNextElement`, `getPreviousElement` and `focusAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Changed class names of the slots inside the `ListItem` (`ItemLayout`'s classnames were replaced with `ListItem`'s) @mnajdova ([#886](https://github.com/stardust-ui/react/pull/886))
 
 ### Features
-- Add `delay` prop for `Loader` component @layershifter([#969](https://github.com/stardust-ui/react/pull/969))
+- Add `delay` prop for `Loader` component @layershifter ([#969](https://github.com/stardust-ui/react/pull/969))
+- Add `getNextElement`, `getPreviousElement` and `focusAsync` to exported as `focusZoneUtilities` @layershifter ([#981](https://github.com/stardust-ui/react/pull/981))
 
 ### Fixes
 - Remove space between `Button.Group` items without `circular` prop @Bugaa92 ([#973](https://github.com/stardust-ui/react/pull/973))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - Add `delay` prop for `Loader` component @layershifter ([#969](https://github.com/stardust-ui/react/pull/969))
-- Add `getNextElement`, `getPreviousElement` and `focusAsync` to exported as `focusZoneUtilities` @layershifter ([#981](https://github.com/stardust-ui/react/pull/981))
+- Add `getNextElement`, `getPreviousElement` and `focusAsync` to exported as `FocusZoneUtilities` @layershifter ([#981](https://github.com/stardust-ui/react/pull/981))
 
 ### Fixes
 - Remove space between `Button.Group` items without `circular` prop @Bugaa92 ([#973](https://github.com/stardust-ui/react/pull/973))

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -8,9 +8,23 @@ const selectors = {
 const steps = [
   steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
   steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
-  steps => steps.click(selectors.triggerButton).snapshot('Opens with selected item highlighted'),
-  steps => steps.hover(selectors.item(2)).snapshot('Highlights another item'),
-  steps => steps.click(selectors.triggerButton).snapshot('Closes the list'),
+  steps =>
+    steps
+      .click(selectors.item(3))
+      .click(selectors.triggerButton)
+      .snapshot('Opens with selected item highlighted'),
+  steps =>
+    steps
+      .click(selectors.item(3))
+      .click(selectors.triggerButton)
+      .hover(selectors.item(2))
+      .snapshot('Highlights another item'),
+  steps =>
+    steps
+      .click(selectors.triggerButton)
+      .click(selectors.item(3))
+      .click(selectors.triggerButton)
+      .snapshot('Closes the list'),
 ]
 
 export default steps

--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.steps.ts
@@ -8,23 +8,9 @@ const selectors = {
 const steps = [
   steps => steps.click(selectors.triggerButton).snapshot('Shows list'),
   steps => steps.click(selectors.item(3)).snapshot('Selects an item'),
-  steps =>
-    steps
-      .click(selectors.item(3))
-      .click(selectors.triggerButton)
-      .snapshot('Opens with selected item highlighted'),
-  steps =>
-    steps
-      .click(selectors.item(3))
-      .click(selectors.triggerButton)
-      .hover(selectors.item(2))
-      .snapshot('Highlights another item'),
-  steps =>
-    steps
-      .click(selectors.triggerButton)
-      .click(selectors.item(3))
-      .click(selectors.triggerButton)
-      .snapshot('Closes the list'),
+  steps => steps.click(selectors.triggerButton).snapshot('Opens with selected item highlighted'),
+  steps => steps.hover(selectors.item(2)).snapshot('Highlights another item'),
+  steps => steps.click(selectors.triggerButton).snapshot('Closes the list'),
 ]
 
 export default steps

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -213,7 +213,7 @@ import {
   getPreviousElement,
   focusAsync,
 } from './lib/accessibility/FocusZone/focusUtilities'
-export const focusZoneUtilities = {
+export const FocusZoneUtilities = {
   getFirstTabbable,
   getLastTabbable,
   getNextElement,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -201,11 +201,23 @@ export {
   ContentComponentProps,
   SizeValue,
 } from './lib'
-export { ShorthandRenderer } from './types'
+export { ShorthandValue, ShorthandRenderer } from './types'
 
 //
 // FocusZone
 //
-import { getFirstTabbable, getLastTabbable } from './lib/accessibility/FocusZone/focusUtilities'
-export const FocusZoneUtilities = { getFirstTabbable, getLastTabbable }
+import {
+  getFirstTabbable,
+  getLastTabbable,
+  getNextElement,
+  getPreviousElement,
+  focusAsync,
+} from './lib/accessibility/FocusZone/focusUtilities'
+export const focusZoneUtilities = {
+  getFirstTabbable,
+  getLastTabbable,
+  getNextElement,
+  getPreviousElement,
+  focusAsync,
+}
 export { FocusZoneDirection, FocusZoneProps } from './lib/accessibility/FocusZone/FocusZone.types'


### PR DESCRIPTION
This PR:
- add exports `getNextElement`, `getPreviousElement` and `focusAsync` to `focusZoneUtilities`.
- exports `ShorthandValue`