### PR TITLE
fix(Popup): Do not propagate keydown events outside Popup's content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix allow `Text` component when rendered as div to behave as block element in Teams theme @mnajdova ([#940](https://github.com/stardust-ui/react/pull/940))
 - Fix font-based `Icon` styles in Teams theme @kuzhelov ([#976](https://github.com/stardust-ui/react/pull/976))
 - Refactor the `ListItem` component to use the `Flex` components instead of `ItemLayout` @mnajdova ([#886](https://github.com/stardust-ui/react/pull/886))
+- Do not propagate keyboard events outside `Popup`'s content @sophieH29 ([#987](https://github.com/stardust-ui/react/pull/987/))
 
 ### Features
 - Add `Reaction` and `ReactionGroup` components @mnajdova ([#959](https://github.com/stardust-ui/react/pull/959))

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -180,7 +180,6 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
   protected actionHandlers: AccessibilityActionHandlers = {
     closeAndFocusTrigger: e => {
       this.close(e, () => _.invoke(this.triggerFocusableDomElement, 'focus'))
-      e.stopPropagation()
     },
     close: e => this.close(e),
     toggle: e => {
@@ -439,8 +438,12 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
     const popupWrapperAttributes = {
       ...(rtl && { dir: 'rtl' }),
       ...accessibility.attributes.popup,
-      ...accessibility.keyHandlers.popup,
-
+      onKeyDown: (e: KeyboardEvent) => {
+        // don't need to propagate keydown events outside Popup
+        // allow only keyboard actions to execute
+        accessibility.keyHandlers.popup.onKeyDown(e)
+        e.stopPropagation()
+      },
       className: popupPositionClasses,
       style: popupPlacementStyles,
       ...this.getContentProps(),

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -438,7 +438,7 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
     const popupWrapperAttributes = {
       ...(rtl && { dir: 'rtl' }),
       ...accessibility.attributes.popup,
-      onKeyDown: (e: KeyboardEvent) => {
+      onKeyDown: (e: React.KeyboardEvent) => {
         // No need to propagate keydown events outside Popup
         // allow only keyboard actions to execute
         _.invoke(accessibility.keyHandlers.popup, 'onKeyDown', e)

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -439,9 +439,9 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
       ...(rtl && { dir: 'rtl' }),
       ...accessibility.attributes.popup,
       onKeyDown: (e: KeyboardEvent) => {
-        // don't need to propagate keydown events outside Popup
+        // No need to propagate keydown events outside Popup
         // allow only keyboard actions to execute
-        accessibility.keyHandlers.popup.onKeyDown(e)
+        _.invoke(accessibility.keyHandlers.popup, 'onKeyDown', e)
         e.stopPropagation()
       },
       className: popupPositionClasses,

--- a/packages/react/test/specs/components/Popup/Popup-test.tsx
+++ b/packages/react/test/specs/components/Popup/Popup-test.tsx
@@ -62,10 +62,18 @@ describe('Popup', () => {
         on={onProp}
       />,
     )
+    // check popup open on key press
     const popupTriggerElement = popup.find(`#${triggerId}`)
     popupTriggerElement.simulate('keydown', { keyCode: keyboardKeyToOpen })
     expect(getPopupContent(popup).length).toBe(1)
 
+    // when popup open, check that stopPropagation is called when keyboard events are invoked
+    const stopPropagation = jest.fn()
+    const popupContentElement = getPopupContent(popup)
+    popupContentElement.simulate('keyDown', { stopPropagation })
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+
+    // check popup closes on Esc
     popupTriggerElement.simulate('keydown', { keyCode: keyboardKeyToClose })
     expect(getPopupContent(popup).length).toBe(0)
   }


### PR DESCRIPTION
Closes https://github.com/stardust-ui/react/issues/978

No need to propagate keydown events outside Popup, allow only keyboard actions to execute