### PR TITLE
feat(Popup): Set aria-modal for both Dialog and Popup with focus trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `getNextElement`, `getPreviousElement` and `focusAsync` to exported as `FocusZoneUtilities` @layershifter ([#981](https://github.com/stardust-ui/react/pull/981))
 - Add `Reaction` and `ReactionGroup` components @mnajdova ([#959](https://github.com/stardust-ui/react/pull/959))
 - Add `reactionGroup` and `reactionGroupPosition` props to the `ChatMessage` component @mnajdova ([#959](https://github.com/stardust-ui/react/pull/959))
+- Set `aria-modal` attribute for both Dialog and Popup with focus trap @sophieH29 ([#995](https://github.com/stardust-ui/react/pull/995))
 
 ### Documentation
 - Add `MenuButton` prototype (only available in development mode) @layershifter ([#947](https://github.com/stardust-ui/react/pull/947))

--- a/packages/react/src/lib/accessibility/Behaviors/Dialog/dialogBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Dialog/dialogBehavior.ts
@@ -16,8 +16,8 @@ import popupFocusTrapBehavior from '../Popup/popupFocusTrapBehavior'
 const dialogBehavior: Accessibility = (props: any) => {
   const behaviorData = popupFocusTrapBehavior(props)
   behaviorData.attributes.popup = {
+    ...behaviorData.attributes.popup,
     role: 'dialog',
-    'aria-modal': true,
   }
 
   return behaviorData

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
@@ -13,7 +13,8 @@ import popupBehavior from './popupBehavior'
  */
 const popupFocusTrapBehavior: Accessibility = (props: any) => {
   const behaviorData = popupBehavior(props)
-  behaviorData.attributes.popup = {
+  behaviorData.attributes.popup = behaviorData.attributes.popup || {}
+  behaviorData.attributes.popup['aria-modal'] = true
     'aria-modal': true,
   }
   behaviorData.focusTrap = true

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
@@ -8,11 +8,17 @@ import popupBehavior from './popupBehavior'
  *
  * @specification
  * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'aria-modal=true' to 'popup' component's part.
  * Traps focus inside component.
  */
-const popupFocusTrapBehavior: Accessibility = (props: any) => ({
-  ...popupBehavior(props),
-  focusTrap: true,
-})
+const popupFocusTrapBehavior: Accessibility = (props: any) => {
+  const behaviorData = popupBehavior(props)
+  behaviorData.attributes.popup = {
+    'aria-modal': true,
+  }
+  behaviorData.focusTrap = true
+
+  return behaviorData
+}
 
 export default popupFocusTrapBehavior

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
@@ -13,8 +13,8 @@ import popupBehavior from './popupBehavior'
  */
 const popupFocusTrapBehavior: Accessibility = (props: any) => {
   const behaviorData = popupBehavior(props)
-  behaviorData.attributes.popup = behaviorData.attributes.popup || {}
-  behaviorData.attributes.popup['aria-modal'] = true
+  behaviorData.attributes.popup = {
+    ...behaviorData.attributes.popup,
     'aria-modal': true,
   }
   behaviorData.focusTrap = true


### PR DESCRIPTION
Both `Dialog` and `Popup` with focus trap behavior, should have set `aria-modal=true`