### PR TITLE
fix(dropdown): applied roving tabindex technique to selected dropdown items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed emoji `Icon` spacing issue and added settings `Icon` ([#991](https://github.com/stardust-ui/react/pull/991))
 - Call update `node` if it was changed for `Ref` component @layershifter ([#993](https://github.com/stardust-ui/react/pull/993))
 - Close previous `Popup` on enter key @jongsue ([#985](https://github.com/stardust-ui/react/pull/985))
+- Fixed Shift+Tab navigation from `DropdownSelectedItem` @silviuavram ([#1004](https://github.com/stardust-ui/react/pull/1004))
 
 ### Features
 - Add `delay` prop for `Loader` component @layershifter ([#969](https://github.com/stardust-ui/react/pull/969))

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -68,7 +68,7 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
   static displayName = 'DropdownSelectedItem'
   static create: Function
   static slotClassNames: DropdownSelectedItemSlotClassNames
-  static className = 'ui-dropdown__selected-item'
+  static className = 'ui-dropdown__selecteditem'
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -90,7 +90,10 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
 
   componentDidUpdate(prevProps: DropdownSelectedItemProps) {
     if (!prevProps.active && this.props.active) {
+      this.itemRef.current.setAttribute('tabindex', '0')
       this.itemRef.current.focus()
+    } else if (prevProps.active && !this.props.active) {
+      this.itemRef.current.setAttribute('tabindex', '-1')
     }
   }
 

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -90,10 +90,7 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
 
   componentDidUpdate(prevProps: DropdownSelectedItemProps) {
     if (!prevProps.active && this.props.active) {
-      this.itemRef.current.setAttribute('tabindex', '0')
       this.itemRef.current.focus()
-    } else if (prevProps.active && !this.props.active) {
-      this.itemRef.current.setAttribute('tabindex', '-1')
     }
   }
 
@@ -124,7 +121,7 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
     unhandledProps,
     styles,
   }: RenderResultConfig<DropdownSelectedItemProps>) {
-    const { header, icon, image } = this.props
+    const { active, header, icon, image } = this.props
 
     const iconElement = Icon.create(icon, {
       defaultProps: {
@@ -142,7 +139,7 @@ class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemPr
     return (
       <Ref innerRef={this.itemRef}>
         <Label
-          tabIndex={-1}
+          tabIndex={active ? 0 : -1}
           styles={styles.root}
           circular
           onClick={this.handleClick}

--- a/packages/react/test/specs/components/Dropdown/DropdownSelectedItem-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/DropdownSelectedItem-test.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+
+import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
+import { getRenderedAttribute } from 'test/specs/commonTests'
+import { mountWithProviderAndGetComponent } from 'test/utils'
+
+describe('DropdownSelectedItem', () => {
+  describe('active', () => {
+    it('sets tabindex to 0 when true', () => {
+      const dropdownSelectedItemComponent = mountWithProviderAndGetComponent(
+        DropdownSelectedItem,
+        <DropdownSelectedItem active />,
+      )
+      expect(getRenderedAttribute(dropdownSelectedItemComponent, 'tabindex', '')).toBe('0')
+    })
+
+    it('sets tabindex to -1 when falsy', () => {
+      const dropdownSelectedItemComponent = mountWithProviderAndGetComponent(
+        DropdownSelectedItem,
+        <DropdownSelectedItem />,
+      )
+      expect(getRenderedAttribute(dropdownSelectedItemComponent, 'tabindex', '')).toBe('-1')
+    })
+  })
+})


### PR DESCRIPTION
Without it, when in a Popup and a selected item is focused, shift tab will make focus escape the Popup, as FocusTrapZone will not handle it as first focusable item in the Popup (due to the lack of tabindex="0").

Also it does not hurt to be able to come back to the selected item via tab/shift tab once you tabbed/shift tabbed away.

