### PR TITLE
fix: (Icon) search & table icon update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Call update `node` if it was changed for `Ref` component @layershifter ([#993](https://github.com/stardust-ui/react/pull/993))
 - Close previous `Popup` on enter key @jongsue ([#985](https://github.com/stardust-ui/react/pull/985))
 - Fixed color of the `timestamp` in `ChatMessages` marked as `mine` in Teams theme @mnajdova ([#1010](https://github.com/stardust-ui/react/pull/1010))
+- Updated table `Icon` & search `Icon` ([#1011](https://github.com/stardust-ui/react/pull/1011))
 
 ### Features
 - Add `delay` prop for `Loader` component @layershifter ([#969](https://github.com/stardust-ui/react/pull/969))

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/search.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/search.tsx
@@ -1,10 +1,21 @@
 import * as React from 'react'
+import cx from 'classnames'
 import { TeamsProcessedSvgIconSpec } from '../types'
+import { teamsIconClassNames } from '../teamsIconClassNames'
 
 export default {
   icon: ({ classes }) => (
     <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
-      <path d="M22.9 22.2l-4.4-4.4c.8-.9 1.3-2.1 1.3-3.4 0-3-2.4-5.4-5.4-5.4-3 0-5.4 2.4-5.4 5.4 0 3 2.4 5.4 5.4 5.4 1.3 0 2.5-.5 3.4-1.3l4.4 4.4c.1.1.2.1.3.1.1 0 .2 0 .3-.1.2-.2.2-.5.1-.7zm-13-7.8c0-2.4 2-4.4 4.4-4.4s4.4 2 4.4 4.4-2 4.4-4.4 4.4-4.4-2-4.4-4.4z" />
+      <g>
+        <path
+          className={cx(teamsIconClassNames.outline, classes.outlinePart)}
+          d="M23.352,22.648l-4.714-4.713A5.711,5.711,0,0,0,20,14.25,5.75,5.75,0,1,0,14.25,20a5.711,5.711,0,0,0,3.685-1.362l4.713,4.714a.5.5,0,1,0,.7-.7ZM9.5,14.25A4.75,4.75,0,1,1,14.25,19,4.8,4.8,0,0,1,9.5,14.25Z"
+        />
+        <path
+          className={cx(teamsIconClassNames.filled, classes.filledPart)}
+          d="M14.25,8a6.236,6.236,0,0,1,5.062,9.9l4.4,4.391A.974.974,0,0,1,24,23a1.029,1.029,0,0,1-1,1,.982.982,0,0,1-.711-.3L17.9,19.312A6.246,6.246,0,1,1,14.25,8Zm0,2a4.25,4.25,0,1,0,4.25,4.25A4.285,4.285,0,0,0,14.25,10Z"
+        />
+      </g>
     </svg>
   ),
   styles: {},

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/search.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/search.tsx
@@ -6,16 +6,14 @@ import { teamsIconClassNames } from '../teamsIconClassNames'
 export default {
   icon: ({ classes }) => (
     <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
-      <g>
-        <path
-          className={cx(teamsIconClassNames.outline, classes.outlinePart)}
-          d="M23.352,22.648l-4.714-4.713A5.711,5.711,0,0,0,20,14.25,5.75,5.75,0,1,0,14.25,20a5.711,5.711,0,0,0,3.685-1.362l4.713,4.714a.5.5,0,1,0,.7-.7ZM9.5,14.25A4.75,4.75,0,1,1,14.25,19,4.8,4.8,0,0,1,9.5,14.25Z"
-        />
-        <path
-          className={cx(teamsIconClassNames.filled, classes.filledPart)}
-          d="M14.25,8a6.236,6.236,0,0,1,5.062,9.9l4.4,4.391A.974.974,0,0,1,24,23a1.029,1.029,0,0,1-1,1,.982.982,0,0,1-.711-.3L17.9,19.312A6.246,6.246,0,1,1,14.25,8Zm0,2a4.25,4.25,0,1,0,4.25,4.25A4.285,4.285,0,0,0,14.25,10Z"
-        />
-      </g>
+      <path
+        className={cx(teamsIconClassNames.outline, classes.outlinePart)}
+        d="M23.352,22.648l-4.714-4.713A5.711,5.711,0,0,0,20,14.25,5.75,5.75,0,1,0,14.25,20a5.711,5.711,0,0,0,3.685-1.362l4.713,4.714a.5.5,0,1,0,.7-.7ZM9.5,14.25A4.75,4.75,0,1,1,14.25,19,4.8,4.8,0,0,1,9.5,14.25Z"
+      />
+      <path
+        className={cx(teamsIconClassNames.filled, classes.filledPart)}
+        d="M14.25,8a6.236,6.236,0,0,1,5.062,9.9l4.4,4.391A.974.974,0,0,1,24,23a1.029,1.029,0,0,1-1,1,.982.982,0,0,1-.711-.3L17.9,19.312A6.246,6.246,0,1,1,14.25,8Zm0,2a4.25,4.25,0,1,0,4.25,4.25A4.285,4.285,0,0,0,14.25,10Z"
+      />
     </svg>
   ),
   styles: {},

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/table.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/table.tsx
@@ -5,18 +5,16 @@ import { teamsIconClassNames } from '../teamsIconClassNames'
 
 export default {
   icon: ({ classes }) => (
-    <svg
-      role="presentation"
-      focusable="false"
-      viewBox="8 8 16 16"
-      className={classes.svg}
-      aria-labelledby="icons_insert_table"
-    >
+    <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
       <g>
-        <path d="M23 8H9a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1zm-9 10v-4h4v4h-4zm4 1v4h-4v-4h4zm-4-6V9h4v4h-4zM9 9h4v4H9V9zm4 5v4H9v-4h4zm-4 5h4v4H9v-4zm10 4v-4h4v4h-4zm4-5h-4v-4h4v4zm-4-5V9h4v4h-4z" />
-        <g className={cx(teamsIconClassNames.filled, classes.filledPart)}>
-          <path d="M14 19h4v5h-4zM14 8h4v5h-4zM8 14h5v4H8zM19 13h5V9a1 1 0 0 0-1-1h-4v5zM14 14h4v4h-4zM13 19H8v4a1 1 0 0 0 1 1h4v-5zM19 14h5v4h-5zM19 19v5h4a1 1 0 0 0 1-1v-4h-5zM13 13V8H9a1 1 0 0 0-1 1v4h5z" />
-        </g>
+        <path
+          className={cx(teamsIconClassNames.outline, classes.outlinePart)}
+          d="M23,8a1,1,0,0,1,1,1V23a1,1,0,0,1-1,1H9a1,1,0,0,1-1-1V9A1,1,0,0,1,9,8ZM9,19v4h4V19Zm5,0v4h4V19ZM9,14v4h4V14Zm5,0v4h4V14ZM9,9v4h4V9ZM19,19v4h4V19ZM14,9v4h4V9Zm5,5v4h4V14Zm0-5v4h4V9Z"
+        />
+        <path
+          className={cx(teamsIconClassNames.filled, classes.filledPart)}
+          d="M23,8a1,1,0,0,1,1,1v4H19V8ZM13,24H9a1,1,0,0,1-1-1V19h5Zm5,0H14V19h4Zm-5-6H8V14h5Zm5,0H14V14h4Zm6,5a1,1,0,0,1-1,1H19V19h5ZM13,13H8V9A1,1,0,0,1,9,8h4Zm5,0H14V8h4Zm6,5H19V14h5Z"
+        />
       </g>
     </svg>
   ),

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/table.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/table.tsx
@@ -6,16 +6,14 @@ import { teamsIconClassNames } from '../teamsIconClassNames'
 export default {
   icon: ({ classes }) => (
     <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
-      <g>
-        <path
-          className={cx(teamsIconClassNames.outline, classes.outlinePart)}
-          d="M23,8a1,1,0,0,1,1,1V23a1,1,0,0,1-1,1H9a1,1,0,0,1-1-1V9A1,1,0,0,1,9,8ZM9,19v4h4V19Zm5,0v4h4V19ZM9,14v4h4V14Zm5,0v4h4V14ZM9,9v4h4V9ZM19,19v4h4V19ZM14,9v4h4V9Zm5,5v4h4V14Zm0-5v4h4V9Z"
-        />
-        <path
-          className={cx(teamsIconClassNames.filled, classes.filledPart)}
-          d="M23,8a1,1,0,0,1,1,1v4H19V8ZM13,24H9a1,1,0,0,1-1-1V19h5Zm5,0H14V19h4Zm-5-6H8V14h5Zm5,0H14V14h4Zm6,5a1,1,0,0,1-1,1H19V19h5ZM13,13H8V9A1,1,0,0,1,9,8h4Zm5,0H14V8h4Zm6,5H19V14h5Z"
-        />
-      </g>
+      <path
+        className={cx(teamsIconClassNames.outline, classes.outlinePart)}
+        d="M23,8a1,1,0,0,1,1,1V23a1,1,0,0,1-1,1H9a1,1,0,0,1-1-1V9A1,1,0,0,1,9,8ZM9,19v4h4V19Zm5,0v4h4V19ZM9,14v4h4V14Zm5,0v4h4V14ZM9,9v4h4V9ZM19,19v4h4V19ZM14,9v4h4V9Zm5,5v4h4V14Zm0-5v4h4V9Z"
+      />
+      <path
+        className={cx(teamsIconClassNames.filled, classes.filledPart)}
+        d="M23,8a1,1,0,0,1,1,1v4H19V8ZM13,24H9a1,1,0,0,1-1-1V19h5Zm5,0H14V19h4Zm-5-6H8V14h5Zm5,0H14V14h4Zm6,5a1,1,0,0,1-1,1H19V19h5ZM13,13H8V9A1,1,0,0,1,9,8h4Zm5,0H14V8h4Zm6,5H19V14h5Z"
+      />
     </svg>
   ),
   styles: {},


### PR DESCRIPTION
This PR updates search & table icons:

**Old search icons**
<img width="1095" alt="screenshot 2019-03-04 at 17 28 15" src="https://user-images.githubusercontent.com/604667/53743246-08382780-3ea3-11e9-91d1-c6e824bb3b34.png">

**New search icons**
<img width="1123" alt="screenshot 2019-03-04 at 17 22 10" src="https://user-images.githubusercontent.com/604667/53743265-15551680-3ea3-11e9-9ae0-804f473a411d.png">

**Old table icons**
<img width="1082" alt="screenshot 2019-03-04 at 17 26 53" src="https://user-images.githubusercontent.com/604667/53743291-200fab80-3ea3-11e9-9293-e7e05bb6a2be.png">

**New table icons**
<img width="1117" alt="screenshot 2019-03-04 at 17 24 29" src="https://user-images.githubusercontent.com/604667/53743304-2736b980-3ea3-11e9-8281-192b2578a7fe.png">
