### PR TITLE
docs(Editor): improve performance and add TS support to CodeSandbox export

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
@@ -1,0 +1,31 @@
+import * as _ from 'lodash'
+
+import { imports } from 'docs/src/components/Playground/renderConfig'
+import { ComponentSourceManagerLanguage } from 'docs/src/components/ComponentDoc/ComponentSourceManager'
+
+const name = 'stardust-ui-example'
+const description =
+  'An exported example from Stardust UI React, https://stardust-ui.github.io/react/'
+const dependencies = _.mapValues(imports, () => 'latest')
+const devDependencies = {
+  '@types/lodash': 'latest',
+  '@types/react': 'latest',
+  '@types/react-dom': 'latest',
+}
+
+const createPackageJson = (mainFilename: string, language: ComponentSourceManagerLanguage) => ({
+  content: JSON.stringify(
+    {
+      name,
+      version: '1.0.0',
+      description,
+      main: mainFilename,
+      dependencies,
+      devDependencies: language === 'ts' ? devDependencies : {},
+    },
+    null,
+    2,
+  ),
+})
+
+export default createPackageJson

--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/indexTemplates.ts
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/indexTemplates.ts
@@ -11,3 +11,17 @@ ReactDOM.render(
   document.getElementById("root")
 );
 `
+
+export const appTemplateTs = `import { Provider, themes } from "@stardust-ui/react"
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import Example from "./example";
+
+ReactDOM.render(
+  <Provider theme={themes.teams}>
+    <Example />
+  </Provider>,
+  document.getElementById("root")
+);
+`

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -328,6 +328,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
   renderCodeEditorMenu = (): JSX.Element => {
     const {
+      canCodeBeFormatted,
       currentCode,
       currentCodeLanguage,
       currentCodePath,
@@ -342,16 +343,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       border: '0',
       paddingTop: '.5rem',
       float: 'right',
-      color: '#ffffff80',
       borderBottom: 0,
-      ':hover': {
-        borderBottom: 0,
-        color: 'white',
-      },
-      ':focus': {
-        borderBottom: 0,
-        color: 'white',
-      },
     }
 
     // get component name from file path:
@@ -366,12 +358,12 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
     const menuItems = [
       {
-        icon: wasCodeChanged ? 'magic' : 'check', // (error && 'bug') || (canCodeBeFormatted ? 'magic' : 'check')
+        icon: canCodeBeFormatted ? 'magic' : 'check', // (error && 'bug') || (canCodeBeFormatted ? 'magic' : 'check')
         // active: !!error,
         content: 'Prettier',
         key: 'prettier',
         onClick: handleCodeFormat,
-        disabled: !wasCodeChanged,
+        disabled: !canCodeBeFormatted,
       },
       {
         icon: 'refresh',
@@ -412,11 +404,12 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
         size="small"
         primary
         underlined
+        activeIndex={-1}
         styles={codeEditorStyle}
         variables={{
           activeColor: 'white',
-          disabledColor: '#ffffff80',
-          color: '#ffffff80',
+          disabledColor: '#ffffff60',
+          color: '#ffffffb0',
         }}
         items={menuItems}
       />

--- a/docs/src/components/ComponentDoc/ComponentSourceManager/ComponentSourceManager.ts
+++ b/docs/src/components/ComponentDoc/ComponentSourceManager/ComponentSourceManager.ts
@@ -33,8 +33,10 @@ export type ComponentSourceManagerState = {
 
   componentAPIs: ComponentSourceManagerAPIs
   currentCode?: string
+  formattedCode?: string
   originalCode?: string
 
+  canCodeBeFormatted: boolean
   wasCodeChanged: boolean
 }
 
@@ -61,6 +63,7 @@ export default class ComponentSourceManager extends React.Component<
       currentCodePath: '',
 
       componentAPIs,
+      canCodeBeFormatted: false,
       wasCodeChanged: false,
     }
   }
@@ -70,7 +73,13 @@ export default class ComponentSourceManager extends React.Component<
     state: ComponentSourceManagerState,
   ): Partial<ComponentSourceManagerState> {
     const { examplePath } = props
-    const { componentAPIs, currentCodeAPI, currentCodeLanguage, currentCode: storedCode } = state
+    const {
+      componentAPIs,
+      currentCodeAPI,
+      currentCodeLanguage,
+      currentCode: storedCode,
+      formattedCode,
+    } = state
 
     const sourceCodes = componentAPIs[currentCodeAPI].sourceCode
     const originalCode = sourceCodes[currentCodeLanguage]
@@ -78,12 +87,16 @@ export default class ComponentSourceManager extends React.Component<
     const currentCode = typeof storedCode === 'string' ? storedCode : originalCode
     const currentCodePath = examplePath + componentAPIs[currentCodeAPI].fileSuffix
 
+    const wasCodeChanged = originalCode !== currentCode
+    const canCodeBeFormatted = wasCodeChanged && currentCode !== formattedCode
+
     return {
       currentCode,
       currentCodePath,
       originalCode,
 
-      wasCodeChanged: originalCode !== currentCode,
+      canCodeBeFormatted,
+      wasCodeChanged,
     }
   }
 
@@ -103,12 +116,14 @@ export default class ComponentSourceManager extends React.Component<
     const prettierParser = currentCodeLanguage === 'ts' ? 'typescript' : 'babylon'
 
     try {
-      this.setState({ currentCode: formatCode(currentCode, prettierParser) })
+      const formattedCode = formatCode(currentCode, prettierParser)
+
+      this.setState({ currentCode: formattedCode, formattedCode })
     } catch (e) {}
   }
 
   handleCodeReset = (): void => {
-    this.setState({ currentCode: undefined })
+    this.setState({ currentCode: undefined, formattedCode: undefined })
   }
 
   handleLanguageChange = (newLanguage: ComponentSourceManagerLanguage): void => {

--- a/docs/src/components/ComponentDoc/ComponentSourceManager/ComponentSourceManager.ts
+++ b/docs/src/components/ComponentDoc/ComponentSourceManager/ComponentSourceManager.ts
@@ -33,10 +33,8 @@ export type ComponentSourceManagerState = {
 
   componentAPIs: ComponentSourceManagerAPIs
   currentCode?: string
-  formattedCode?: string
   originalCode?: string
 
-  canCodeBeFormatted: boolean
   wasCodeChanged: boolean
 }
 
@@ -63,7 +61,6 @@ export default class ComponentSourceManager extends React.Component<
       currentCodePath: '',
 
       componentAPIs,
-      canCodeBeFormatted: false,
       wasCodeChanged: false,
     }
   }
@@ -81,20 +78,11 @@ export default class ComponentSourceManager extends React.Component<
     const currentCode = typeof storedCode === 'string' ? storedCode : originalCode
     const currentCodePath = examplePath + componentAPIs[currentCodeAPI].fileSuffix
 
-    const prettierParser = currentCodeLanguage === 'ts' ? 'typescript' : 'babylon'
-    let formattedCode
-
-    try {
-      formattedCode = formatCode(currentCode, prettierParser)
-    } catch (e) {}
-
     return {
       currentCode,
       currentCodePath,
-      formattedCode,
       originalCode,
 
-      canCodeBeFormatted: !!formattedCode ? currentCode !== formattedCode : false,
       wasCodeChanged: originalCode !== currentCode,
     }
   }
@@ -111,7 +99,12 @@ export default class ComponentSourceManager extends React.Component<
   }
 
   handleCodeFormat = (): void => {
-    this.setState(prevState => ({ currentCode: prevState.formattedCode }))
+    const { currentCode, currentCodeLanguage } = this.state
+    const prettierParser = currentCodeLanguage === 'ts' ? 'typescript' : 'babylon'
+
+    try {
+      this.setState({ currentCode: formatCode(currentCode, prettierParser) })
+    } catch (e) {}
   }
 
   handleCodeReset = (): void => {

--- a/docs/src/components/Editor/Editor.tsx
+++ b/docs/src/components/Editor/Editor.tsx
@@ -57,7 +57,7 @@ export const EDITOR_BACKGROUND_COLOR = '#1D1F21'
 export const EDITOR_GUTTER_COLOR = '#26282d'
 
 class Editor extends React.Component<EditorProps> {
-  editorRef: any
+  editorRef = React.createRef<any>()
   name = `docs-editor-${_.uniqueId()}`
 
   static propTypes = {
@@ -102,18 +102,29 @@ class Editor extends React.Component<EditorProps> {
 
     // focus editor when editor it becomes active
     if (active !== previousPros.active && active) {
-      this.editorRef.editor.focus()
+      this.editorRef.current.editor.focus()
     }
   }
 
+  handleChange = _.debounce((value: string, e) => {
+    _.invoke(this.props, 'onChange', value, e)
+  }, 200)
+
   setCursorVisibility = visible => {
-    const cursor = this.editorRef.editor.renderer.$cursorLayer.element
+    const cursor = this.editorRef.current.editor.renderer.$cursorLayer.element
 
     cursor.style.display = visible ? '' : 'none'
   }
 
   render() {
-    return <AceEditor {...this.props} name={this.name} ref={c => (this.editorRef = c)} />
+    return (
+      <AceEditor
+        {...this.props}
+        name={this.name}
+        onChange={this.handleChange}
+        ref={this.editorRef}
+      />
+    )
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "puppeteer": "^1.11.0",
     "react": "^16.3.0",
     "react-ace": "^5.1.2",
-    "react-codesandboxer": "^3.1.1",
+    "react-codesandboxer": "^3.1.3",
     "react-custom-scrollbars": "^4.2.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,10 +2789,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codesandboxer@^0.7.1:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/codesandboxer/-/codesandboxer-0.7.2.tgz#f14d8cab9971cf6c535d83b0f40c24c62256d511"
-  integrity sha512-Fl4UAWi2F0qtFUzY2V+HX/nXm8yGHBW7UZNyBbixOqvwm6zvkx0YLJTFBUp9C5aAjvQP+5Bw6Ie9sN6UK8rebw==
+codesandboxer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/codesandboxer/-/codesandboxer-1.0.1.tgz#b294a55de488da2eae5cfc6fdd663f07fbe6bb3c"
+  integrity sha512-5V/MGuAPyrdlkrjRZsyBGeBeyyW0a4a+EgmlmyWttgN+AiOB/i0LLNhzVx0DlwYu/fZ38e+hdiLCe0DJQNa6oA==
   dependencies:
     babel-runtime "^6.26.0"
     form-data "^2.3.2"
@@ -7821,7 +7821,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.pick@^4.2.1:
+lodash.pick@^4.2.1, lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
@@ -10132,12 +10132,14 @@ react-addons-shallow-compare@^15.6.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-codesandboxer@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-codesandboxer/-/react-codesandboxer-3.1.1.tgz#e7af0f00509d0292f91d3730f71565dbf781b0d7"
-  integrity sha512-P1DybPTyHC3PRP2QZ5SeM5MaaQDkr4eROL1XYW0Y703PSPNhUeR1t6xmb5bkkvXpmPg6DdS2eqEddcfaFBimYA==
+react-codesandboxer@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-codesandboxer/-/react-codesandboxer-3.1.3.tgz#0492685f965eb6466f841af52d46b6776c72d22e"
+  integrity sha512-1Qzw+UbnwkRdCCPLGdgmuCLhGzzBRPsJWDEBPlbDZQxvWXysapgPImOqva3Dp6jt3nSniZFKw4VaNdUzDnjXRA==
   dependencies:
-    codesandboxer "^0.7.1"
+    codesandboxer "^1.0.1"
+    lodash.isequal "^4.5.0"
+    lodash.pick "^4.4.0"
     react-node-resolver "^1.0.1"
 
 react-custom-scrollbars@^4.2.1:


### PR DESCRIPTION
### 1. Editor performance

- I disabled code formatting on each rerender
- used `_.debounce()` directly in the `Editor` component

### 2. CodeSandbox export improvements
- much correct description

![image](https://user-images.githubusercontent.com/14183168/53818724-3421de80-3f71-11e9-9273-a34194e9a0c1.png)
- TS code is exportable now, too 🎉 


