### PR TITLE
feat(Label): add label type: badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Features
+- Add `Label` type `Badge` @jaanus03 ([#1020](https://github.com/stardust-ui/react/pull/1020))
 
 <!--------------------------------[ v0.23.0 ]------------------------------- -->
 ## [v0.23.0](https://github.com/stardust-ui/react/tree/v0.23.0) (2019-03-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Allow arrays as shorthand for the Components containing prop of type `CollectionShorthand` @mnajdova ([#996](https://github.com/stardust-ui/react/pull/996))
 - Allow to pass `children` and `content` to `MenuDivider` @layershifter ([#1009](https://github.com/stardust-ui/react/pull/1009))
 - Add `AutoFocusZone` component, for focusing inner element on mount @mnajdova ([#1015](https://github.com/stardust-ui/react/pull/1015))
+- Add `Label` type `Badge` @jaanus03 ([#1020](https://github.com/stardust-ui/react/pull/1020))
 
 ### Documentation
 - Add `MenuButton` prototype (only available in development mode) @layershifter ([#947](https://github.com/stardust-ui/react/pull/947))

--- a/docs/src/examples/components/Label/Variations/LabelExampleBadge.shorthand.tsx
+++ b/docs/src/examples/components/Label/Variations/LabelExampleBadge.shorthand.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { Label } from '@stardust-ui/react'
+
+const LabelExampleBadgeShorthand = () => (
+  <>
+    <Label
+      content="Badge with icon"
+      additionalContent="and additional text"
+      icon={{ name: 'emoji', outline: true }}
+      iconPosition="start"
+      badge
+    />
+    <br />
+    <br />
+    <Label
+      content="Badge without additional text"
+      icon={{ name: 'emoji', outline: true }}
+      iconPosition="start"
+      badge
+    />
+    <br />
+    <br />
+    <Label content="Badge without icon" badge />
+  </>
+)
+
+export default LabelExampleBadgeShorthand

--- a/docs/src/examples/components/Label/Variations/LabelExampleBadge.shorthand.tsx
+++ b/docs/src/examples/components/Label/Variations/LabelExampleBadge.shorthand.tsx
@@ -5,7 +5,7 @@ const LabelExampleBadgeShorthand = () => (
   <>
     <Label
       content="Badge with icon"
-      additionalContent="and additional text"
+      detail="and additional text"
       icon={{ name: 'emoji', outline: true }}
       iconPosition="start"
       badge

--- a/docs/src/examples/components/Label/Variations/LabelExampleDetail.shorthand.tsx
+++ b/docs/src/examples/components/Label/Variations/LabelExampleDetail.shorthand.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import { Label } from '@stardust-ui/react'
 
+const labelSizes = ['mini', 'tiny', 'small', 'medium', 'large', 'big', 'huge', 'massive']
+
 const LabelExampleBadgeShorthand = () => (
   <>
     <Label
-      content="Badge with icon"
-      detail="and additional text"
+      content="Label content"
+      detail="label detail"
       icon={{ name: 'emoji', outline: true }}
       iconPosition="start"
       badge
@@ -21,7 +23,13 @@ const LabelExampleBadgeShorthand = () => (
     <br />
     <br />
     <Label content="Badge without icon" badge />
+
+    <br />
+    <br />
+
+    {labelSizes.map(size => (
+      <Label key={size} size={size} content={size} />
+    ))}
   </>
 )
-
 export default LabelExampleBadgeShorthand

--- a/docs/src/examples/components/Label/Variations/index.tsx
+++ b/docs/src/examples/components/Label/Variations/index.tsx
@@ -14,6 +14,11 @@ const Variations = () => (
       description="A Label can have different colors."
       examplePath="components/Label/Variations/LabelExampleColor"
     />
+    <ComponentExample
+      title="Badge"
+      description="A Label can have the look of a Badge."
+      examplePath="components/Label/Variations/LabelExampleBadge"
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/components/Label/Variations/index.tsx
+++ b/docs/src/examples/components/Label/Variations/index.tsx
@@ -15,9 +15,9 @@ const Variations = () => (
       examplePath="components/Label/Variations/LabelExampleColor"
     />
     <ComponentExample
-      title="Badge"
-      description="A Label can have the look of a Badge."
-      examplePath="components/Label/Variations/LabelExampleBadge"
+      title="Detail"
+      description="A label can contain a detail"
+      examplePath="components/Label/Variations/LabelExampleDetail"
     />
   </ExampleSection>
 )

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -19,6 +19,7 @@ import Icon from '../Icon/Icon'
 import Image from '../Image/Image'
 import Layout from '../Layout/Layout'
 import Text from '../Text/Text'
+import Box from '../Box/Box'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 import { ReactProps, ShorthandValue } from '../../types'
@@ -56,7 +57,7 @@ export interface LabelProps
   /** A Label can position its image at the start or end of the layout. */
   imagePosition?: 'start' | 'end'
 
-  /** A label can look and feel like a badge. */
+  /** A Label can look and feel like a badge. */
   badge?: boolean
 
   /** A Label can have an additional section for text. */
@@ -153,12 +154,9 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     const hasStartElement = startImage || startIcon
     const hasEndElement = endIcon || endImage
 
-    const main = (
-      <span>
-        {content}
-        {additionalContentElement}
-      </span>
-    )
+    const main = Box.create([content, additionalContentElement], {
+      defaultProps: { as: 'span' },
+    })
 
     return (
       <ElementType {...accessibility.attributes.root} {...unhandledProps} className={classes.root}>

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -61,7 +61,7 @@ export interface LabelProps
   badge?: boolean
 
   /** A Label can have an additional section for text. */
-  additionalContent?: string
+  detail?: string
 }
 
 /**
@@ -83,7 +83,7 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     imagePosition: PropTypes.oneOf(['start', 'end']),
     fluid: PropTypes.bool,
     badge: PropTypes.bool,
-    additionalContent: PropTypes.string,
+    detail: PropTypes.string,
   }
 
   static defaultProps = {
@@ -102,15 +102,7 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
   }
 
   renderComponent({ accessibility, ElementType, classes, unhandledProps, variables, styles }) {
-    const {
-      children,
-      content,
-      additionalContent,
-      icon,
-      iconPosition,
-      image,
-      imagePosition,
-    } = this.props
+    const { children, content, detail, icon, iconPosition, image, imagePosition } = this.props
 
     if (childrenExist(children)) {
       return (
@@ -138,14 +130,12 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
       },
       overrideProps: this.handleIconOverrides,
     })
-    const additionalContentElement = additionalContent
-      ? Text.create(additionalContent, {
-          defaultProps: {
-            styles: styles.additionalContent,
-            variables: variables.additionalContent,
-          },
-        })
-      : null
+    const detailElement = Text.create(detail, {
+      defaultProps: {
+        styles: styles.detail,
+        variables: variables.detail,
+      },
+    })
 
     const startImage = imagePosition === 'start' && imageElement
     const startIcon = iconPosition === 'start' && iconElement
@@ -154,7 +144,7 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     const hasStartElement = startImage || startIcon
     const hasEndElement = endIcon || endImage
 
-    const main = Box.create([content, additionalContentElement], {
+    const main = Box.create([content, detailElement], {
       defaultProps: { as: 'span' },
     })
 

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -18,6 +18,7 @@ import {
 import Icon from '../Icon/Icon'
 import Image from '../Image/Image'
 import Layout from '../Layout/Layout'
+import Text from '../Text/Text'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 import { ReactProps, ShorthandValue } from '../../types'
@@ -54,6 +55,12 @@ export interface LabelProps
 
   /** A Label can position its image at the start or end of the layout. */
   imagePosition?: 'start' | 'end'
+
+  /** A label can look and feel like a badge. */
+  badge?: boolean
+
+  /** A Label can have an additional section for text. */
+  additionalContent?: string
 }
 
 /**
@@ -74,6 +81,8 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     image: customPropTypes.itemShorthand,
     imagePosition: PropTypes.oneOf(['start', 'end']),
     fluid: PropTypes.bool,
+    badge: PropTypes.bool,
+    additionalContent: PropTypes.string,
   }
 
   static defaultProps = {
@@ -92,7 +101,15 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
   }
 
   renderComponent({ accessibility, ElementType, classes, unhandledProps, variables, styles }) {
-    const { children, content, icon, iconPosition, image, imagePosition } = this.props
+    const {
+      children,
+      content,
+      additionalContent,
+      icon,
+      iconPosition,
+      image,
+      imagePosition,
+    } = this.props
 
     if (childrenExist(children)) {
       return (
@@ -120,14 +137,28 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
       },
       overrideProps: this.handleIconOverrides,
     })
+    const additionalContentElement = additionalContent
+      ? Text.create(additionalContent, {
+          defaultProps: {
+            styles: styles.additionalContent,
+            variables: variables.additionalContent,
+          },
+        })
+      : null
 
     const startImage = imagePosition === 'start' && imageElement
     const startIcon = iconPosition === 'start' && iconElement
     const endIcon = iconPosition === 'end' && iconElement
     const endImage = imagePosition === 'end' && imageElement
-
     const hasStartElement = startImage || startIcon
     const hasEndElement = endIcon || endImage
+
+    const main = (
+      <span>
+        {content}
+        {additionalContentElement}
+      </span>
+    )
 
     return (
       <ElementType {...accessibility.attributes.root} {...unhandledProps} className={classes.root}>
@@ -140,7 +171,7 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
               </>
             )
           }
-          main={content}
+          main={main}
           end={
             hasEndElement && (
               <>

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -62,6 +62,9 @@ export interface LabelProps
 
   /** A Label can have an additional section for text. */
   detail?: string
+
+  /** A Label can have different sizes */
+  size?: string
 }
 
 /**
@@ -84,6 +87,7 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
     fluid: PropTypes.bool,
     badge: PropTypes.bool,
     detail: PropTypes.string,
+    size: PropTypes.oneOf(['mini', 'tiny', 'small', 'medium', 'large', 'big', 'huge', 'massive']),
   }
 
   static defaultProps = {

--- a/packages/react/src/themes/teams/components/Label/labelStyles.ts
+++ b/packages/react/src/themes/teams/components/Label/labelStyles.ts
@@ -8,6 +8,7 @@ import { LabelVariables } from './labelVariables'
 const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
   root: ({ props: p, variables: v, colors }): ICSSInJSStyle => {
     return {
+      // Default Label styles
       display: 'inline-flex',
       alignItems: 'center',
       overflow: 'hidden',
@@ -25,6 +26,18 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
       ...(p.circular && {
         borderRadius: v.circularRadius,
       }),
+
+      // Label type: Badge
+      ...(p.badge && {
+        height: v.badgeHeight,
+        lineHeight: v.badgeLineheight,
+        color: p.color ? colors.foreground : v.badgeColor,
+        borderRadius: v.badgeBorderRadius,
+        padding: p.additionalContent ? v.badgePadding : v.badgePaddingWithoutAdditionalContent,
+        ...(!p.icon && {
+          padding: v.badgePaddingWithoutIcon,
+        }),
+      }),
     }
   },
 
@@ -33,12 +46,29 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
     width: v.height,
   }),
 
-  icon: ({ props: p }): ICSSInJSStyle =>
-    p.icon &&
-    typeof p.icon === 'object' &&
-    (p.icon as any).onClick && {
-      cursor: 'pointer',
-    },
+  icon: ({ props: p, colors }): ICSSInJSStyle => {
+    return {
+      ...(p.icon &&
+        typeof p.icon === 'object' &&
+        (p.icon as any).onClick && {
+          cursor: 'pointer',
+        }),
+
+      // Label type: Badge
+      ...(p.badge && {
+        marginRight: '5px',
+        color: p.color ? colors.foreground : 'black',
+      }),
+    }
+  },
+
+  additionalContent: ({ variables: v, props: p, colors }): ICSSInJSStyle => ({
+    borderLeft: `solid ${pxToRem(1)}`,
+    borderColor: p.color ? colors.foreground : v.additionalContentBorderColor,
+    height: pxToRem(16),
+    marginLeft: '6px',
+    paddingLeft: '6px',
+  }),
 }
 
 export default labelStyles

--- a/packages/react/src/themes/teams/components/Label/labelStyles.ts
+++ b/packages/react/src/themes/teams/components/Label/labelStyles.ts
@@ -34,7 +34,7 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
         color: p.color ? colors.foreground : v.badgeColor,
         borderRadius: v.badgeBorderRadius,
         backgroundColor: p.color ? colors.background : v.badgeBackgroundColor,
-        padding: p.additionalContent ? v.badgePadding : v.badgePaddingWithoutAdditionalContent,
+        padding: p.detail ? v.badgePadding : v.badgePaddingWithoutdetail,
         ...(!p.icon && {
           padding: v.badgePaddingWithoutIcon,
         }),
@@ -65,11 +65,11 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
     }
   },
 
-  additionalContent: ({ variables: v, props: p, colors }): ICSSInJSStyle => ({
-    borderLeft: v.additionalContentLeftBorder,
-    borderColor: p.color ? colors.foreground : v.additionalContentBorderColor,
-    marginLeft: v.additionalContentMarginLeft,
-    paddingLeft: v.additionalContentPaddingLeft,
+  detail: ({ variables: v, props: p, colors }): ICSSInJSStyle => ({
+    borderLeft: v.detailLeftBorder,
+    borderColor: p.color ? colors.foreground : v.detailBorderColor,
+    marginLeft: v.detailMarginLeft,
+    paddingLeft: v.detailPaddingLeft,
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Label/labelStyles.ts
+++ b/packages/react/src/themes/teams/components/Label/labelStyles.ts
@@ -12,13 +12,14 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
       display: 'inline-flex',
       alignItems: 'center',
       overflow: 'hidden',
-      height: v.height,
-      lineHeight: v.height,
+      height: v.height.mini,
+      lineHeight: v.height.mini,
       color: colors.foreground,
       backgroundColor: colors.background,
       fontSize: pxToRem(14),
       borderRadius: pxToRem(3),
-      padding: v.padding,
+      padding: v.padding.mini,
+      margin: v.margin,
       ...(p.image &&
         (p.imagePosition === 'start'
           ? { paddingLeft: v.startPaddingLeft }
@@ -39,12 +40,19 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
           padding: v.badgePaddingWithoutIcon,
         }),
       }),
+
+      // Size
+      ...(p.size && {
+        padding: v.padding[p.size],
+        height: v.height[p.size],
+        lineHeight: v.height[p.size],
+      }),
     }
   },
 
   image: ({ variables: v }): ICSSInJSStyle => ({
-    height: v.height,
-    width: v.height,
+    height: v.height.mini,
+    width: v.height.mini,
   }),
 
   icon: ({ props: p, variables: v, colors }): ICSSInJSStyle => {

--- a/packages/react/src/themes/teams/components/Label/labelStyles.ts
+++ b/packages/react/src/themes/teams/components/Label/labelStyles.ts
@@ -33,6 +33,7 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
         lineHeight: v.badgeLineheight,
         color: p.color ? colors.foreground : v.badgeColor,
         borderRadius: v.badgeBorderRadius,
+        backgroundColor: p.color ? colors.background : v.badgeBackgroundColor,
         padding: p.additionalContent ? v.badgePadding : v.badgePaddingWithoutAdditionalContent,
         ...(!p.icon && {
           padding: v.badgePaddingWithoutIcon,

--- a/packages/react/src/themes/teams/components/Label/labelStyles.ts
+++ b/packages/react/src/themes/teams/components/Label/labelStyles.ts
@@ -46,7 +46,7 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
     width: v.height,
   }),
 
-  icon: ({ props: p, colors }): ICSSInJSStyle => {
+  icon: ({ props: p, variables: v, colors }): ICSSInJSStyle => {
     return {
       ...(p.icon &&
         typeof p.icon === 'object' &&
@@ -56,18 +56,19 @@ const labelStyles: ComponentSlotStylesInput<LabelProps, LabelVariables> = {
 
       // Label type: Badge
       ...(p.badge && {
-        marginRight: '5px',
-        color: p.color ? colors.foreground : 'black',
+        ...(p.iconPosition === 'start'
+          ? { marginRight: v.badgeIconMargin }
+          : { marginLeft: v.badgeIconMargin }),
+        color: p.color ? colors.foreground : v.badgeColor,
       }),
     }
   },
 
   additionalContent: ({ variables: v, props: p, colors }): ICSSInJSStyle => ({
-    borderLeft: `solid ${pxToRem(1)}`,
+    borderLeft: v.additionalContentLeftBorder,
     borderColor: p.color ? colors.foreground : v.additionalContentBorderColor,
-    height: pxToRem(16),
-    marginLeft: '6px',
-    paddingLeft: '6px',
+    marginLeft: v.additionalContentMarginLeft,
+    paddingLeft: v.additionalContentPaddingLeft,
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Label/labelVariables.ts
+++ b/packages/react/src/themes/teams/components/Label/labelVariables.ts
@@ -11,6 +11,15 @@ export interface LabelVariables {
   endPaddingRight: string
   height: string
   iconColor: string
+
+  badgeHeight: string
+  badgeLineheight: string
+  badgeColor: string
+  badgeBorderRadius: string
+  badgePadding: string
+  badgePaddingWithoutAdditionalContent: string
+  badgePaddingWithoutIcon: string
+  additionalContentBorderColor: string
 }
 
 export default (siteVars: SiteVariablesPrepared): LabelVariables => {
@@ -29,5 +38,15 @@ export default (siteVars: SiteVariablesPrepared): LabelVariables => {
 
     // variables for 'icon' part
     iconColor: color,
+
+    // Label type: Badge
+    badgeHeight: pxToRem(24),
+    badgeLineheight: pxToRem(24),
+    badgeColor: siteVars.colors.black,
+    badgeBorderRadius: pxToRem(2),
+    badgePadding: `0 ${pxToRem(8)}`,
+    badgePaddingWithoutAdditionalContent: `0 ${pxToRem(10)} 0 ${pxToRem(8)}`,
+    badgePaddingWithoutIcon: `0 ${pxToRem(10)}`,
+    additionalContentBorderColor: siteVars.gray06,
   }
 }

--- a/packages/react/src/themes/teams/components/Label/labelVariables.ts
+++ b/packages/react/src/themes/teams/components/Label/labelVariables.ts
@@ -19,7 +19,11 @@ export interface LabelVariables {
   badgePadding: string
   badgePaddingWithoutAdditionalContent: string
   badgePaddingWithoutIcon: string
+  badgeIconMargin: string
   additionalContentBorderColor: string
+  additionalContentLeftBorder: string
+  additionalContentMarginLeft: string
+  additionalContentPaddingLeft: string
 }
 
 export default (siteVars: SiteVariablesPrepared): LabelVariables => {
@@ -47,6 +51,10 @@ export default (siteVars: SiteVariablesPrepared): LabelVariables => {
     badgePadding: `0 ${pxToRem(8)}`,
     badgePaddingWithoutAdditionalContent: `0 ${pxToRem(10)} 0 ${pxToRem(8)}`,
     badgePaddingWithoutIcon: `0 ${pxToRem(10)}`,
+    badgeIconMargin: pxToRem(5),
     additionalContentBorderColor: siteVars.gray06,
+    additionalContentLeftBorder: `solid ${pxToRem(1)}`,
+    additionalContentMarginLeft: pxToRem(6),
+    additionalContentPaddingLeft: pxToRem(6),
   }
 }

--- a/packages/react/src/themes/teams/components/Label/labelVariables.ts
+++ b/packages/react/src/themes/teams/components/Label/labelVariables.ts
@@ -18,13 +18,13 @@ export interface LabelVariables {
   badgeBackgroundColor: string
   badgeBorderRadius: string
   badgePadding: string
-  badgePaddingWithoutAdditionalContent: string
+  badgePaddingWithoutdetail: string
   badgePaddingWithoutIcon: string
   badgeIconMargin: string
-  additionalContentBorderColor: string
-  additionalContentLeftBorder: string
-  additionalContentMarginLeft: string
-  additionalContentPaddingLeft: string
+  detailBorderColor: string
+  detailLeftBorder: string
+  detailMarginLeft: string
+  detailPaddingLeft: string
 }
 
 export default (siteVars: SiteVariablesPrepared): LabelVariables => {
@@ -51,12 +51,12 @@ export default (siteVars: SiteVariablesPrepared): LabelVariables => {
     badgeBackgroundColor: siteVars.gray10,
     badgeBorderRadius: pxToRem(2),
     badgePadding: `0 ${pxToRem(8)}`,
-    badgePaddingWithoutAdditionalContent: `0 ${pxToRem(10)} 0 ${pxToRem(8)}`,
+    badgePaddingWithoutdetail: `0 ${pxToRem(10)} 0 ${pxToRem(8)}`,
     badgePaddingWithoutIcon: `0 ${pxToRem(10)}`,
     badgeIconMargin: pxToRem(5),
-    additionalContentBorderColor: siteVars.gray06,
-    additionalContentLeftBorder: `solid ${pxToRem(1)}`,
-    additionalContentMarginLeft: pxToRem(6),
-    additionalContentPaddingLeft: pxToRem(6),
+    detailBorderColor: siteVars.gray06,
+    detailLeftBorder: `solid ${pxToRem(1)}`,
+    detailMarginLeft: pxToRem(6),
+    detailPaddingLeft: pxToRem(6),
   }
 }

--- a/packages/react/src/themes/teams/components/Label/labelVariables.ts
+++ b/packages/react/src/themes/teams/components/Label/labelVariables.ts
@@ -6,10 +6,11 @@ type LabelColorScheme = Pick<ColorScheme, 'foreground' | 'background'>
 export interface LabelVariables {
   colorScheme: ColorValues<LabelColorScheme>
   circularRadius: string
-  padding: string
+  padding: { [name: string]: string }
   startPaddingLeft: string
   endPaddingRight: string
-  height: string
+  margin: string
+  height: { [name: string]: string }
   iconColor: string
 
   badgeHeight: string
@@ -36,10 +37,29 @@ export default (siteVars: SiteVariablesPrepared): LabelVariables => {
       background: 'rgb(232, 232, 232)',
     }),
     circularRadius: pxToRem(9999),
-    padding: `0 ${pxToRem(4)} 0 ${pxToRem(4)}`,
+    padding: {
+      mini: `0 ${pxToRem(4)} 0 ${pxToRem(4)}`,
+      tiny: `0 ${pxToRem(6)} 0 ${pxToRem(6)}`,
+      small: `0 ${pxToRem(8)} 0 ${pxToRem(8)}`,
+      medium: `0 ${pxToRem(10)} 0 ${pxToRem(10)}`,
+      large: `0 ${pxToRem(12)} 0 ${pxToRem(12)}`,
+      big: `0 ${pxToRem(14)} 0 ${pxToRem(14)}`,
+      huge: `0 ${pxToRem(16)} 0 ${pxToRem(16)}`,
+      massive: `0 ${pxToRem(18)} 0 ${pxToRem(18)}`,
+    },
     startPaddingLeft: '0px',
     endPaddingRight: '0px',
-    height: pxToRem(20),
+    margin: `0 ${pxToRem(2)}`,
+    height: {
+      mini: `${pxToRem(20)}`,
+      tiny: `${pxToRem(24)}`,
+      small: `${pxToRem(28)}`,
+      medium: `${pxToRem(32)}`,
+      large: `${pxToRem(36)}`,
+      big: `${pxToRem(40)}`,
+      huge: `${pxToRem(44)}`,
+      massive: `${pxToRem(48)}`,
+    },
 
     // variables for 'icon' part
     iconColor: color,

--- a/packages/react/src/themes/teams/components/Label/labelVariables.ts
+++ b/packages/react/src/themes/teams/components/Label/labelVariables.ts
@@ -15,6 +15,7 @@ export interface LabelVariables {
   badgeHeight: string
   badgeLineheight: string
   badgeColor: string
+  badgeBackgroundColor: string
   badgeBorderRadius: string
   badgePadding: string
   badgePaddingWithoutAdditionalContent: string
@@ -47,6 +48,7 @@ export default (siteVars: SiteVariablesPrepared): LabelVariables => {
     badgeHeight: pxToRem(24),
     badgeLineheight: pxToRem(24),
     badgeColor: siteVars.colors.black,
+    badgeBackgroundColor: siteVars.gray10,
     badgeBorderRadius: pxToRem(2),
     badgePadding: `0 ${pxToRem(8)}`,
     badgePaddingWithoutAdditionalContent: `0 ${pxToRem(10)} 0 ${pxToRem(8)}`,


### PR DESCRIPTION
This PR adds an optional type 'badge' to Label component that looks and acts a little different from existing types.

- Has a new optional field 'additionalContent' 
- Looks are redlined for Teams theme

![badge-redlines](https://user-images.githubusercontent.com/604667/53882930-545ca680-4020-11e9-9be3-ad210b2a9a4f.png)
