### PR TITLE
WIP: chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# https://help.github.com/articles/about-codeowners/
-
-# Default owners
-* @davezuko @kuzhelov @layershifter @levithomason @miroslavstastny @mnajdova


### PR DESCRIPTION
Codeowners are a great idea, but it emails every owner on every PR to review it.  It also means every comment on every PR also sends an email.  This is insane and I can't see emails where I'm actually mentioned and need to pay attention.

I've already disabled required codeowner approval, but this did not stop the emails.  All owners are still pinged and emailed, even though they are not required.  PRs still require a review, just not from codeowners.  I think we can be big boys and girls and do the right thing without the enforced list of "approved" approvers.

