### PR TITLE
fix(dropdown): fix getA11ySelectionMessage usages across examples

### DIFF
--- a/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExample.shorthand.tsx
@@ -13,12 +13,6 @@ const inputItems = [
   'Selina Kyle',
 ]
 
-const DropdownExample = () => (
-  <Dropdown
-    items={inputItems}
-    placeholder="Select your hero"
-    getA11ySelectionMessage={{ onAdd: item => `${item} has been selected.` }}
-  />
-)
+const DropdownExample = () => <Dropdown items={inputItems} placeholder="Select your hero" />
 
 export default DropdownExample

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand.tsx
@@ -18,8 +18,14 @@ const DropdownExampleMultiple = () => (
     multiple
     items={inputItems}
     placeholder="Select your heroes"
+    getA11ySelectionMessage={getA11ySelectionMessage}
     noResultsMessage="We couldn't find any matches."
   />
 )
+
+const getA11ySelectionMessage = {
+  onAdd: item => `${item} has been selected.`,
+  onRemove: item => `${item} has been removed.`,
+}
 
 export default DropdownExampleMultiple

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleSearch.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleSearch.shorthand.tsx
@@ -14,14 +14,12 @@ const inputItems = [
 ]
 
 const DropdownExampleSearch = () => (
-  <>
-    <Dropdown
-      search
-      items={inputItems}
-      placeholder="Start typing a name"
-      noResultsMessage="We couldn't find any matches."
-    />
-  </>
+  <Dropdown
+    search
+    items={inputItems}
+    placeholder="Start typing a name"
+    noResultsMessage="We couldn't find any matches."
+  />
 )
 
 export default DropdownExampleSearch

--- a/docs/src/examples/components/Dropdown/Types/DropdownExampleSearchMultiple.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Types/DropdownExampleSearchMultiple.shorthand.tsx
@@ -19,8 +19,14 @@ const DropdownExampleSearchMultiple = () => (
     multiple
     items={inputItems}
     placeholder="Start typing a name"
+    getA11ySelectionMessage={getA11ySelectionMessage}
     noResultsMessage="We couldn't find any matches."
   />
 )
+
+const getA11ySelectionMessage = {
+  onAdd: item => `${item} has been selected.`,
+  onRemove: item => `${item} has been removed.`,
+}
 
 export default DropdownExampleSearchMultiple


### PR DESCRIPTION
## fix(dropdown): fix getA11ySelectionMessage usages across examples

This PR restores the initial usages of `getA11ySelectionMessage` method. This method should be used only for `Dropdown` components that have the `multiple` prop