### PR TITLE
fix(external example layout): color styles

### DIFF
--- a/docs/src/components/ExternalExampleLayout.tsx
+++ b/docs/src/components/ExternalExampleLayout.tsx
@@ -54,26 +54,36 @@ class ExternalExampleLayout extends React.Component<
 
     return (
       <Provider key={this.state.renderId} theme={{ rtl: isRtlEnabled }}>
-        <div dir={isRtlEnabled ? 'rtl' : undefined}>
-          <SourceRender
-            babelConfig={babelConfig}
-            source={exampleSource.js}
-            renderHtml={false}
-            resolver={importResolver}
-          >
-            <SourceRender.Consumer>
-              {({ element, error }) => (
-                <>
-                  {element}
-                  {/* This block allows to see issues with examples as visual regressions. */}
-                  {error && (
-                    <div style={{ fontSize: '5rem', color: 'red' }}>{error.toString()}</div>
+        <Provider.Consumer
+          render={({ siteVariables }) => (
+            <div
+              dir={isRtlEnabled ? 'rtl' : undefined}
+              style={{
+                color: siteVariables.bodyColor,
+                backgroundColor: siteVariables.bodyBackground,
+              }}
+            >
+              <SourceRender
+                babelConfig={babelConfig}
+                source={exampleSource.js}
+                renderHtml={false}
+                resolver={importResolver}
+              >
+                <SourceRender.Consumer>
+                  {({ element, error }) => (
+                    <>
+                      {element}
+                      {/* This block allows to see issues with examples as visual regressions. */}
+                      {error && (
+                        <div style={{ fontSize: '5rem', color: 'red' }}>{error.toString()}</div>
+                      )}
+                    </>
                   )}
-                </>
-              )}
-            </SourceRender.Consumer>
-          </SourceRender>
-        </div>
+                </SourceRender.Consumer>
+              </SourceRender>
+            </div>
+          )}
+        />
       </Provider>
     )
   }


### PR DESCRIPTION
## fix(external example layout): color styles

We need to add `color` and `backgroundColor` styles to our `ExternalExampleLayout` component in order to:
- render correct styles of components (`color` and `backgroundColor`) for:
  - the visual tests for other themes introduced in #1043
  - the maximized examples
- align it to the `ComponentExample` view (see: https://github.com/stardust-ui/react/blob/469e8e5a3089054b0efb26f19e0343d7bc00c419/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx#L603)

These issues are already addressed in #852 so this PR should be seen as a TEMPORARY FIX that will be reverted after #852 is merged