### PR TITLE
fix(unit tests): fix warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: yarn prettier
       - run:
           name: Unit Tests
-          command: yarn test --maxWorkers=4
+          command: yarn test --maxWorkers=2
       - run:
           name: Report coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: yarn prettier
       - run:
           name: Unit Tests
-          command: yarn test --strict --maxWorkers=4
+          command: yarn test --maxWorkers=4
       - run:
           name: Report coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/build/gulp/tasks/test-unit.ts
+++ b/build/gulp/tasks/test-unit.ts
@@ -9,12 +9,10 @@ import sh from '../sh'
 const jest = ({ watch = false } = {}) => cb => {
   process.env.NODE_ENV = 'test'
 
-  const jestConfigFileName = `jest.config.${argv.strict ? 'strict' : 'common'}.js`
-
   // in watch mode jest never exits
   // let the gulp task complete to prevent blocking subsequent tasks
   const command = [
-    `jest --config ./build/jest/${jestConfigFileName} --coverage`,
+    `jest --config ./jest.config.js --coverage`,
     watch && '--watchAll',
     argv.runInBand && '--runInBand',
     argv.maxWorkers && `--maxWorkers=${argv.maxWorkers}`,

--- a/build/jest/jest.config.common.js
+++ b/build/jest/jest.config.common.js
@@ -21,6 +21,9 @@ module.exports = {
   globals: {
     'ts-jest': {
       tsConfig: `<rootDir>/build/tsconfig.test.json`,
+      diagnostics: {
+        ignoreCodes: 151001,
+      },
     },
   },
 }

--- a/build/jest/jest.config.common.js
+++ b/build/jest/jest.config.common.js
@@ -1,12 +1,16 @@
 const { jest: lernaAliases } = require('lerna-alias')
 
+const setupTestFrameworkScriptFile = process.env.CI
+  ? `${__dirname}/setup.strict.ts`
+  : `${__dirname}/setup.common.ts`
+
 module.exports = {
   rootDir: `${__dirname}/../../`,
   coverageDirectory: './coverage/',
   coverageReporters: ['json', 'lcov'],
   testRegex: '/test/.*-test\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
-  setupTestFrameworkScriptFile: `${__dirname}/setup.common.ts`,
+  setupTestFrameworkScriptFile,
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },

--- a/build/jest/jest.config.common.js
+++ b/build/jest/jest.config.common.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsConfig: `./build/tsconfig.test.json`,
+      tsConfig: `<rootDir>/build/tsconfig.test.json`,
     },
   },
 }

--- a/build/jest/jest.config.strict.js
+++ b/build/jest/jest.config.strict.js
@@ -1,5 +1,0 @@
-const commonConfig = require('./jest.config.common')
-
-module.exports = Object.assign({}, commonConfig, {
-  setupTestFrameworkScriptFile: `${__dirname}/setup.strict.ts`,
-})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,10 @@
-const commonConfig = require('./build/jest/jest.config.common')
+const { rollup: lernaAlises } = require('lerna-alias')
 
-module.exports = commonConfig
+// packages/react/src -> packages/react,
+// as lernaAliases append 'src' by default
+const stardustPackages = lernaAlises({ sourceDirectory: false })
+const projects = Object.keys(stardustPackages).map(packageName => stardustPackages[packageName])
+
+module.exports = {
+  projects,
+}

--- a/packages/react-component-event-listener/jest.config.js
+++ b/packages/react-component-event-listener/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/jest/jest.config.common')

--- a/packages/react-component-event-listener/jest.config.js
+++ b/packages/react-component-event-listener/jest.config.js
@@ -1,1 +1,4 @@
-module.exports = require('../../build/jest/jest.config.common')
+module.exports = {
+  ...require('../../build/jest/jest.config.common'),
+  name: 'react-component-event-listener',
+}

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/jest/jest.config.common')

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,1 +1,4 @@
-module.exports = require('../../build/jest/jest.config.common')
+module.exports = {
+  ...require('../../build/jest/jest.config.common'),
+  name: 'react',
+}

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/numberList.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/numberList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { teamsIconClassNames } from '../teamsIconClassNames'
-import { TeamsSvgIconSpec } from 'src/themes/teams/components/Icon/svg/types'
+import { TeamsSvgIconSpec } from '../../svg/types'
 
 export default {
   icon: ({ classes, rtl }) => {

--- a/packages/react/src/themes/teams/components/Icon/svg/types.ts
+++ b/packages/react/src/themes/teams/components/Icon/svg/types.ts
@@ -2,7 +2,7 @@ import { SvgIconSpec, ComponentSlotStyleFunction } from '../../../../types'
 import { ObjectOf } from '../../../../../types'
 import { IconProps } from '../../../../../components/Icon/Icon'
 
-type SvgIconSpecWithStyles = {
+export type SvgIconSpecWithStyles = {
   icon: SvgIconSpec
   styles: ObjectOf<ComponentSlotStyleFunction<IconProps, any>>
 }

--- a/packages/react/test/__mocks__/popper.js.ts
+++ b/packages/react/test/__mocks__/popper.js.ts
@@ -1,0 +1,13 @@
+import * as PopperJs from 'popper.js'
+
+// Popper.js does not work with JSDOM: https://github.com/FezVrasta/popper.js/issues/478
+export default class Popper {
+  static placements = (PopperJs as any).placements
+
+  constructor() {
+    return {
+      destroy: () => {},
+      scheduleUpdate: () => {},
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1058:
- esInterop warnings
- popper warnings
- it is now possible to run tests from WebStorm