### PR TITLE
feat(Nesting): add NestingAuto component

### DIFF
--- a/packages/react-component-nesting-registry/jest.config.js
+++ b/packages/react-component-nesting-registry/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require('../../build/jest/jest.config.common'),
+  name: 'react-component-nesting-registry',
+}

--- a/packages/react-component-nesting-registry/package.json
+++ b/packages/react-component-nesting-registry/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@stardust-ui/react-component-event-listener",
-  "description": "React components for binding events on the global scope.",
+  "name": "@stardust-ui/react-component-nesting-registry",
+  "description": "Registers a DOM nodes within a context.",
   "version": "0.23.1",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
   "bugs": "https://github.com/stardust-ui/react/issues",
@@ -10,7 +10,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/stardust-ui/react/tree/master/packages/react-component-event-listener",
+  "homepage": "https://github.com/stardust-ui/react/tree/master/packages/react-component-nesting-registry",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -24,7 +24,7 @@
   },
   "repository": "stardust-ui/react.git",
   "scripts": {
-    "build": "cross-env TS_NODE_PROJECT=../../tsconfig.json gulp bundle:package:no-umd --package react-component-event-listener"
+    "build": "cross-env TS_NODE_PROJECT=../../tsconfig.json gulp bundle:package:no-umd --package react-component-nesting-registry"
   },
   "sideEffects": false,
   "types": "dist/es/index.d.ts"

--- a/packages/react-component-nesting-registry/src/NestingAuto.tsx
+++ b/packages/react-component-nesting-registry/src/NestingAuto.tsx
@@ -1,0 +1,25 @@
+import * as PropTypes from 'prop-types'
+import * as React from 'react'
+
+import NestingChild from './NestingChild'
+import NestingContext from './NestingContext'
+import NestingRoot from './NestingRoot'
+import { NestingProps } from './types'
+
+const NestingAuto: React.FC<NestingProps> = props => (
+  <NestingContext.Consumer>
+    {contextValue => {
+      const hasContext = !!contextValue
+      const Component = hasContext ? NestingChild : NestingRoot
+
+      return React.createElement(Component, props)
+    }}
+  </NestingContext.Consumer>
+)
+
+NestingAuto.displayName = 'NestingAuto'
+NestingAuto.propTypes = {
+  children: PropTypes.func.isRequired,
+}
+
+export default NestingAuto

--- a/packages/react-component-nesting-registry/src/NestingChild.tsx
+++ b/packages/react-component-nesting-registry/src/NestingChild.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+
+import NestingContext from './NestingContext'
+import { NestingContextValue, NestingProps, NodeRef } from './types'
+
+type NestingChildInnerProps = NestingContextValue & NestingProps
+
+class NestingChildInner<T extends Node> extends React.Component<NestingChildInnerProps> {
+  childRef = React.createRef<T>()
+
+  componentDidMount() {
+    this.props.register(this.childRef)
+  }
+
+  componentWillUnmount() {
+    this.props.unregister(this.childRef)
+  }
+
+  getRefs = (): NodeRef[] => this.props.getContextRefs(this.childRef)
+
+  render() {
+    return this.props.children(this.getRefs, this.childRef)
+  }
+}
+
+const NestingChild: React.FunctionComponent<NestingProps> = ({ children }) => (
+  <NestingContext.Consumer>
+    {(contextValue: NestingContextValue) => (
+      <NestingChildInner {...contextValue}>{children}</NestingChildInner>
+    )}
+  </NestingContext.Consumer>
+)
+
+export default NestingChild

--- a/packages/react-component-nesting-registry/src/NestingContext.ts
+++ b/packages/react-component-nesting-registry/src/NestingContext.ts
@@ -1,0 +1,6 @@
+import * as React from 'react'
+import { NestingContextValue } from './types'
+
+const NestingContext = React.createContext<NestingContextValue | null>(null)
+
+export default NestingContext

--- a/packages/react-component-nesting-registry/src/NestingRoot.tsx
+++ b/packages/react-component-nesting-registry/src/NestingRoot.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+
+import RefStack from './lib/RefStack'
+import NestingContext from './NestingContext'
+import { NestingProps, NodeRef } from './types'
+
+class NestingRoot<T extends Node> extends React.Component<NestingProps> {
+  registry = new RefStack()
+  parentRef = React.createRef<T>()
+
+  componentDidMount() {
+    this.registry.register(this.parentRef)
+  }
+
+  componentWillUnmount() {
+    this.registry.unregister(this.parentRef)
+  }
+
+  getRefs = (): NodeRef[] => this.registry.getContextRefs(this.parentRef)
+
+  render() {
+    return (
+      <NestingContext.Provider value={this.registry}>
+        {this.props.children(this.getRefs, this.parentRef)}
+      </NestingContext.Provider>
+    )
+  }
+}
+
+export default NestingRoot

--- a/packages/react-component-nesting-registry/src/hooks/types.ts
+++ b/packages/react-component-nesting-registry/src/hooks/types.ts
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { GetRefs, NestedContextProps, NestingContextValue } from '../types'
+
+export type UseNestingHookResult<T> = {
+  NestedComponent: React.Provider<NestingContextValue> | React.ReactFragment
+  nestedProps: NestedContextProps | null
+
+  getRefs: GetRefs
+  isRoot: boolean
+  ref: React.RefObject<T>
+}

--- a/packages/react-component-nesting-registry/src/hooks/useNestingAuto.ts
+++ b/packages/react-component-nesting-registry/src/hooks/useNestingAuto.ts
@@ -1,0 +1,14 @@
+import * as React from 'react'
+
+import NestingContext from '../NestingContext'
+import useNestingChild from './useNestingChild'
+import useNestingRoot from './useNestingRoot'
+import { UseNestingHookResult } from './types'
+
+const useNestingAuto = <T extends Node>(): UseNestingHookResult<T> => {
+  const context = React.useContext(NestingContext)
+
+  return context ? useNestingChild<T>() : useNestingRoot<T>()
+}
+
+export default useNestingAuto

--- a/packages/react-component-nesting-registry/src/hooks/useNestingChild.ts
+++ b/packages/react-component-nesting-registry/src/hooks/useNestingChild.ts
@@ -1,0 +1,30 @@
+import * as React from 'react'
+
+import NestingContext from '../NestingContext'
+import { NestingContextValue } from '../types'
+import { UseNestingHookResult } from './types'
+
+const useNestingChild = <T extends Node>(): UseNestingHookResult<T> => {
+  const nestingContext = React.useContext(NestingContext) as NestingContextValue
+  const childRef = React.useRef(null)
+
+  const getRefs = React.useCallback(() => {
+    return nestingContext.getContextRefs(childRef)
+  }, [])
+
+  React.useEffect(() => {
+    nestingContext.register(childRef)
+    return () => nestingContext.unregister(childRef)
+  }, [])
+
+  return {
+    NestedComponent: React.Fragment,
+    nestedProps: null,
+
+    getRefs,
+    isRoot: false,
+    ref: childRef,
+  }
+}
+
+export default useNestingChild

--- a/packages/react-component-nesting-registry/src/hooks/useNestingRoot.ts
+++ b/packages/react-component-nesting-registry/src/hooks/useNestingRoot.ts
@@ -1,0 +1,44 @@
+import * as React from 'react'
+
+import NestingContext from '../NestingContext'
+import { NestedContextProps } from '../types'
+import RefStack from '../lib/RefStack'
+import { UseNestingHookResult } from './types'
+
+const registrySet = new RefStack()
+
+const useNestingRoot = <T extends Node>(): UseNestingHookResult<T> => {
+  const [registry] = React.useState(registrySet)
+  const parentRef = React.useRef<T>(null)
+
+  const nestedProps: NestedContextProps = React.useMemo(
+    () => ({
+      value: {
+        getContextRefs: registry.getContextRefs,
+        register: registry.register,
+        unregister: registry.unregister,
+      },
+    }),
+    [],
+  )
+  const getRefs = React.useCallback(() => {
+    return registry.getContextRefs(parentRef)
+  }, [])
+
+  React.useEffect(() => {
+    registry.register(parentRef)
+
+    return () => registry.unregister(parentRef)
+  }, [])
+
+  return {
+    NestedComponent: NestingContext.Provider,
+    nestedProps,
+
+    getRefs,
+    isRoot: true,
+    ref: parentRef,
+  }
+}
+
+export default useNestingRoot

--- a/packages/react-component-nesting-registry/src/index.ts
+++ b/packages/react-component-nesting-registry/src/index.ts
@@ -1,0 +1,2 @@
+export { default as Unstable_NestingAuto } from './NestingAuto'
+export { GetRefs, NodeRef } from './types'

--- a/packages/react-component-nesting-registry/src/lib/RefStack.ts
+++ b/packages/react-component-nesting-registry/src/lib/RefStack.ts
@@ -1,0 +1,20 @@
+import { NodeRef } from '../types'
+
+export default class RefStack {
+  private set = new Set<NodeRef>()
+
+  public getContextRefs = (ref: NodeRef): NodeRef[] => {
+    const nodes = Array.from(this.set)
+    const refId = nodes.indexOf(ref)
+
+    return nodes.slice(refId)
+  }
+
+  public register = (ref: NodeRef): void => {
+    this.set.add(ref)
+  }
+
+  public unregister = (ref: NodeRef): void => {
+    this.set.delete(ref)
+  }
+}

--- a/packages/react-component-nesting-registry/src/types.ts
+++ b/packages/react-component-nesting-registry/src/types.ts
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+export type GetContextRefs = (needleRef: NodeRef) => NodeRef[]
+export type GetRefs = () => NodeRef[]
+export type NodeRef<T extends Node = Node> = React.RefObject<T>
+
+export type NestingContextValue = {
+  getContextRefs: GetContextRefs
+  register: (ref: NodeRef) => void
+  unregister: (ref: NodeRef) => void
+}
+
+export interface NestedContextProps {
+  value: NestingContextValue
+}
+
+export interface NestingProps {
+  children: (getRefs: GetRefs, ref: NodeRef) => React.ReactElement<any>
+}

--- a/packages/react-component-nesting-registry/test/NestingAuto-test.tsx
+++ b/packages/react-component-nesting-registry/test/NestingAuto-test.tsx
@@ -1,0 +1,46 @@
+import {
+  NodeRef,
+  Unstable_NestingAuto as NestingAuto,
+} from '@stardust-ui/react-component-nesting-registry'
+import { mount } from 'enzyme'
+import * as React from 'react'
+
+describe('NestingAuto', () => {
+  describe('children', () => {
+    it('renders components based on present context', () => {
+      const wrapper = mount(
+        <NestingAuto>{() => <NestingAuto>{() => <div />}</NestingAuto>}</NestingAuto>,
+      )
+
+      expect(wrapper.childAt(0).is('NestingRoot')).toBe(true)
+      // <NestingAuto /> => <NestingRoot /> => <NestingAuto /> => <NestingChild />
+      expect(
+        wrapper
+          .childAt(0)
+          .childAt(0)
+          .childAt(0)
+          .is('NestingChild'),
+      ).toBe(true)
+    })
+
+    it('is a render function', () => {
+      const children = jest
+        .fn()
+        .mockImplementation((_, ref: NodeRef<HTMLDivElement>) => <div ref={ref} />)
+      mount(<NestingAuto>{children}</NestingAuto>)
+      const getRefs = children.mock.calls[0][0]
+
+      expect(children).toBeCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ current: expect.objectContaining({ tagName: 'DIV' }) }),
+      )
+      expect(getRefs()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            current: expect.objectContaining({ tagName: 'DIV' }),
+          }),
+        ]),
+      )
+    })
+  })
+})

--- a/packages/react-component-nesting-registry/tsconfig.json
+++ b/packages/react-component-nesting-registry/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../build/tsconfig.common",
+  "compilerOptions": {
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
Extracted from #949.

### Introduce `@stardust-ui/react-component-nesting-registry`

API is not fully ready, that's why the package exports only `Unstable_NestingAuto`.

#### `Unstable_NestingAuto`

Provides way to get array of refs for children, actually all API is concentrated within `getRefs()` function and ref object.

```jsx
<Unstable_NestingAuto>
  {(getRefs(), ref) => <div onClick={() => console.log(getRefs()} ref={ref}  />}
</Unstable_NestingAuto>
```

- `getRefs()` will return an array with ref to the current component and all children refs.
- `ref` should be assigned to a correct element, in the case of `Popup` it's a content part

#### Hooks story

`/hooks` folder contains implementation based on React Hooks, it's stored there before we will decide to  require React 16.8. Not exported.