### PR TITLE
feat(prototypes): banner alerts with different intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `shrink` prop behavior for `Flex.Item` @kuzhelov ([#1086](https://github.com/stardust-ui/react/pull/1086))
 - Disable `devMode` for Fela by default @layershifter ([#1090](https://github.com/stardust-ui/react/pull/1090))
 - Fix accessibility types for aria attributes @layershifter ([#1087](https://github.com/stardust-ui/react/pull/1087))
+- Fix `action` prop size issue for `Alert` @Bugaa92 ([#1083](https://github.com/stardust-ui/react/pull/1083))
 
 ### Features
 - Add `Alert` component @Bugaa92 ([#1063](https://github.com/stardust-ui/react/pull/1063))

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -375,6 +375,13 @@ class Sidebar extends React.Component<any, any> {
         styles: menuItemStyles,
       },
       {
+        key: 'alerts',
+        content: 'Alerts',
+        as: NavLink,
+        to: '/prototype-alerts',
+        styles: menuItemStyles,
+      },
+      {
         key: 'asyncshorthand',
         content: 'Async Shorthand',
         as: NavLink,

--- a/docs/src/prototypes/alerts/AnimatedBannerAlert.tsx
+++ b/docs/src/prototypes/alerts/AnimatedBannerAlert.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react'
+import { Alert, Animation, SiteVariablesInput, AlertProps } from '@stardust-ui/react'
+
+interface BannerAlertProps extends AlertProps {
+  oof?: boolean
+  critical?: boolean
+  urgent?: boolean
+}
+
+/**
+ * Customized Alert that can express different intents through boolean props:
+ * oof, urgent, critical
+ */
+const BannerAlert: React.FunctionComponent<BannerAlertProps> = props => {
+  const { oof, critical, urgent, ...rest } = props
+  return (
+    <Alert
+      variables={(siteVars: SiteVariablesInput) => {
+        const appWhite = siteVars.colors.grey[50]
+
+        if (oof) {
+          return {
+            color: siteVars.orchid,
+            backgroundColor: '#F9F5F8',
+            borderColor: '#DCADC7',
+          }
+        }
+
+        if (urgent) {
+          return {
+            color: appWhite,
+            backgroundColor: siteVars.red,
+            borderColor: siteVars.red,
+          }
+        }
+
+        if (critical) {
+          return {
+            color: appWhite,
+            backgroundColor: siteVars.gray03,
+            borderColor: siteVars.gray02,
+          }
+        }
+
+        return {}
+      }}
+      {...rest}
+    />
+  )
+}
+
+interface AnimatedBannerAlertProps extends BannerAlertProps {
+  closable?: boolean
+}
+
+interface AnimatedBannerAlertState {
+  open: boolean
+}
+
+/**
+ * Needs to have 'slideDown' animation defined in parent Provider
+ */
+class AnimatedBannerAlert extends React.Component<
+  AnimatedBannerAlertProps,
+  AnimatedBannerAlertState
+> {
+  private readonly initialState: AnimatedBannerAlertState = { open: true }
+
+  state = this.initialState
+
+  componentDidUpdate(prevProps: AnimatedBannerAlertProps) {
+    const p = prevProps
+    const { info, danger, oof, critical, urgent } = this.props
+
+    if (
+      p.info !== info ||
+      p.danger !== danger ||
+      p.oof !== oof ||
+      p.critical !== critical ||
+      p.urgent !== urgent
+    ) {
+      this.setState(this.initialState)
+    }
+  }
+
+  handleClick = () => this.setState({ open: false })
+
+  render() {
+    const { open } = this.state
+    const { closable, ...rest } = this.props
+
+    return closable ? (
+      <Animation name={open ? '' : 'slideDown'}>
+        <BannerAlert {...rest} action={{ icon: 'close', onClick: this.handleClick }} />
+      </Animation>
+    ) : (
+      <BannerAlert {...rest} />
+    )
+  }
+}
+
+export default AnimatedBannerAlert

--- a/docs/src/prototypes/alerts/AnimatedBannerAlert.tsx
+++ b/docs/src/prototypes/alerts/AnimatedBannerAlert.tsx
@@ -56,18 +56,16 @@ interface AnimatedBannerAlertProps extends BannerAlertProps {
 /**
  * Needs to have 'slideDown' animation defined in parent Provider
  */
-class AnimatedBannerAlert extends React.Component<AnimatedBannerAlertProps, { open: boolean }> {
-  render() {
-    const { open, ...rest } = this.props
+const AnimatedBannerAlert: React.FunctionComponent<AnimatedBannerAlertProps> = props => {
+  const { open, ...rest } = props
 
-    if (open === undefined) return <BannerAlert {...rest} />
+  if (open === undefined) return <BannerAlert {...rest} />
 
-    return (
-      <Animation name={open ? '' : 'slideDown'}>
-        <BannerAlert {...rest} />
-      </Animation>
-    )
-  }
+  return (
+    <Animation name={open ? '' : 'slideDown'}>
+      <BannerAlert {...rest} />
+    </Animation>
+  )
 }
 
 export default AnimatedBannerAlert

--- a/docs/src/prototypes/alerts/AnimatedBannerAlert.tsx
+++ b/docs/src/prototypes/alerts/AnimatedBannerAlert.tsx
@@ -50,51 +50,22 @@ const BannerAlert: React.FunctionComponent<BannerAlertProps> = props => {
 }
 
 interface AnimatedBannerAlertProps extends BannerAlertProps {
-  closable?: boolean
-}
-
-interface AnimatedBannerAlertState {
-  open: boolean
+  open?: boolean
 }
 
 /**
  * Needs to have 'slideDown' animation defined in parent Provider
  */
-class AnimatedBannerAlert extends React.Component<
-  AnimatedBannerAlertProps,
-  AnimatedBannerAlertState
-> {
-  private readonly initialState: AnimatedBannerAlertState = { open: true }
-
-  state = this.initialState
-
-  componentDidUpdate(prevProps: AnimatedBannerAlertProps) {
-    const p = prevProps
-    const { info, danger, oof, critical, urgent } = this.props
-
-    if (
-      p.info !== info ||
-      p.danger !== danger ||
-      p.oof !== oof ||
-      p.critical !== critical ||
-      p.urgent !== urgent
-    ) {
-      this.setState(this.initialState)
-    }
-  }
-
-  handleClick = () => this.setState({ open: false })
-
+class AnimatedBannerAlert extends React.Component<AnimatedBannerAlertProps, { open: boolean }> {
   render() {
-    const { open } = this.state
-    const { closable, ...rest } = this.props
+    const { open, ...rest } = this.props
 
-    return closable ? (
+    if (open === undefined) return <BannerAlert {...rest} />
+
+    return (
       <Animation name={open ? '' : 'slideDown'}>
-        <BannerAlert {...rest} action={{ icon: 'close', onClick: this.handleClick }} />
+        <BannerAlert {...rest} />
       </Animation>
-    ) : (
-      <BannerAlert {...rest} />
     )
   }
 }

--- a/docs/src/prototypes/alerts/BannerAlerts.tsx
+++ b/docs/src/prototypes/alerts/BannerAlerts.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react'
+import * as _ from 'lodash'
+import {
+  Flex,
+  Provider,
+  RadioGroup,
+  ThemeAnimation,
+  RadioGroupItemProps,
+  Header,
+  Button,
+} from '@stardust-ui/react'
+
+import AnimatedBannerAlert from './AnimatedBannerAlert'
+import ComposeMessage from '../chatPane/composeMessage'
+
+type BannerName = 'info' | 'oof' | 'danger' | 'urgent' | 'critical'
+
+const bannerNames: BannerName[] = ['info', 'oof', 'danger', 'urgent', 'critical']
+
+const bannerRadioItems: RadioGroupItemProps[] = bannerNames.map(bannerName => ({
+  key: bannerName,
+  value: bannerName,
+  label: `${_.startCase(bannerName)} banner`,
+}))
+
+const isAlertClosable = (bannerName: BannerName) =>
+  bannerName !== 'critical' && bannerName !== 'urgent'
+
+interface BannerAlertsState {
+  selectedBanner: RadioGroupItemProps
+}
+
+class BannerAlerts extends React.Component<{}, BannerAlertsState> {
+  private readonly initialState: BannerAlertsState = { selectedBanner: bannerRadioItems[0] }
+
+  state = this.initialState
+
+  render() {
+    const { selectedBanner } = this.state
+    const bannerName = selectedBanner.value as BannerName
+
+    return (
+      <Provider theme={{ animations: { slideDown } }}>
+        <Flex
+          column
+          style={{
+            width: '50%',
+            backgroundColor: '#f3f2f1',
+            padding: '10px 50px',
+            position: 'relative',
+          }}
+        >
+          <Flex space="between" vAlign="center">
+            <Header as="h3">Select a banner:</Header>
+            <Button content="Reset Banner" onClick={() => this.setState(this.initialState)} />
+          </Flex>
+          <RadioGroup
+            checkedValue={selectedBanner.value}
+            items={bannerRadioItems}
+            checkedValueChanged={(e, props) => this.setState({ selectedBanner: props })}
+          />
+          <AnimatedBannerAlert
+            {...{
+              [bannerName]: true,
+              attached: true,
+              closable: isAlertClosable(bannerName),
+              content: selectedBanner.label,
+            }}
+          />
+          <ComposeMessage attached="bottom" />
+        </Flex>
+      </Provider>
+    )
+  }
+}
+
+export default BannerAlerts
+
+const slideDown: ThemeAnimation = {
+  keyframe: {
+    from: { transform: 'translateY(0)' },
+    to: { transform: 'translateY(100%)', display: 'none' },
+  },
+  duration: '.3s',
+  iterationCount: '1',
+  timingFunction: 'linear',
+  fillMode: 'forwards',
+}

--- a/docs/src/prototypes/alerts/BannerAlerts.tsx
+++ b/docs/src/prototypes/alerts/BannerAlerts.tsx
@@ -33,7 +33,7 @@ const slideDown: ThemeAnimation = {
     from: { transform: 'translateY(0)' },
     to: { transform: 'translateY(100%)', display: 'none' },
   },
-  duration: '.3s',
+  duration: '.2s',
   iterationCount: '1',
   timingFunction: 'linear',
   fillMode: 'forwards',

--- a/docs/src/prototypes/alerts/BannerAlerts.tsx
+++ b/docs/src/prototypes/alerts/BannerAlerts.tsx
@@ -40,7 +40,7 @@ const slideDown: ThemeAnimation = {
 }
 
 interface BannerAlertsState {
-  selectedBannerName: string
+  selectedBannerName: BannerName
   open: boolean
 }
 
@@ -84,8 +84,8 @@ class BannerAlerts extends React.Component<{}, BannerAlertsState> {
               key: selectedBannerName,
               attached: true,
               [selectedBannerName]: true,
-              content: getBannerContent(selectedBannerName as BannerName),
-              ...(isAlertClosable(selectedBannerName as BannerName) && {
+              content: getBannerContent(selectedBannerName),
+              ...(isAlertClosable(selectedBannerName) && {
                 open,
                 action: { icon: 'close', onClick: this.closeSelectedBanner },
               }),

--- a/docs/src/prototypes/alerts/BannerAlerts.tsx
+++ b/docs/src/prototypes/alerts/BannerAlerts.tsx
@@ -91,7 +91,7 @@ class BannerAlerts extends React.Component<{}, BannerAlertsState> {
               }),
             }}
           />
-          <ComposeMessage attached="bottom" />
+          <ComposeMessage attached />
         </Flex>
       </Provider>
     )

--- a/docs/src/prototypes/alerts/index.tsx
+++ b/docs/src/prototypes/alerts/index.tsx
@@ -5,8 +5,8 @@ import BannerAlerts from './BannerAlerts'
 export default () => (
   <PrototypeSection title="Alerts">
     <ComponentPrototype
-      title="Types of alerts"
-      description="The Alert component can be customized to show other intents than the ones defined (using variables)."
+      title="Banner Alerts"
+      description="The Alert component can be customized (using variables) to show other intents in addition to the predefined ones."
     >
       <BannerAlerts />
     </ComponentPrototype>

--- a/docs/src/prototypes/alerts/index.tsx
+++ b/docs/src/prototypes/alerts/index.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+import { PrototypeSection, ComponentPrototype } from '../Prototypes'
+import BannerAlerts from './BannerAlerts'
+
+export default () => (
+  <PrototypeSection title="Alerts">
+    <ComponentPrototype
+      title="Types of alerts"
+      description="The Alert component can be customized to show other intents than the ones defined (using variables)."
+    >
+      <BannerAlerts />
+    </ComponentPrototype>
+  </PrototypeSection>
+)

--- a/docs/src/prototypes/chatPane/chatPaneContent.tsx
+++ b/docs/src/prototypes/chatPane/chatPaneContent.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import Scrollbars from 'react-custom-scrollbars'
 import { Chat, Divider, Avatar } from '@stardust-ui/react'
-import { ChatData, ChatItemTypes, generateChatProps } from './services'
-import style from './chatProtoStyle'
 
-export interface ChatPaneContainerProps {
-  chat: ChatData
-}
+import { Props } from 'src/types'
+import { ChatData, ChatItemTypes, generateChatProps } from './services'
+import chatProtoStyle from './chatProtoStyle'
+
+export type ChatPaneContainerProps = Props<{ chat: ChatData }>
 
 class ChatPaneContainer extends React.PureComponent<ChatPaneContainerProps> {
   public render() {
@@ -22,7 +22,7 @@ class ChatPaneContainer extends React.PureComponent<ChatPaneContainerProps> {
           >
             <div
               id="chat-pane-reader-text"
-              style={style.screenReaderContainerStyles}
+              style={chatProtoStyle.screenReaderContainerStyles}
               role="heading"
               aria-level={2}
             >
@@ -55,7 +55,11 @@ class ChatPaneContainer extends React.PureComponent<ChatPaneContainerProps> {
               content: (
                 <>
                   {itemType === ChatItemTypes.message && (
-                    <div style={style.screenReaderContainerStyles} role="heading" aria-level={4}>
+                    <div
+                      style={chatProtoStyle.screenReaderContainerStyles}
+                      role="heading"
+                      aria-level={4}
+                    >
                       {this.getMessagePreviewForScreenReader(props)}
                     </div>
                   )}

--- a/docs/src/prototypes/chatPane/chatPaneHeader.tsx
+++ b/docs/src/prototypes/chatPane/chatPaneHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { Avatar, Button, Divider, Icon, Layout, Segment, Text } from '@stardust-ui/react'
-import style from './chatProtoStyle'
+import { Avatar, Button, Divider, Icon, Segment, Text, Flex } from '@stardust-ui/react'
+import chatProtoStyle from './chatProtoStyle'
 
 import { ChatData } from './services'
 
@@ -11,12 +11,11 @@ export interface ChatPaneHeaderProps {
 class ChatPaneHeader extends React.PureComponent<ChatPaneHeaderProps> {
   public render() {
     return (
-      <Layout
-        vertical
-        start={this.renderBanner()}
-        main={this.renderMainArea()}
-        end={<Divider size={2} styles={{ padding: '0 32px' }} />}
-      />
+      <Flex column>
+        <Flex.Item>{this.renderBanner()}</Flex.Item>
+        {this.renderMainArea()}
+        <Divider size={2} styles={{ padding: '0 32px' }} />
+      </Flex>
     )
   }
 
@@ -26,7 +25,8 @@ class ChatPaneHeader extends React.PureComponent<ChatPaneHeaderProps> {
         content={
           <Icon
             name="team-create"
-            variables={siteVars => ({ color: siteVars.colors.white, margin: 'auto 8px' })}
+            styles={{ margin: 'auto 8px' }}
+            variables={siteVars => ({ color: siteVars.colors.white })}
           />
         }
         styles={({ variables: v }) => ({
@@ -45,32 +45,32 @@ class ChatPaneHeader extends React.PureComponent<ChatPaneHeaderProps> {
     const { chat } = this.props
 
     return (
-      <Layout
+      <Flex
         role="region"
         aria-labelledby="heading"
-        start={<Avatar name={chat.title} />}
-        main={
-          <div
-            id="heading"
-            role="heading"
-            aria-level={2}
-            aria-labelledby="chat-header-reader-text chat-header-title"
-          >
-            <div id="chat-header-reader-text" style={style.screenReaderContainerStyles}>
-              Chat header
-            </div>
-            <Text
-              id="chat-header-title"
-              size="large"
-              content={chat.title}
-              styles={{ marginLeft: '12px', fontWeight: 600 }}
-            />
+        hAlign="stretch"
+        vAlign="center"
+        styles={{ height: '64px', padding: '0 32px' }}
+      >
+        <Avatar name={chat.title} />
+        <div
+          id="heading"
+          role="heading"
+          aria-level={2}
+          aria-labelledby="chat-header-reader-text chat-header-title"
+        >
+          <div id="chat-header-reader-text" style={chatProtoStyle.screenReaderContainerStyles}>
+            Chat header
           </div>
-        }
-        end={this.renderHeaderButtons()}
-        alignItems="center"
-        styles={{ padding: '16px 32px' }}
-      />
+          <Text
+            id="chat-header-title"
+            size="large"
+            content={chat.title}
+            styles={{ marginLeft: '12px', fontWeight: 600 }}
+          />
+        </div>
+        <Flex.Item push>{this.renderHeaderButtons()}</Flex.Item>
+      </Flex>
     )
   }
 

--- a/docs/src/prototypes/chatPane/chatPaneLayout.tsx
+++ b/docs/src/prototypes/chatPane/chatPaneLayout.tsx
@@ -1,30 +1,26 @@
 import * as React from 'react'
-import { Layout } from '@stardust-ui/react'
+import { Flex } from '@stardust-ui/react'
+import { Props } from 'src/types'
 import { ChatData } from './services'
 
 import ChatPaneHeader from './chatPaneHeader'
 import ChatPaneContainer from './chatPaneContent'
 import ComposeMessage from './composeMessage'
 
-export interface ChatPaneLayoutProps {
-  chat: ChatData
-}
-
-const ChatPaneLayout: React.SFC<ChatPaneLayoutProps> = ({ chat }: ChatPaneLayoutProps) => (
-  <Layout
-    vertical
-    start={<ChatPaneHeader chat={chat} />}
-    main={<ChatPaneContainer chat={chat} />}
-    end={<ComposeMessage />}
+const ChatPaneLayout: React.FunctionComponent<Props<{ chat: ChatData }>> = ({ chat }) => (
+  <Flex
+    fill
+    column
     styles={{
       backgroundColor: '#f3f2f1',
-      left: 0,
-      marginLeft: '250px',
       width: '50%',
-      height: '100%',
-      position: 'fixed',
+      position: 'absolute',
     }}
-  />
+  >
+    <ChatPaneHeader chat={chat} />
+    <ChatPaneContainer chat={chat} />
+    <ComposeMessage style={{ padding: '16px 32px' }} />
+  </Flex>
 )
 
 export default ChatPaneLayout

--- a/docs/src/prototypes/chatPane/chatProtoStyle.ts
+++ b/docs/src/prototypes/chatPane/chatProtoStyle.ts
@@ -1,13 +1,16 @@
-const style: any = {}
+import * as React from 'react'
 
-style.screenReaderContainerStyles = {
-  border: '0px',
-  clip: 'rect(0px, 0px, 0px, 0px)',
-  height: '1px',
-  margin: '-1px',
-  overflow: 'hidden',
-  padding: '0px',
-  width: '1px',
-  position: 'absolute',
+const chatProtoStyle: Record<string, React.CSSProperties> = {
+  screenReaderContainerStyles: {
+    border: '0px',
+    clip: 'rect(0px, 0px, 0px, 0px)',
+    height: '1px',
+    margin: '-1px',
+    overflow: 'hidden',
+    padding: '0px',
+    width: '1px',
+    position: 'absolute',
+  },
 }
-export default style
+
+export default chatProtoStyle

--- a/docs/src/prototypes/chatPane/composeMessage.tsx
+++ b/docs/src/prototypes/chatPane/composeMessage.tsx
@@ -52,19 +52,25 @@ const ComposeMessage: React.FunctionComponent<ComposeMessageProps> = props => (
 )
 
 const getInputWrapperStyles = ({ attached }: ComposeMessageProps): React.CSSProperties => {
-  const borderTop = '3px'
-  const borderBottom = '2px'
+  const borderTopRadius = '3px'
+  const borderBottomRadius = '2px'
+  const borderWidth = '1px'
 
   return {
     boxSizing: 'border-box',
-    border: '1px solid',
-    borderRadius: `${borderTop} ${borderTop} ${borderBottom} ${borderBottom}`,
+    borderStyle: 'solid',
+    borderWidth,
+    borderRadius: `${borderTopRadius} ${borderTopRadius} ${borderBottomRadius} ${borderBottomRadius}`,
 
     ...((attached === 'top' || attached === true) && {
-      borderRadius: `${borderTop} ${borderTop} 0 0`,
+      borderRadius: `0 0 ${borderBottomRadius} ${borderBottomRadius}`,
+      marginTop: `-${borderWidth}`,
     }),
 
-    ...(attached === 'bottom' && { borderRadius: `0 0 ${borderBottom} ${borderBottom}` }),
+    ...(attached === 'bottom' && {
+      borderRadius: `${borderTopRadius} ${borderTopRadius} 0 0`,
+      marginBottom: `-${borderWidth}`,
+    }),
   }
 }
 

--- a/docs/src/prototypes/chatPane/composeMessage.tsx
+++ b/docs/src/prototypes/chatPane/composeMessage.tsx
@@ -1,89 +1,97 @@
 import * as React from 'react'
 import {
-  Layout,
+  Flex,
   Input,
+  Menu,
+  Provider,
   toolbarButtonBehavior,
   toolbarBehavior,
-  Menu,
   MenuItemProps,
 } from '@stardust-ui/react'
-import style from './chatProtoStyle'
 
-class ComposeMessage extends React.Component {
-  public render() {
-    return (
-      <Layout
-        role="region"
-        aria-labelledby="chat-compose-reader-text"
-        vertical
-        start={
-          <div>
-            <div
-              role="heading"
-              aria-level={2}
-              id="chat-compose-reader-text"
-              style={style.screenReaderContainerStyles}
-            >
-              Compose
-            </div>
-            {this.renderInput()}
+import { Props } from 'src/types'
+import chatProtoStyle from './chatProtoStyle'
+
+type ComposeMessageProps = Props<{
+  attached?: 'top' | 'bottom' | boolean
+  style?: React.CSSProperties
+}>
+
+const ComposeMessage: React.FunctionComponent<ComposeMessageProps> = props => (
+  <Provider.Consumer
+    render={({ siteVariables: siteVars }) => (
+      <Flex column role="region" aria-labelledby="chat-compose-reader-text" style={props.style}>
+        <div>
+          <div
+            role="heading"
+            aria-level={2}
+            id="chat-compose-reader-text"
+            style={chatProtoStyle.screenReaderContainerStyles}
+          >
+            Compose
           </div>
-        }
-        main={this.renderToolbar()}
-        styles={{ padding: '16px 32px' }}
-      />
-    )
+          <Input
+            fluid
+            placeholder="Type a message"
+            input={{ styles: { height: '3.1429rem' /* 44px */ } }}
+            styles={{ ...getInputWrapperStyles(props), borderColor: siteVars.colors.grey[200] }}
+            variables={{ backgroundColor: siteVars.colors.white }}
+          />
+        </div>
+        <Menu
+          defaultActiveIndex={0}
+          items={getMenuItems()}
+          iconOnly
+          accessibility={toolbarBehavior}
+          aria-label="Compose Editor"
+          styles={{ marginTop: '10px' }}
+        />
+      </Flex>
+    )}
+  />
+)
+
+const getInputWrapperStyles = ({ attached }: ComposeMessageProps): React.CSSProperties => {
+  const borderTop = '3px'
+  const borderBottom = '2px'
+
+  return {
+    boxSizing: 'border-box',
+    border: '1px solid',
+    borderRadius: `${borderTop} ${borderTop} ${borderBottom} ${borderBottom}`,
+
+    ...((attached === 'top' || attached === true) && {
+      borderRadius: `${borderTop} ${borderTop} 0 0`,
+    }),
+
+    ...(attached === 'bottom' && { borderRadius: `0 0 ${borderBottom} ${borderBottom}` }),
   }
+}
 
-  private renderInput(): React.ReactNode {
-    return (
-      <Input
-        fluid
-        placeholder="Type a message"
-        input={{ styles: { height: '3.1429rem' /* 44px */ } }}
-        variables={siteVars => ({ backgroundColor: siteVars.colors.white })}
-      />
-    )
-  }
+const getMenuItems = (): MenuItemProps[] => {
+  const items: MenuItemProps[] = [
+    'compose',
+    'attach',
+    'smile',
+    'picture',
+    'smile outline',
+    'calendar alternate',
+    'ellipsis horizontal',
+    'send',
+  ].map((name, index) => ({
+    key: `${index}-${name}`,
+    icon: {
+      name,
+      xSpacing: 'both',
+      variables: siteVars => ({ color: siteVars.gray02 }),
+    },
+    accessibility: toolbarButtonBehavior,
+    'aria-label': `${name} tool`,
+  }))
 
-  private renderToolbar(): React.ReactNode {
-    const items: MenuItemProps[] = [
-      'compose',
-      'attach',
-      'smile',
-      'picture',
-      'smile outline',
-      'calendar alternate',
-      'ellipsis horizontal',
-      'send',
-    ].map((icon, index) => this.getMenuItem(icon, index))
+  items.splice(-1, 0, { key: 'separator', styles: { flex: 1 } })
 
-    items.splice(-1, 0, { key: 'separator', styles: { flex: 1 } })
-
-    return (
-      <Menu
-        defaultActiveIndex={0}
-        items={items}
-        iconOnly
-        accessibility={toolbarBehavior}
-        aria-label="Compose Editor"
-        styles={{ marginTop: '10px' }}
-      />
-    )
-  }
-
-  private getMenuItem(name: string, index: number): MenuItemProps {
-    return {
-      key: `${index}-${name}`,
-      icon: {
-        name,
-        xSpacing: 'both',
-        variables: siteVars => ({ color: siteVars.gray02 }),
-      },
-      accessibility: toolbarButtonBehavior,
-      'aria-label': `${name} tool`,
-    }
-  }
+  return items
 }
 
 export default ComposeMessage

--- a/docs/src/prototypes/chatPane/index.tsx
+++ b/docs/src/prototypes/chatPane/index.tsx
@@ -1,32 +1,8 @@
 import * as React from 'react'
-import { Provider, Divider } from '@stardust-ui/react'
 
 import ChatPaneLayout from './chatPaneLayout'
 import { getChatMock } from './services'
-import { pxToRem } from 'src/lib'
 
 const chatMock = getChatMock({ msgCount: 40, userCount: 6 })
-const dividerSelector = `& .${Divider.className}`
 
-export default () => (
-  <Provider
-    theme={{
-      componentStyles: {
-        Layout: {
-          start: { display: 'block' },
-          end: { display: 'block' },
-        },
-        ChatItem: {
-          root: {
-            [dividerSelector]: {
-              marginLeft: `-${pxToRem(40)}`,
-              marginRight: `-${pxToRem(40)}`,
-            },
-          },
-        },
-      },
-    }}
-  >
-    <ChatPaneLayout chat={chatMock.chat} />
-  </Provider>
-)
+export default () => <ChatPaneLayout chat={chatMock.chat} />

--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -150,6 +150,7 @@ function createMessageContentWithAttachments(content: string, messageId: string)
       <div style={{ marginTop: '20px', display: 'flex' }}>
         {_.map(['MeetingNotes.pptx', 'Document.docx'], (fileName, index) => (
           <Attachment
+            key={`attachment-${index}`}
             icon="file word outline"
             aria-label={`File attachment ${fileName}. Press tab for more options Press Enter to open the file`}
             header={fileName}

--- a/docs/src/routes.tsx
+++ b/docs/src/routes.tsx
@@ -85,6 +85,12 @@ const Router = () => (
             path="/menu-button"
             component={require('./prototypes/MenuButton/index').default}
           />,
+          <DocsLayout
+            exact
+            key="/prototype-alerts"
+            path="/prototype-alerts"
+            component={require('./prototypes/alerts/index').default}
+          />,
         ]}
         <DocsLayout exact path="/accessibility" component={Accessibility} />
         <DocsLayout exact path="/theming" component={Theming} />

--- a/packages/react/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertStyles.ts
@@ -62,7 +62,8 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
     position: 'relative',
     width: '100%',
     boxSizing: 'border-box',
-    border: v.border,
+    borderStyle: v.borderStyle,
+    borderWidth: v.borderWidth,
     borderRadius: v.borderRadius,
     minHeight: v.minHeight,
     padding: v.padding,
@@ -72,12 +73,10 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
 
     ...((p.attached === 'top' || p.attached === true) && {
       borderRadius: `${v.borderRadius} ${v.borderRadius} 0 0`,
-      marginBottom: '-1px',
     }),
 
     ...(p.attached === 'bottom' && {
       borderRadius: `0 0 ${v.borderRadius} ${v.borderRadius}`,
-      marginTop: '-1px',
     }),
   }),
 
@@ -88,6 +87,7 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
   action: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
     height: v.actionSize,
     minWidth: v.actionSize,
+    margin: `-${v.borderWidth} 0`,
     color: v.actionColor || 'currentColor',
     ...(p.info && { color: siteVariables.gray02 }),
     ':focus': { outline: 0 },

--- a/packages/react/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertStyles.ts
@@ -72,9 +72,13 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
 
     ...((p.attached === 'top' || p.attached === true) && {
       borderRadius: `${v.borderRadius} ${v.borderRadius} 0 0`,
+      marginBottom: '-1px',
     }),
 
-    ...(p.attached === 'bottom' && { borderRadius: `0 0 ${v.borderRadius} ${v.borderRadius}` }),
+    ...(p.attached === 'bottom' && {
+      borderRadius: `0 0 ${v.borderRadius} ${v.borderRadius}`,
+      marginTop: '-1px',
+    }),
   }),
 
   content: (): ICSSInJSStyle => ({
@@ -86,6 +90,7 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
     minWidth: v.actionSize,
     color: v.actionColor || 'currentColor',
     ...(p.info && { color: siteVariables.gray02 }),
+    ':focus': { outline: 0 },
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Alert/alertVariables.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertVariables.ts
@@ -4,7 +4,8 @@ import { pxToRem } from '../../../../lib'
 import { SiteVariablesPrepared } from 'src/themes/types'
 
 export interface AlertVariables {
-  border: string
+  borderStyle: string
+  borderWidth: string
   borderRadius: string
   backgroundColor: string
   borderColor: string
@@ -18,20 +19,20 @@ export interface AlertVariables {
 }
 
 export default (siteVars: SiteVariablesPrepared): AlertVariables => {
-  const alertHeight = 28
-  const borderSize = 1
+  const minHeight = pxToRem(28)
 
   return {
-    border: `${pxToRem(borderSize)} solid`,
+    borderStyle: 'solid',
+    borderWidth: '1px',
     borderRadius: pxToRem(3),
     backgroundColor: siteVars.colors.grey[50], // $app-white
     borderColor: siteVars.gray06,
     color: siteVars.gray02,
     fontWeight: siteVars.fontWeightSemibold,
-    minHeight: pxToRem(alertHeight),
+    minHeight,
     padding: `0 0 0 ${pxToRem(16)}`,
 
-    actionSize: pxToRem(alertHeight - 2 * borderSize),
+    actionSize: minHeight,
     actionColor: undefined,
   }
 }


### PR DESCRIPTION
## feat(prototypes): banner alerts with different intents

### Description:

This PR contains:
- in `docs/src/prototypes/alerts/AnimatedBannerAlert.tsx`:  `BannerAlert`, a customized prototype using `Alert` component that can express different intents through boolean props
- in `docs/src/prototypes/alerts/BannerAlerts.tsx`: a view showing an `AnimatedBannerAlert` custom component on top of a compose box

### Demo:
![banner-alerts](https://user-images.githubusercontent.com/5442794/54822207-c847b180-4ca4-11e9-974d-c8d36e73ec50.gif)
