### PR TITLE
fix(renderer): disable `devMode` for Fela by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add aria posinset and setsize, hide menu indicator from narration @jurokapsiar ([#1066](https://github.com/stardust-ui/react/pull/1066))
 - Fix applying accessibility key handlers @layershifter ([#1072](https://github.com/stardust-ui/react/pull/1072))
 - Fix `shrink` prop behavior for `Flex.Item` @kuzhelov ([#1086](https://github.com/stardust-ui/react/pull/1086))
+- Disable `devMode` for Fela by default @layershifter ([#1090](https://github.com/stardust-ui/react/pull/1090))
 
 ### Features
 - Add `Alert` component @Bugaa92 ([#1063](https://github.com/stardust-ui/react/pull/1063))

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -13,7 +13,7 @@ try {
   felaDevMode = !!window.localStorage.felaDevMode
 } catch {}
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   if (felaDevMode) {
     console.warn(
       [

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -18,8 +18,8 @@ if (process.env.NODE_ENV !== 'production') {
     console.warn(
       [
         '@stardust-ui/react:',
-        'You are running Fela in development mode and this can cause performance degrades.' +
-          'To disable it please paste `window.localStorage.felaDevMode = false` to your browsers console and reload current page.',
+        'You are running Fela in development mode and this can cause performance degrades.',
+        'To disable it please paste `window.localStorage.felaDevMode = false` to your browsers console and reload current page.',
       ].join(' '),
     )
   } else {

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -7,6 +7,33 @@ import rtl from 'fela-plugin-rtl'
 
 import { Renderer } from '../themes/types'
 
+let felaDevMode = false
+
+try {
+  felaDevMode = !!window.localStorage.felaDevMode
+} catch {}
+
+if (process.env.NODE_ENV !== 'production') {
+  if (felaDevMode) {
+    console.warn(
+      [
+        '@stardust-ui/react:',
+        'You are running Fela in development mode and this can cause performance degrades.' +
+          'To disable it please paste `window.localStorage.felaDevMode = false` to your browsers console and reload current page.',
+      ].join(' '),
+    )
+  } else {
+    console.warn(
+      [
+        '@stardust-ui/react:',
+        'You are running Fela in production mode.',
+        'This limits your ability to edit styles in browsers development tools.',
+        'To enable development mode please paste `window.localStorage.felaDevMode = true` to your browsers console and reload the page.',
+      ].join(' '),
+    )
+  }
+}
+
 // Blacklist contains a list of classNames that are used by FontAwesome
 // https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use
 const blacklistedClassNames = ['fa', 'fas', 'far', 'fal', 'fab']
@@ -15,7 +42,7 @@ const filterClassName = (className: string): boolean =>
   className.indexOf('ad') === -1 && blacklistedClassNames.indexOf(className) === -1
 
 const createRendererConfig = (options: any = {}) => ({
-  devMode: process.env.NODE_ENV !== 'production',
+  devMode: felaDevMode,
   plugins: [
     // is necessary to prevent accidental style typos
     // from breaking ALL the styles on the page


### PR DESCRIPTION
Fixes #1088.

---

When Fela's renderer is in `devMode` (default before), the `insertRule()` function uses a de-optimized code path (`insertRuleInDevMode.js`) for writing style updates to the style nodes.  It replaces the text of the style node in the head, opposed to using the browser's optimized `CSSStyleSheet.insertRule()` method.

It's friendly for development tools because you can edit styles, but it provides wrong development experience for consumers because components are much slower.

---

## `devMode=true`

![image](https://user-images.githubusercontent.com/14183168/54767745-836d3d80-4c06-11e9-8f6c-f5d024d503ed.png)

## `devMode=false`

![image](https://user-images.githubusercontent.com/14183168/54767761-8cf6a580-4c06-11e9-9d8f-d6673b5cbc08.png)
