### PR TITLE
feat(Input): add `placeholderColor` variable for Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - Add `Alert` component @Bugaa92 ([#1063](https://github.com/stardust-ui/react/pull/1063))
+- Add `placeholderColor` variable for `Input` component in Teams theme @layershifter ([#1092](https://github.com/stardust-ui/react/pull/1092))
 
 <!--------------------------------[ v0.23.1 ]------------------------------- -->
 ## [v0.23.1](https://github.com/stardust-ui/react/tree/v0.23.1) (2019-03-13)

--- a/packages/react/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/react/src/themes/teams/components/Input/inputStyles.ts
@@ -26,7 +26,7 @@ const inputStyles: ComponentSlotStylesInput<InputProps, InputVariables> = {
     ...(p.fluid && { width: '100%' }),
     ...(p.inline && { float: 'left' }),
     '::placeholder': {
-      color: v.fontColor,
+      color: v.placeholderColor,
     },
     ':focus': {
       borderBottomColor: v.inputFocusBorderBottomColor,

--- a/packages/react/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/react/src/themes/teams/components/Input/inputVariables.ts
@@ -15,6 +15,7 @@ export interface InputVariables {
   inputPadding: string
   inputFocusBorderBottomColor: string
   inputFocusBorderRadius: string
+  placeholderColor: string
 }
 
 export default (siteVars): InputVariables => ({
@@ -35,4 +36,6 @@ export default (siteVars): InputVariables => ({
   inputPadding: `${pxToRem(7)} ${pxToRem(12)}`,
   inputFocusBorderBottomColor: siteVars.colors.primary[500],
   inputFocusBorderRadius: `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`,
+
+  placeholderColor: siteVars.gray02,
 })


### PR DESCRIPTION
Fixes #1036.

![image](https://user-images.githubusercontent.com/14183168/54829158-7744b700-4cbe-11e9-8dc6-4411621f6b72.png)

```jsx
<Input placeholder="Search..." variables={{ placeholderColor: 'red' }} />
```
