### PR TITLE
feat(components): align slotClassNames property for all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `timestamp` to be shown if the `reactionGroup` prop is applied on the `ChatMessage` component in Teams theme @mnajdova ([#1100](https://github.com/stardust-ui/react/pull/1100))
 - Fix typings for `FlexProps` and `FlexItemProps` @miroslavstastny ([#1089](https://github.com/stardust-ui/react/pull/1089))
 - Fix `selectableFocusHoverColor` value in `List` for Teams theme @layershifter ([#1113](https://github.com/stardust-ui/react/pull/1113))
+- Align `slotClassNames` property for all components @Bugaa92 ([#1093](https://github.com/stardust-ui/react/pull/1093))
 
 ### Features
 - Add `attached` prop on the `ChatMessage` component, which is automatically set by the `ChatItem` component @mnajdova ([#1100](https://github.com/stardust-ui/react/pull/1100))

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -170,14 +170,14 @@ class Accordion extends AutoControlledComponent<ReactProps<AccordionProps>, any>
 
       children.push(
         AccordionTitle.create(title, {
-          defaultProps: { active, index },
+          defaultProps: { className: Accordion.slotClassNames.title, active, index },
           overrideProps: this.handleTitleOverrides,
           render: renderPanelTitle,
         }),
       )
       children.push(
         AccordionContent.create(content, {
-          defaultProps: { active },
+          defaultProps: { className: Accordion.slotClassNames.content, active },
           render: renderPanelContent,
         }),
       )

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -23,6 +23,11 @@ import {
   ShorthandRenderFunction,
 } from '../../types'
 
+export interface AccordionSlotClassNames {
+  content: string
+  title: string
+}
+
 export interface AccordionProps extends UIComponentProps, ChildrenComponentProps {
   /** Index of the currently active panel. */
   activeIndex?: number[] | number
@@ -80,6 +85,11 @@ class Accordion extends AutoControlledComponent<ReactProps<AccordionProps>, any>
   static displayName = 'Accordion'
 
   static className = 'ui-accordion'
+
+  static slotClassNames: AccordionSlotClassNames = {
+    content: AccordionContent.className,
+    title: AccordionTitle.className,
+  }
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Chat/Chat.tsx
+++ b/packages/react/src/components/Chat/Chat.tsx
@@ -17,6 +17,10 @@ import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibil
 import { chatBehavior } from '../../lib/accessibility'
 import { UIComponentProps, ChildrenComponentProps } from '../../lib/commonPropInterfaces'
 
+export interface ChatSlotClassNames {
+  item: string
+}
+
 export interface ChatProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -32,9 +36,13 @@ export interface ChatProps extends UIComponentProps, ChildrenComponentProps {
  * A Chat displays messages between users.
  */
 class Chat extends UIComponent<ReactProps<ChatProps>, any> {
+  static displayName = 'Chat'
+
   static className = 'ui-chat'
 
-  static displayName = 'Chat'
+  static slotClassNames: ChatSlotClassNames = {
+    item: ChatItem.className,
+  }
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Chat/Chat.tsx
+++ b/packages/react/src/components/Chat/Chat.tsx
@@ -74,7 +74,11 @@ class Chat extends UIComponent<ReactProps<ChatProps>, any> {
         {...unhandledProps}
         {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
       >
-        {childrenExist(children) ? children : _.map(items, item => ChatItem.create(item))}
+        {childrenExist(children)
+          ? children
+          : _.map(items, item =>
+              ChatItem.create(item, { defaultProps: { className: Chat.slotClassNames.item } }),
+            )}
       </ElementType>
     )
   }

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -493,6 +493,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
     return DropdownSearchInput.create(searchInput || {}, {
       defaultProps: {
+        className: Dropdown.slotClassNames.searchInput,
         placeholder: noPlaceholder ? '' : placeholder,
         inline,
         variables,
@@ -575,6 +576,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     const items = _.map(filteredItems, (item, index) =>
       DropdownItem.create(item, {
         defaultProps: {
+          className: Dropdown.slotClassNames.item,
           active: highlightedIndex === index,
           variables,
           ...(typeof item === 'object' &&
@@ -616,6 +618,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     return value.map((item, index) =>
       DropdownSelectedItem.create(item, {
         defaultProps: {
+          className: Dropdown.slotClassNames.selectedItem,
           active: this.isSelectedItemActive(index),
           variables,
           ...(typeof item === 'object' &&

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -1105,10 +1105,10 @@ Dropdown.slotClassNames = {
   clearIndicator: `${Dropdown.className}__clear-indicator`,
   container: `${Dropdown.className}__container`,
   toggleIndicator: `${Dropdown.className}__toggle-indicator`,
-  item: DropdownItem.className,
+  item: `${Dropdown.className}__item`,
   itemsList: `${Dropdown.className}__items-list`,
-  searchInput: DropdownSearchInput.className,
-  selectedItem: DropdownSelectedItem.className,
+  searchInput: `${Dropdown.className}__searchinput`,
+  selectedItem: `${Dropdown.className}__selecteditem`,
   selectedItems: `${Dropdown.className}__selected-items`,
   triggerButton: `${Dropdown.className}__trigger-button`,
 }

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -46,7 +46,10 @@ export interface DropdownSlotClassNames {
   clearIndicator: string
   container: string
   toggleIndicator: string
+  item: string
   itemsList: string
+  searchInput: string
+  selectedItem: string
   selectedItems: string
   triggerButton: string
 }
@@ -1099,7 +1102,10 @@ Dropdown.slotClassNames = {
   clearIndicator: `${Dropdown.className}__clear-indicator`,
   container: `${Dropdown.className}__container`,
   toggleIndicator: `${Dropdown.className}__toggle-indicator`,
+  item: DropdownItem.className,
   itemsList: `${Dropdown.className}__items-list`,
+  searchInput: DropdownSearchInput.className,
+  selectedItem: DropdownSelectedItem.className,
   selectedItems: `${Dropdown.className}__selected-items`,
   triggerButton: `${Dropdown.className}__trigger-button`,
 }

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -16,6 +16,10 @@ import { defaultBehavior } from '../../lib/accessibility'
 import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
 import FormField from './FormField'
 
+export interface FormSlotClassNames {
+  field: string
+}
+
 export interface FormProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -48,6 +52,10 @@ class Form extends UIComponent<ReactProps<FormProps>, any> {
   public static displayName = 'Form'
 
   public static className = 'ui-form'
+
+  static slotClassNames: FormSlotClassNames = {
+    field: FormField.className,
+  }
 
   public static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -100,7 +100,9 @@ class Form extends UIComponent<ReactProps<FormProps>, any> {
 
   private renderFields = () => {
     const { fields } = this.props
-    return _.map(fields, field => FormField.create(field))
+    return _.map(fields, field =>
+      FormField.create(field, { defaultProps: { className: Form.slotClassNames.field } }),
+    )
   }
 }
 

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -95,6 +95,7 @@ class Header extends UIComponent<ReactProps<HeaderProps>, any> {
         {!hasChildren &&
           HeaderDescription.create(description, {
             defaultProps: {
+              className: Header.slotClassNames.description,
               variables: {
                 ...(v.descriptionColor && { color: v.descriptionColor }),
               },

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -18,6 +18,10 @@ import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 import { ReactProps, ShorthandValue } from '../../types'
 
+export interface HeaderSlotClassNames {
+  description: string
+}
+
 export interface HeaderProps
   extends UIComponentProps,
     ChildrenComponentProps,
@@ -47,11 +51,15 @@ export interface HeaderProps
  *    In addition to that, both will be displayed in the list of headings.
  */
 class Header extends UIComponent<ReactProps<HeaderProps>, any> {
-  static create: Function
+  static displayName = 'Header'
 
   static className = 'ui-header'
 
-  static displayName = 'Header'
+  static slotClassNames: HeaderSlotClassNames = {
+    description: HeaderDescription.className,
+  }
+
+  static create: Function
 
   static propTypes = {
     ...commonPropTypes.createCommon({ color: true }),

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -206,6 +206,7 @@ class List extends AutoControlledComponent<ReactProps<ListProps>, ListState> {
       }
 
       const itemProps = {
+        className: List.slotClassNames.item,
         ..._.pick(this.props, List.itemProps),
         ...maybeSelectableItemProps,
         index,

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -19,6 +19,10 @@ import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibil
 import { ContainerFocusHandler } from '../../lib/accessibility/FocusHandling/FocusContainer'
 import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
 
+export interface ListSlotClassNames {
+  item: string
+}
+
 export interface ListProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -67,6 +71,10 @@ class List extends AutoControlledComponent<ReactProps<ListProps>, ListState> {
   static displayName = 'List'
 
   static className = 'ui-list'
+
+  static slotClassNames: ListSlotClassNames = {
+    item: ListItem.className,
+  }
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -23,6 +23,11 @@ import MenuDivider from './MenuDivider'
 
 export type MenuShorthandKinds = 'divider' | 'item'
 
+export interface MenuSlotClassNames {
+  divider: string
+  item: string
+}
+
 export interface MenuProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -87,6 +92,11 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
   static displayName = 'Menu'
 
   static className = 'ui-menu'
+
+  static slotClassNames: MenuSlotClassNames = {
+    divider: MenuDivider.className,
+    item: MenuItem.className,
+  }
 
   static create: Function
 

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -173,6 +173,7 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
       if (kind === 'divider') {
         return MenuDivider.create(item, {
           defaultProps: {
+            className: Menu.slotClassNames.divider,
             primary,
             secondary,
             vertical,
@@ -187,6 +188,7 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
 
       return MenuItem.create(item, {
         defaultProps: {
+          className: Menu.slotClassNames.item,
           iconOnly,
           pills,
           pointing,

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -30,6 +30,7 @@ import Indicator from '../Indicator/Indicator'
 
 export interface MenuItemSlotClassNames {
   wrapper: string
+  menu: string
 }
 
 export interface MenuItemProps
@@ -136,9 +137,9 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
 
   static className = 'ui-menu__item'
 
-  static create: Function
-
   static slotClassNames: MenuItemSlotClassNames
+
+  static create: Function
 
   static propTypes = {
     ...commonPropTypes.createCommon(),
@@ -231,6 +232,7 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
             {Menu.create(menu, {
               defaultProps: {
                 accessibility: submenuBehavior,
+                className: MenuItem.slotClassNames.menu,
                 vertical: true,
                 primary,
                 secondary,
@@ -371,6 +373,7 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
 
 MenuItem.create = createShorthandFactory({ Component: MenuItem, mappedProp: 'content' })
 MenuItem.slotClassNames = {
+  menu: `${MenuItem.className}__menu`,
   wrapper: `${MenuItem.className}__wrapper`,
 }
 

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -30,7 +30,7 @@ import Indicator from '../Indicator/Indicator'
 
 export interface MenuItemSlotClassNames {
   wrapper: string
-  menu: string
+  submenu: string
 }
 
 export interface MenuItemProps
@@ -232,7 +232,7 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
             {Menu.create(menu, {
               defaultProps: {
                 accessibility: submenuBehavior,
-                className: MenuItem.slotClassNames.menu,
+                className: MenuItem.slotClassNames.submenu,
                 vertical: true,
                 primary,
                 secondary,
@@ -373,7 +373,7 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
 
 MenuItem.create = createShorthandFactory({ Component: MenuItem, mappedProp: 'content' })
 MenuItem.slotClassNames = {
-  menu: `${MenuItem.className}__menu`,
+  submenu: `${MenuItem.className}__submenu`,
   wrapper: `${MenuItem.className}__wrapper`,
 }
 

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -51,6 +51,10 @@ export type RestrictedClickEvents = 'click' | 'focus'
 export type RestrictedHoverEvents = 'hover' | 'focus'
 export type PopupEventsArray = RestrictedClickEvents[] | RestrictedHoverEvents[]
 
+export interface PopupSlotClassNames {
+  content: string
+}
+
 export interface PopupProps
   extends StyledComponentProps<PopupProps>,
     ChildrenComponentProps,
@@ -141,6 +145,10 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
   static displayName = 'Popup'
 
   static className = 'ui-popup'
+
+  static slotClassNames: PopupSlotClassNames = {
+    content: PopupContent.className,
+  }
 
   static Content = PopupContent
 

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -472,7 +472,10 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
       accessibility.focusTrap || accessibility.autoFocus ? {} : popupWrapperAttributes
 
     const popupContent = Popup.Content.create(content, {
-      defaultProps: popupContentAttributes,
+      defaultProps: {
+        className: Popup.slotClassNames.content,
+        ...popupContentAttributes,
+      },
       overrideProps: this.getContentProps,
     })
 

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -176,7 +176,7 @@ class RadioGroup extends AutoControlledComponent<ReactProps<RadioGroupProps>, an
 
     return _.map(items, item =>
       RadioGroupItem.create(item, {
-        defaultProps: { vertical },
+        defaultProps: { className: RadioGroup.slotClassNames.item, vertical },
         overrideProps: this.handleItemOverrides,
       }),
     )

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -19,6 +19,10 @@ import { radioGroupBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
 import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
 
+export interface RadioGroupSlotClassNames {
+  item: string
+}
+
 export interface RadioGroupProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -55,6 +59,10 @@ class RadioGroup extends AutoControlledComponent<ReactProps<RadioGroupProps>, an
   static displayName = 'RadioGroup'
 
   static className = 'ui-radiogroup'
+
+  static slotClassNames: RadioGroupSlotClassNames = {
+    item: RadioGroupItem.className,
+  }
 
   static create: Function
 

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -17,6 +17,10 @@ import { ShorthandValue, ShorthandRenderFunction, ReactProps } from '../../types
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 
+export interface TreeSlotClassNames {
+  item: string
+}
+
 export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
   /** Index of the currently active subtree. */
   activeIndex?: number[] | number
@@ -56,9 +60,13 @@ export interface TreeState {
 class Tree extends AutoControlledComponent<ReactProps<TreeProps>, TreeState> {
   static create: Function
 
+  static displayName = 'Tree'
+
   static className = 'ui-tree'
 
-  static displayName = 'Tree'
+  static slotClassNames: TreeSlotClassNames = {
+    item: TreeItem.className,
+  }
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -130,6 +130,7 @@ class Tree extends AutoControlledComponent<ReactProps<TreeProps>, TreeState> {
     return _.map(items, (item: ShorthandValue, index: number) =>
       TreeItem.create(item, {
         defaultProps: {
+          className: Tree.slotClassNames.item,
           index,
           exclusive,
           renderItemTitle,

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -23,6 +23,11 @@ import {
   ShorthandValue,
 } from '../../types'
 
+export interface TreeItemSlotClassNames {
+  title: string
+  tree: string
+}
+
 export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -65,9 +70,14 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
 class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
   static create: Function
 
+  static displayName = 'TreeItem'
+
   static className = 'ui-tree__item'
 
-  static displayName = 'TreeItem'
+  static slotClassNames: TreeItemSlotClassNames = {
+    title: TreeTitle.className,
+    tree: `${TreeItem.className}__tree`,
+  }
 
   static autoControlledProps = ['open']
 
@@ -116,6 +126,7 @@ class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
         {open &&
           Tree.create(items, {
             defaultProps: {
+              className: TreeItem.slotClassNames.tree,
               exclusive,
               renderItemTitle,
             },

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -117,6 +117,7 @@ class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
       <>
         {TreeTitle.create(title, {
           defaultProps: {
+            className: TreeItem.slotClassNames.title,
             open,
             hasSubtree,
           },

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -25,7 +25,7 @@ import {
 
 export interface TreeItemSlotClassNames {
   title: string
-  tree: string
+  subtree: string
 }
 
 export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps {
@@ -76,7 +76,7 @@ class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
 
   static slotClassNames: TreeItemSlotClassNames = {
     title: TreeTitle.className,
-    tree: `${TreeItem.className}__tree`,
+    subtree: `${TreeItem.className}__subtree`,
   }
 
   static autoControlledProps = ['open']
@@ -127,7 +127,7 @@ class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
         {open &&
           Tree.create(items, {
             defaultProps: {
-              className: TreeItem.slotClassNames.tree,
+              className: TreeItem.slotClassNames.subtree,
               exclusive,
               renderItemTitle,
             },


### PR DESCRIPTION
## feat(components): align slotClassNames property for all components

### Description

This PR:
- introduces ability to select submenus from `MenuItem` components: **`MenuItem.slotClassNames.menu`**
- aligns `slotClassNames` property on composed components in order to be able to target subcomponents directly;
**e.g.:** a `Menu` item can be targeted referencing:
  - it's `className` directly: `MenuItem.className` // even before this PR
  - the item as a slot of the parent component: **`Menu.slotClassNames.item`** // introduced in this PR
