### PR TITLE
fix(MenuItem): Item separator - replace ::before with box-shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix narration for `Menu` @miroslavstastny ([#1105](https://github.com/stardust-ui/react/pull/1105))
+
 <!--------------------------------[ v0.25.0 ]------------------------------- -->
 ## [v0.25.0](https://github.com/stardust-ui/react/tree/v0.25.0) (2019-03-26)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.24.0...v0.25.0)

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -76,30 +76,6 @@ const getFocusedStyles = ({
   }
 }
 
-const itemSeparator: ComponentSlotStyleFunction<MenuItemPropsAndState, MenuVariables> = ({
-  props,
-  variables: v,
-}): ICSSInJSStyle => {
-  const { iconOnly, pills, primary, underlined, vertical } = props
-
-  return (
-    !vertical &&
-    !pills &&
-    !underlined &&
-    !iconOnly && {
-      '::before': {
-        position: 'absolute',
-        content: '""',
-        top: 0,
-        right: 0,
-        width: pxToRem(1),
-        height: '100%',
-        ...(primary ? { background: v.primaryBorderColor } : { background: v.borderColor }),
-      },
-    }
-  )
-}
-
 const pointingBeak: ComponentSlotStyleFunction<MenuItemPropsAndState, MenuVariables> = ({
   props,
   variables: v,
@@ -162,6 +138,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
       isFromKeyboard,
       pills,
       pointing,
+      primary,
       secondary,
       underlined,
       vertical,
@@ -212,7 +189,13 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
           marginBottom: verticalPointingBottomMargin,
         }),
 
-      ...itemSeparator({ props, variables: v, theme, colors }),
+      // item separator
+      ...(!vertical &&
+        !pills &&
+        !underlined &&
+        !iconOnly && {
+          boxShadow: `-1px 0 0 0 ${primary ? v.primaryBorderColor : v.borderColor} inset`,
+        }),
 
       // active styles
       ...(active && {


### PR DESCRIPTION
Replaces `:before` with `box-shadow` to draw vertical line between menu items in Teams theme.
This is necessary to fix OSX/Chrome/VoiceOver screen reader navigation between menu items.
Fixes #982.