### PR TITLE
fix(docs): display name for function components

### DIFF
--- a/docs/src/views/Layout.tsx
+++ b/docs/src/views/Layout.tsx
@@ -77,7 +77,6 @@ export default () => (
           </OpaqueBackground>
         )
       }}
-      value={`<OpaqueBackground color="lightyellow">This is a bad approach to opaque background :(</OpaqueBackground>`}
     />
     <Header as="h4">Box's misuse: handle relative positioning cases</Header>
     <CodeSnippet
@@ -102,7 +101,6 @@ export default () => (
           </RelativePositioned>
         )
       }}
-      value={`<RelativePositioned left='30px'>This is a bad way to support relative-positioning :(</RelativePositioned>`}
     />
     <p>
       While it might seem that the intent is addressed with the approach taken, however, this is

--- a/docs/src/views/Layout.tsx
+++ b/docs/src/views/Layout.tsx
@@ -69,6 +69,7 @@ export default () => (
         const OpaqueBackground = ({ children, color }) => (
           <Segment styles={{ backgroundColor: color }} content={{ children }} />
         )
+        OpaqueBackground.dislayName = 'OpaqueBackground'
 
         return (
           <OpaqueBackground color="lightyellow">

--- a/docs/src/views/Layout.tsx
+++ b/docs/src/views/Layout.tsx
@@ -69,7 +69,7 @@ export default () => (
         const OpaqueBackground = ({ children, color }) => (
           <Segment styles={{ backgroundColor: color }} content={{ children }} />
         )
-        OpaqueBackground.dislayName = 'OpaqueBackground'
+        OpaqueBackground.displayName = 'OpaqueBackground'
 
         return (
           <OpaqueBackground color="lightyellow">


### PR DESCRIPTION
This fix is necessary to prevent crashes on rendering docs pages that contain code snippet with function components that have no display name. The crash is happening because of `No Display Name` used by `react-element-to-jsx-string` for function components in prod:

https://github.com/algolia/react-element-to-jsx-string/issues/11

Fix is provided to the Layout guide page.