### PR TITLE
feat(menu): pointing && vertical menu redlining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.25.0...v0.25.1)
 
 ### Fixes
+- Update vertical && pointing `Menu` styles @jaanus03 ([#1116](https://github.com/stardust-ui/react/pull/1116))
 - Fix narration for `Menu` @miroslavstastny ([#1105](https://github.com/stardust-ui/react/pull/1105))
 - Fix `timestamp` to be shown if the `reactionGroup` prop is applied on the `ChatMessage` component in Teams theme @mnajdova ([#1100](https://github.com/stardust-ui/react/pull/1100))
 - Fix typings for `FlexProps` and `FlexItemProps` @miroslavstastny ([#1089](https://github.com/stardust-ui/react/pull/1089))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Update vertical && pointing `Menu` styles @jaanus03 ([#1116](https://github.com/stardust-ui/react/pull/1116))
+
 <!--------------------------------[ v0.25.1 ]------------------------------- -->
 ## [v0.25.1](https://github.com/stardust-ui/react/tree/v0.25.1) (2019-03-29)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.25.0...v0.25.1)
 
 ### Fixes
-- Update vertical && pointing `Menu` styles @jaanus03 ([#1116](https://github.com/stardust-ui/react/pull/1116))
 - Fix narration for `Menu` @miroslavstastny ([#1105](https://github.com/stardust-ui/react/pull/1105))
 - Fix `timestamp` to be shown if the `reactionGroup` prop is applied on the `ChatMessage` component in Teams theme @mnajdova ([#1100](https://github.com/stardust-ui/react/pull/1100))
 - Fix typings for `FlexProps` and `FlexItemProps` @miroslavstastny ([#1089](https://github.com/stardust-ui/react/pull/1089))

--- a/packages/react/src/themes/teams-dark/components/Menu/menuVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Menu/menuVariables.ts
@@ -7,6 +7,8 @@ export default (siteVars: any): Partial<MenuVariables> => ({
   focusedBorder: `solid ${pxToRem(1)} ${siteVars.colors.white}`,
   focusedBackgroundColor: 'transparent',
 
+  primaryActiveBorderColor: siteVars.brand06,
+
   hoverBackgroundColor: siteVars.gray08,
 
   activeColor: siteVars.colors.white,

--- a/packages/react/src/themes/teams-dark/components/Menu/menuVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Menu/menuVariables.ts
@@ -7,7 +7,7 @@ export default (siteVars: any): Partial<MenuVariables> => ({
   focusedBorder: `solid ${pxToRem(1)} ${siteVars.colors.white}`,
   focusedBackgroundColor: 'transparent',
 
-  primaryActiveBorderColor: siteVars.brand06,
+  pointingIndicatorBackgroundColor: siteVars.brand06,
 
   hoverBackgroundColor: siteVars.gray08,
 

--- a/packages/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -6,7 +6,7 @@ type MenuItemPropsAndState = MenuItemProps & MenuItemState
 
 const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariables> = {
   wrapper: ({ props: p, variables: v }): ICSSInJSStyle => {
-    const { iconOnly, isFromKeyboard, vertical, active, underlined, primary } = p
+    const { iconOnly, isFromKeyboard, vertical, active, underlined, primary, pointing } = p
 
     return {
       ':hover': {
@@ -45,6 +45,13 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
           },
         }),
       }),
+
+      ...(pointing &&
+        vertical && {
+          '::before': {
+            display: 'none',
+          },
+        }),
     }
   },
 

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -193,19 +193,23 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
         ...getActionStyles({ props, variables: v, color: v.color }),
 
         ...(pointing &&
-          (vertical
-            ? !isFromKeyboard && {
-                '::before': {
-                  content: `''`,
-                  position: 'absolute',
-                  width: pxToRem(3),
-                  height: `calc(100% + ${pxToRem(4)})`,
-                  top: pxToRem(-2),
-                  backgroundColor: v.pointingIndicatorBackgroundColor,
-                  ...(pointing === 'end' ? { right: pxToRem(-2) } : { left: pxToRem(-2) }),
-                },
-              }
-            : pointingBeak({ props, variables: v, theme, colors }))),
+          vertical &&
+          !isFromKeyboard && {
+            '::before': {
+              content: `''`,
+              position: 'absolute',
+              width: pxToRem(3),
+              height: `calc(100% + ${pxToRem(4)})`,
+              top: pxToRem(-2),
+              backgroundColor: v.pointingIndicatorBackgroundColor,
+              ...(pointing === 'end' ? { right: pxToRem(-2) } : { left: pxToRem(-2) }),
+            },
+          }),
+
+        ...(pointing &&
+          !vertical && {
+            ...pointingBeak({ props, variables: v, theme, colors }),
+          }),
       }),
 
       ...(iconOnly && {

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -72,9 +72,6 @@ const getFocusedStyles = ({
           outline: v.focusedOutline,
           margin: pxToRem(1),
           background: v.focusedBackgroundColor,
-          ...(pointing && {
-            marginBottom: verticalPointingBottomMarginFocus,
-          }),
         }
       : {}),
   }
@@ -182,11 +179,6 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
         },
         boxShadow: 'none',
       }),
-
-      ...(pointing &&
-        vertical && {
-          marginBottom: verticalPointingBottomMargin,
-        }),
 
       // item separator
       ...(!vertical &&

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -183,9 +183,10 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
         boxShadow: 'none',
       }),
 
-      ...(pointing && {
-        marginBottom: verticalPointingBottomMargin,
-      }),
+      ...(pointing &&
+        vertical && {
+          marginBottom: verticalPointingBottomMargin,
+        }),
 
       // item separator
       ...(!vertical &&

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -9,7 +9,6 @@ type MenuItemPropsAndState = MenuItemProps & MenuItemState
 export const verticalPillsBottomMargin = pxToRem(5)
 export const horizontalPillsRightMargin = pxToRem(8)
 export const verticalPointingBottomMargin = pxToRem(12)
-export const verticalPointingBottomMarginFocus = pxToRem(13)
 
 const underlinedItem = (color: string): ICSSInJSStyle => ({
   paddingBottom: 0,

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -201,7 +201,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
                   width: pxToRem(3),
                   height: `calc(100% + ${pxToRem(4)})`,
                   top: pxToRem(-2),
-                  backgroundColor: v.primaryActiveBorderColor,
+                  backgroundColor: v.pointingIndicatorBackgroundColor,
                   ...(pointing === 'end' ? { right: pxToRem(-2) } : { left: pxToRem(-2) }),
                 },
               }

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -9,6 +9,7 @@ type MenuItemPropsAndState = MenuItemProps & MenuItemState
 export const verticalPillsBottomMargin = pxToRem(5)
 export const horizontalPillsRightMargin = pxToRem(8)
 export const verticalPointingBottomMargin = pxToRem(12)
+export const verticalPointingBottomMarginFocus = pxToRem(13)
 
 const underlinedItem = (color: string): ICSSInJSStyle => ({
   paddingBottom: 0,
@@ -65,12 +66,15 @@ const getFocusedStyles = ({
           background: v.hoverBackgroundColor,
         }),
 
-    ...(vertical && isFromKeyboard && !pointing && !primary
+    ...(vertical && isFromKeyboard && !primary
       ? {
           border: v.focusedBorder,
           outline: v.focusedOutline,
           margin: pxToRem(1),
           background: v.focusedBackgroundColor,
+          ...(pointing && {
+            marginBottom: verticalPointingBottomMarginFocus,
+          }),
         }
       : {}),
   }
@@ -179,15 +183,9 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
         boxShadow: 'none',
       }),
 
-      ...(pointing &&
-        vertical && {
-          borderTopLeftRadius: `${pxToRem(3)}`,
-          borderTopRightRadius: `${pxToRem(3)}`,
-          ...(pointing === 'end'
-            ? { borderRight: `${pxToRem(3)} solid transparent` }
-            : { borderLeft: `${pxToRem(3)} solid transparent` }),
-          marginBottom: verticalPointingBottomMargin,
-        }),
+      ...(pointing && {
+        marginBottom: verticalPointingBottomMargin,
+      }),
 
       // item separator
       ...(!vertical &&
@@ -203,9 +201,17 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
 
         ...(pointing &&
           (vertical
-            ? pointing === 'end'
-              ? { borderRight: `${pxToRem(3)} solid ${v.primaryActiveBorderColor}` }
-              : { borderLeft: `${pxToRem(3)} solid ${v.primaryActiveBorderColor}` }
+            ? !isFromKeyboard && {
+                '::before': {
+                  content: `''`,
+                  position: 'absolute',
+                  width: pxToRem(3),
+                  height: `calc(100% + ${pxToRem(4)})`,
+                  top: pxToRem(-2),
+                  backgroundColor: v.primaryActiveBorderColor,
+                  ...(pointing === 'end' ? { right: pxToRem(-2) } : { left: pxToRem(-2) }),
+                },
+              }
             : pointingBeak({ props, variables: v, theme, colors }))),
       }),
 

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -49,7 +49,7 @@ const getFocusedStyles = ({
   variables: MenuVariables
   color: string
 }): ICSSInJSStyle => {
-  const { primary, underlined, isFromKeyboard, active, vertical, pointing } = props
+  const { primary, underlined, isFromKeyboard, active, vertical } = props
   if (active && !underlined && !vertical) return {}
   return {
     ...(underlined && !isFromKeyboard

--- a/packages/react/src/themes/teams/components/Menu/menuVariables.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuVariables.ts
@@ -36,6 +36,8 @@ export interface MenuVariables {
   verticalDividerMargin: string
   verticalItemBorder: string
 
+  pointingIndicatorBackgroundColor: string
+
   underlinedBottomBorderWidth: string
 
   dividerHeight: string
@@ -78,6 +80,8 @@ export default (siteVars: any): MenuVariables => {
     verticalBoxShadow: siteVars.shadowLevel3,
     verticalDividerMargin: `${pxToRem(8)} 0`,
     verticalItemBorder: `solid ${pxToRem(2)} transparent`,
+
+    pointingIndicatorBackgroundColor: siteVars.colors.primary[500],
 
     underlinedBottomBorderWidth: pxToRem(2),
 


### PR DESCRIPTION
This PR is a minor update to vertical && pointing menu styles.
It removes bordered corners, straightens the "pointing" indicator and adds focus styles.

<img width="1049" alt="Screenshot 2019-03-27 at 16 16 51" src="https://user-images.githubusercontent.com/604667/55083371-1b0dd880-50ac-11e9-92c1-555e321119b2.png">
