### PR TITLE
fix(dropdown): fix tab selection and blur reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `selectableFocusHoverColor` value in `List` for Teams theme @layershifter ([#1113](https://github.com/stardust-ui/react/pull/1113))
 - Align `slotClassNames` property for all components @Bugaa92 ([#1093](https://github.com/stardust-ui/react/pull/1093))
 - Fix `selectedBackgroundColor`/`selectableFocusHoverColor` value in `List` for Teams Dark and Teams HC themes @layershifter ([#1117](https://github.com/stardust-ui/react/pull/1117))
+- Fix `Dropdown` multiple selection tab behavior and single search selection blur reset @silviuavram ([#1118](https://github.com/stardust-ui/react/pull/1118))
 
 ### Features
 - Add `attached` prop on the `ChatMessage` component, which is automatically set by the `ChatItem` component @mnajdova ([#1100](https://github.com/stardust-ui/react/pull/1100))

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -762,9 +762,10 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
         case keyboardKey.Tab:
           if (!_.isNil(highlightedIndex)) {
             selectItemAtIndex(highlightedIndex)
-          }
-          if (this.props.multiple && !this.props.tabInMultipleSelection) {
-            e.preventDefault()
+            // Keep focus here if condition applies.
+            if (this.props.multiple && !this.props.tabInMultipleSelection) {
+              e.preventDefault()
+            }
           }
           break
         case keyboardKey.ArrowLeft:
@@ -901,10 +902,11 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
         if (_.isNil(highlightedIndex)) {
           toggleMenu()
         } else {
+          // Keep focus here in this case.
+          if (this.props.multiple && !this.props.tabInMultipleSelection) {
+            e.preventDefault()
+          }
           selectItemAtIndex(highlightedIndex)
-        }
-        if (this.props.multiple && !this.props.tabInMultipleSelection) {
-          e.preventDefault()
         }
         return
       case keyboardKey.Escape:

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -128,6 +128,9 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   /** A message to be displayed in the list when dropdown is loading. */
   loadingMessage?: ShorthandValue
 
+  /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. */
+  moveFocusOnTab?: boolean
+
   /** A dropdown can perform a multiple selection. */
   multiple?: boolean
 
@@ -187,9 +190,6 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
 
   /** Sets search query value (controlled mode). */
   searchQuery?: string
-
-  /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. */
-  tabInMultipleSelection?: boolean
 
   /** Controls appearance of toggle indicator that shows/hides items list. */
   toggleIndicator?: ShorthandValue
@@ -256,6 +256,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     itemToString: PropTypes.func,
     loading: PropTypes.bool,
     loadingMessage: customPropTypes.itemShorthand,
+    moveFocusOnTab: PropTypes.bool,
     multiple: PropTypes.bool,
     noResultsMessage: customPropTypes.itemShorthand,
     onOpenChange: PropTypes.func,
@@ -268,7 +269,6 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     search: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     searchQuery: PropTypes.string,
     searchInput: customPropTypes.itemShorthand,
-    tabInMultipleSelection: PropTypes.bool,
     toggleIndicator: customPropTypes.itemShorthand,
     triggerButton: customPropTypes.itemShorthand,
     value: PropTypes.oneOfType([
@@ -763,7 +763,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
           if (!_.isNil(highlightedIndex)) {
             selectItemAtIndex(highlightedIndex)
             // Keep focus here if condition applies.
-            if (this.props.multiple && !this.props.tabInMultipleSelection) {
+            if (this.props.multiple && !this.props.moveFocusOnTab) {
               e.preventDefault()
             }
           }
@@ -903,7 +903,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
           toggleMenu()
         } else {
           // Keep focus here in this case.
-          if (this.props.multiple && !this.props.tabInMultipleSelection) {
+          if (this.props.multiple && !this.props.moveFocusOnTab) {
             e.preventDefault()
           }
           selectItemAtIndex(highlightedIndex)

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -128,7 +128,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   /** A message to be displayed in the list when dropdown is loading. */
   loadingMessage?: ShorthandValue
 
-  /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. */
+  /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. Only available to multiple selection dropdowns. */
   moveFocusOnTab?: boolean
 
   /** A dropdown can perform a multiple selection. */
@@ -358,6 +358,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
             toggleMenu,
             highlightedIndex,
             selectItemAtIndex,
+            reset,
           }) => {
             const { innerRef, ...accessibilityRootPropsRest } = getRootProps(
               { refKey: 'innerRef' },
@@ -383,6 +384,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
                           highlightedIndex,
                           getInputProps,
                           selectItemAtIndex,
+                          reset,
                           variables,
                         )
                       : this.renderTriggerButton(styles, rtl, getToggleButtonProps)}
@@ -463,8 +465,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
               onFocus: () => {
                 this.setState({ focused: true })
               },
-              onBlur: e => {
-                e.nativeEvent['preventDownshiftDefault'] = true
+              onBlur: () => {
                 this.setState({ focused: false })
               },
               onKeyDown: e => {
@@ -488,6 +489,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
       otherStateToSet?: Partial<StateChangeOptions<any>>,
       cb?: () => void,
     ) => void,
+    reset: () => void,
     variables,
   ): JSX.Element {
     const { inline, searchInput, multiple, placeholder } = this.props
@@ -510,6 +512,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
           highlightedIndex,
           rtl,
           selectItemAtIndex,
+          reset,
           accessibilityComboboxProps,
           getInputProps,
         ),
@@ -742,6 +745,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
       otherStateToSet?: Partial<StateChangeOptions<any>>,
       cb?: () => void,
     ) => void,
+    reset: () => void,
     accessibilityComboboxProps: Object,
     getInputProps: (options?: GetInputPropsOptions) => any,
   ) => {
@@ -766,6 +770,8 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
             if (this.props.multiple && !this.props.moveFocusOnTab) {
               e.preventDefault()
             }
+          } else {
+            reset()
           }
           break
         case keyboardKey.ArrowLeft:

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -188,6 +188,9 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   /** Sets search query value (controlled mode). */
   searchQuery?: string
 
+  /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. */
+  tabInMultipleSelection?: boolean
+
   /** Controls appearance of toggle indicator that shows/hides items list. */
   toggleIndicator?: ShorthandValue
 
@@ -265,6 +268,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     search: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     searchQuery: PropTypes.string,
     searchInput: customPropTypes.itemShorthand,
+    tabInMultipleSelection: PropTypes.bool,
     toggleIndicator: customPropTypes.itemShorthand,
     triggerButton: customPropTypes.itemShorthand,
     value: PropTypes.oneOfType([
@@ -459,7 +463,8 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
               onFocus: () => {
                 this.setState({ focused: true })
               },
-              onBlur: () => {
+              onBlur: e => {
+                e.nativeEvent['preventDownshiftDefault'] = true
                 this.setState({ focused: false })
               },
               onKeyDown: e => {
@@ -745,6 +750,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
       searchInputProps: DropdownSearchInputProps,
     ) => {
       this.setState({ focused: false })
+      e.nativeEvent['preventDownshiftDefault'] = true
       _.invoke(predefinedProps, 'onInputBlur', e, searchInputProps)
     }
 
@@ -756,6 +762,9 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
         case keyboardKey.Tab:
           if (!_.isNil(highlightedIndex)) {
             selectItemAtIndex(highlightedIndex)
+          }
+          if (this.props.multiple && !this.props.tabInMultipleSelection) {
+            e.preventDefault()
           }
           break
         case keyboardKey.ArrowLeft:
@@ -893,6 +902,9 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
           toggleMenu()
         } else {
           selectItemAtIndex(highlightedIndex)
+        }
+        if (this.props.multiple && !this.props.tabInMultipleSelection) {
+          e.preventDefault()
         }
         return
       case keyboardKey.Escape:


### PR DESCRIPTION
This PR aims to fix 2 issues:

1. On multiple selection and search, using Tab (and Shift+Tab) to select an item will keep the focus on the dropdown, unless the `tabInMultipleSelection` is set to true.
2. On single search, will prevent default Downshift reset behavior when there is a blur on input text.

These 2 issues should also be addressed in Downshift but we need them now, so will patch them now like this and will follow-up in Downshift later. Downshift should make sure that selection on blur works (now it just resets on blur). Also I am planning to add multiple selection to Downshift in the future.

Please provide input about implementation and naming.

Should close https://github.com/stardust-ui/react/issues/1101.