### PR TITLE
chore(customPropTypes): use direct imports for customPropTypes

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import {
   AutoControlledComponent,
-  customPropTypes,
   childrenExist,
   UIComponentProps,
   ChildrenComponentProps,

--- a/packages/react/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/react/src/components/Accordion/AccordionTitle.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -10,7 +11,6 @@ import {
   ContentComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
-  customPropTypes,
   rtlTextContainer,
 } from '../../lib'
 import { ReactProps, ComponentEventHandler, ShorthandValue } from '../../types'

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
@@ -6,7 +7,6 @@ import {
   UIComponentProps,
   ContentComponentProps,
   commonPropTypes,
-  customPropTypes,
   childrenExist,
   rtlTextContainer,
 } from '../../lib'

--- a/packages/react/src/components/Attachment/Attachment.tsx
+++ b/packages/react/src/components/Attachment/Attachment.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
 import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
 import {
   UIComponent,
-  customPropTypes,
   createShorthandFactory,
   commonPropTypes,
   isFromKeyboard,

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import Image from '../Image/Image'
@@ -8,7 +9,6 @@ import { defaultBehavior } from '../../lib/accessibility'
 import { ReactProps, ShorthandValue } from '../../types'
 import {
   createShorthandFactory,
-  customPropTypes,
   UIComponent,
   UIComponentProps,
   commonPropTypes,

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
@@ -5,7 +6,6 @@ import * as _ from 'lodash'
 import {
   UIComponent,
   childrenExist,
-  customPropTypes,
   createShorthandFactory,
   isFromKeyboard,
   UIComponentProps,

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
@@ -6,7 +7,6 @@ import { ReactProps, ShorthandValue } from '../../types'
 import {
   UIComponent,
   childrenExist,
-  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,

--- a/packages/react/src/components/Chat/Chat.tsx
+++ b/packages/react/src/components/Chat/Chat.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import {
   childrenExist,
-  customPropTypes,
   UIComponent,
   commonPropTypes,
   rtlTextContainer,

--- a/packages/react/src/components/Chat/ChatItem.tsx
+++ b/packages/react/src/components/Chat/ChatItem.tsx
@@ -1,6 +1,6 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
-import * as _ from 'lodash'
 
 import { ReactProps, ShorthandValue } from '../../types'
 import {
@@ -11,7 +11,6 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
-  customPropTypes,
   rtlTextContainer,
   getElementProp,
 } from '../../lib'

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import cx from 'classnames'
@@ -6,7 +7,6 @@ import * as _ from 'lodash'
 import {
   childrenExist,
   createShorthandFactory,
-  customPropTypes,
   RenderResultConfig,
   UIComponent,
   UIComponentProps,

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -6,7 +7,6 @@ import {
   UIComponentProps,
   commonPropTypes,
   ColorComponentProps,
-  customPropTypes,
   ContentComponentProps,
   AutoControlledComponent,
   doesNodeContainClick,

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
@@ -25,7 +26,6 @@ import Downshift, {
 import {
   AutoControlledComponent,
   RenderResultConfig,
-  customPropTypes,
   commonPropTypes,
   handleRef,
   UIComponentProps,

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -1,14 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
-import {
-  UIComponent,
-  RenderResultConfig,
-  createShorthandFactory,
-  customPropTypes,
-  commonPropTypes,
-} from '../../lib'
+import { UIComponent, RenderResultConfig, createShorthandFactory, commonPropTypes } from '../../lib'
 import { ShorthandValue, ComponentEventHandler, ReactProps } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import ListItem from '../List/ListItem'

--- a/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -1,14 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
-import {
-  UIComponent,
-  RenderResultConfig,
-  createShorthandFactory,
-  commonPropTypes,
-  customPropTypes,
-} from '../../lib'
+import { UIComponent, RenderResultConfig, createShorthandFactory, commonPropTypes } from '../../lib'
 import { ComponentEventHandler, ReactProps } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import Input from '../Input/Input'

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
@@ -5,13 +6,7 @@ import * as _ from 'lodash'
 import keyboardKey from 'keyboard-key'
 import { ComponentEventHandler, ShorthandValue, ReactProps } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
-import {
-  customPropTypes,
-  createShorthandFactory,
-  UIComponent,
-  RenderResultConfig,
-  commonPropTypes,
-} from '../../lib'
+import { createShorthandFactory, UIComponent, RenderResultConfig, commonPropTypes } from '../../lib'
 import { Image, Icon, Label } from '../..'
 import { IconProps } from '../Icon/Icon'
 import Ref from '../Ref/Ref'

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
@@ -5,7 +6,6 @@ import * as _ from 'lodash'
 import {
   UIComponent,
   childrenExist,
-  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,

--- a/packages/react/src/components/Form/FormField.tsx
+++ b/packages/react/src/components/Form/FormField.tsx
@@ -1,9 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import {
   UIComponent,
-  customPropTypes,
   childrenExist,
   createShorthandFactory,
   UIComponentProps,

--- a/packages/react/src/components/Grid/Grid.tsx
+++ b/packages/react/src/components/Grid/Grid.tsx
@@ -1,9 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import {
   UIComponent,
   childrenExist,
-  customPropTypes,
   RenderResultConfig,
   UIComponentProps,
   ChildrenComponentProps,

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import {
   childrenExist,
   createShorthandFactory,
-  customPropTypes,
   UIComponent,
   UIComponentProps,
   ChildrenComponentProps,

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import {
   callable,
   UIComponent,
   createShorthandFactory,
-  customPropTypes,
   UIComponentProps,
   commonPropTypes,
   ColorComponentProps,

--- a/packages/react/src/components/Indicator/Indicator.tsx
+++ b/packages/react/src/components/Indicator/Indicator.tsx
@@ -1,13 +1,8 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 
-import {
-  createShorthandFactory,
-  UIComponent,
-  UIComponentProps,
-  commonPropTypes,
-  customPropTypes,
-} from '../../lib'
+import { createShorthandFactory, UIComponent, UIComponentProps, commonPropTypes } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { iconBehavior } from '../../lib/accessibility'
 import { ReactProps, ShorthandValue } from '../../types'

--- a/packages/react/src/components/Input/Input.tsx
+++ b/packages/react/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import cx from 'classnames'
@@ -5,7 +6,6 @@ import * as _ from 'lodash'
 
 import {
   AutoControlledComponent,
-  customPropTypes,
   RenderResultConfig,
   partitionHTMLProps,
   UIComponentProps,

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import {
   childrenExist,
   createShorthandFactory,
-  customPropTypes,
   pxToRem,
   UIComponent,
   UIComponentProps,

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as PropTypes from 'prop-types'
 
 import {
-  customPropTypes,
   childrenExist,
   AutoControlledComponent,
   UIComponentProps,

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
@@ -7,7 +8,6 @@ import {
   UIComponentProps,
   commonPropTypes,
   ColorComponentProps,
-  customPropTypes,
   SizeValue,
 } from '../../lib'
 import { loaderBehavior } from '../../lib/accessibility'

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -6,7 +7,6 @@ import {
   AutoControlledComponent,
   childrenExist,
   createShorthandFactory,
-  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -1,4 +1,5 @@
 import { documentRef, EventListener } from '@stardust-ui/react-component-event-listener'
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import cx from 'classnames'
 import * as PropTypes from 'prop-types'
@@ -8,7 +9,6 @@ import {
   AutoControlledComponent,
   childrenExist,
   createShorthandFactory,
-  customPropTypes,
   doesNodeContainClick,
   UIComponentProps,
   ChildrenComponentProps,

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -1,5 +1,6 @@
 import { documentRef, EventListener } from '@stardust-ui/react-component-event-listener'
 import { NodeRef, Unstable_NestingAuto } from '@stardust-ui/react-component-nesting-registry'
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as PropTypes from 'prop-types'
@@ -18,7 +19,6 @@ import {
   StyledComponentProps,
   commonPropTypes,
   isFromKeyboard,
-  customPropTypes,
   handleRef,
   doesNodeContainClick,
 } from '../../lib'

--- a/packages/react/src/components/Portal/Portal.tsx
+++ b/packages/react/src/components/Portal/Portal.tsx
@@ -1,4 +1,5 @@
 import { documentRef, EventListener } from '@stardust-ui/react-component-event-listener'
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
@@ -12,7 +13,6 @@ import {
   ContentComponentProps,
   handleRef,
   rtlTextContainer,
-  customPropTypes,
 } from '../../lib'
 import Ref from '../Ref/Ref'
 import PortalInner from './PortalInner'

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,6 @@
 // TODO:
 // vertical - padding variable?
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -7,7 +8,6 @@ import * as React from 'react'
 import {
   AutoControlledComponent,
   childrenExist,
-  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,

--- a/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
@@ -1,9 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
 import {
-  customPropTypes,
   AutoControlledComponent,
   createShorthandFactory,
   isFromKeyboard,

--- a/packages/react/src/components/Reaction/Reaction.tsx
+++ b/packages/react/src/components/Reaction/Reaction.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
@@ -9,7 +10,6 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  customPropTypes,
   createShorthandFactory,
   ContentComponentProps,
   isFromKeyboard,

--- a/packages/react/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/react/src/components/Reaction/ReactionGroup.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as _ from 'lodash'
 
@@ -5,7 +6,6 @@ import { ReactProps, ShorthandValue } from '../../types'
 import {
   UIComponent,
   childrenExist,
-  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,

--- a/packages/react/src/components/Ref/Ref.tsx
+++ b/packages/react/src/components/Ref/Ref.tsx
@@ -1,8 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import { isForwardRef } from 'react-is'
 
-import { ChildrenComponentProps, customPropTypes } from '../../lib'
+import { ChildrenComponentProps } from '../../lib'
 import { ReactProps } from '../../types'
 import RefFindNode from './RefFindNode'
 import RefForward from './RefForward'

--- a/packages/react/src/components/Ref/RefFindNode.tsx
+++ b/packages/react/src/components/Ref/RefFindNode.tsx
@@ -1,8 +1,9 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
-import { ChildrenComponentProps, customPropTypes, handleRef } from '../../lib'
+import { ChildrenComponentProps, handleRef } from '../../lib'
 
 export interface RefFindNodeProps extends ChildrenComponentProps<React.ReactElement<any>> {
   /**

--- a/packages/react/src/components/Ref/RefForward.tsx
+++ b/packages/react/src/components/Ref/RefForward.tsx
@@ -1,7 +1,8 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
-import { ChildrenComponentProps, customPropTypes, handleRef } from '../../lib'
+import { ChildrenComponentProps, handleRef } from '../../lib'
 
 export interface RefForwardProps extends ChildrenComponentProps<React.ReactElement<any>> {
   /**

--- a/packages/react/src/components/Status/Status.tsx
+++ b/packages/react/src/components/Status/Status.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import Icon from '../Icon/Icon'
@@ -5,7 +6,6 @@ import { statusBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 
 import {
-  customPropTypes,
   UIComponent,
   createShorthandFactory,
   UIComponentProps,

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -1,10 +1,10 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import {
   childrenExist,
   createShorthandFactory,
-  customPropTypes,
   UIComponent,
   UIComponentProps,
   ContentComponentProps,

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -8,7 +9,6 @@ import {
   childrenExist,
   commonPropTypes,
   createShorthandFactory,
-  customPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
   rtlTextContainer,

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -1,3 +1,4 @@
+import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -9,7 +10,6 @@ import { Accessibility } from '../../lib/accessibility/types'
 import {
   UIComponent,
   childrenExist,
-  customPropTypes,
   createShorthandFactory,
   commonPropTypes,
   UIComponentProps,

--- a/packages/react/src/lib/index.ts
+++ b/packages/react/src/lib/index.ts
@@ -2,7 +2,6 @@
 import 'mdn-polyfills/Object.assign'
 import 'mdn-polyfills/String.prototype.includes'
 
-import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as commonPropTypes from './commonPropTypes'
 
 export { default as applyAccessibilityKeyHandlers } from './applyAccessibilityKeyHandlers'
@@ -37,7 +36,6 @@ export { default as isBrowser } from './isBrowser'
 export { default as doesNodeContainClick } from './doesNodeContainClick'
 
 export { pxToRem, updateCachedRemSize } from './fontSizeUtility'
-export { customPropTypes }
 export { default as createAnimationStyles } from './createAnimationStyles'
 export { default as createComponent } from './createStardustComponent'
 export { getKindProp } from './getKindProp'


### PR DESCRIPTION
This PR removes reexport `customPropTypes` from `lib/index.ts` as it useless.