### PR TITLE
feat(Icon): export `flag` icon in Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add predefined icon set for the usages in the `Input`, `Dropdown` and `AccordionTitle` components @mnajdova ([#1120](https://github.com/stardust-ui/react/pull/1120))
 - Add `Popup` styles to Teams Dark and High Contrast themes @kuzhelov ([#1121](https://github.com/stardust-ui/react/pull/1121))
+- export `flag` icon in Teams theme @jaanus03 ([#1133](https://github.com/stardust-ui/react/pull/1133))
 
 ### BREAKING CHANGES
 - `color` and `backgroundColor` variables were moved from `PopupContent` to `popup` slot of `Popup` component @kuzhelov ([#1121](https://github.com/stardust-ui/react/pull/1121))

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/flag.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/flag.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import cx from 'classnames'
+import { TeamsProcessedSvgIconSpec } from '../types'
+import { teamsIconClassNames } from '../teamsIconClassNames'
+
+export default {
+  icon: ({ classes }) => (
+    <svg role="presentation" focusable="false" viewBox="8 8 16 16" className={classes.svg}>
+      <g>
+        <path
+          className={cx(teamsIconClassNames.outline, classes.outlinePart)}
+          d="M12.5,9.5a.514.514,0,0,1,.5.5h7a.5.5,0,0,1,.5.5,18.763,18.763,0,0,1-1.438,3,19.477,19.477,0,0,1,1.438,3,.5.5,0,0,1-.5.5H13v5.5a.5.5,0,0,1-1,0V10A.5.5,0,0,1,12.5,9.5ZM13,11v5h6.188l-1.133-2.273a.5.5,0,0,1,0-.454L19.188,11Z"
+        />
+        <path
+          className={cx(teamsIconClassNames.filled, classes.filledPart)}
+          d="M12.5,9.5a.514.514,0,0,1,.5.5h7a.5.5,0,0,1,.5.5,23.8,23.8,0,0,1-1.438,3,22.292,22.292,0,0,1,1.438,3,.5.5,0,0,1-.5.5H13v5.5a.5.5,0,0,1-1,0V10A.5.5,0,0,1,12.5,9.5Z"
+        />
+      </g>
+    </svg>
+  ),
+  styles: {},
+} as TeamsProcessedSvgIconSpec

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
@@ -37,6 +37,7 @@ import filesSketch from './filesSketch'
 import filesSound from './filesSound'
 import filesTxt from './filesTxt'
 import filesZip from './filesZip'
+import flag from './flag'
 import download from './download'
 import edit from './edit'
 import email from './email'
@@ -141,6 +142,7 @@ export default {
   'files-sound': filesSound,
   'files-txt': filesTxt,
   'files-zip': filesZip,
+  flag,
   download,
   edit,
   email,


### PR DESCRIPTION
This PR add a new `flag` icon.
![flag-icon](https://user-images.githubusercontent.com/604667/55236208-19711b80-5238-11e9-9ef6-e5c6fda8373a.png)
