### PR TITLE
fix(chore): remove static type references for slotClassNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix in `Dropdown`, close it after `searchQuery` will become empty @layershifter ([#1124](https://github.com/stardust-ui/react/pull/1124))
 - Correctly align RTL text in LTR theme and vice versa @miroslavstastny ([#1115](https://github.com/stardust-ui/react/pull/1115))
 - `chatBehavior` - remove role 'presentation' @sophieH29 ([#1137](https://github.com/stardust-ui/react/pull/1137))
+- Temporarily remove static type references in `slotClassNames` to prevent circular dependency crashes @kuzhelov ([#1145](https://github.com/stardust-ui/react/pull/1145))
 
 ### Features
 - Add predefined icon set for the usages in the `Input`, `Dropdown` and `AccordionTitle` components @mnajdova ([#1120](https://github.com/stardust-ui/react/pull/1120))

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -87,8 +87,8 @@ class Accordion extends AutoControlledComponent<ReactProps<AccordionProps>, any>
   static className = 'ui-accordion'
 
   static slotClassNames: AccordionSlotClassNames = {
-    content: AccordionContent.className,
-    title: AccordionTitle.className,
+    content: `${Accordion.className}__content`,
+    title: `${Accordion.className}__title`,
   }
 
   static propTypes = {

--- a/packages/react/src/components/Chat/Chat.tsx
+++ b/packages/react/src/components/Chat/Chat.tsx
@@ -41,7 +41,7 @@ class Chat extends UIComponent<ReactProps<ChatProps>, any> {
   static className = 'ui-chat'
 
   static slotClassNames: ChatSlotClassNames = {
-    item: ChatItem.className,
+    item: `${Chat.className}__item`,
   }
 
   static propTypes = {

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -54,7 +54,7 @@ class Form extends UIComponent<ReactProps<FormProps>, any> {
   public static className = 'ui-form'
 
   static slotClassNames: FormSlotClassNames = {
-    field: FormField.className,
+    field: `${Form.className}__field`,
   }
 
   public static propTypes = {

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -56,7 +56,7 @@ class Header extends UIComponent<ReactProps<HeaderProps>, any> {
   static className = 'ui-header'
 
   static slotClassNames: HeaderSlotClassNames = {
-    description: HeaderDescription.className,
+    description: `${Header.className}__description`,
   }
 
   static create: Function

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -73,7 +73,7 @@ class List extends AutoControlledComponent<ReactProps<ListProps>, ListState> {
   static className = 'ui-list'
 
   static slotClassNames: ListSlotClassNames = {
-    item: ListItem.className,
+    item: `${List.className}__item`,
   }
 
   static propTypes = {

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -94,8 +94,8 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
   static className = 'ui-menu'
 
   static slotClassNames: MenuSlotClassNames = {
-    divider: MenuDivider.className,
-    item: MenuItem.className,
+    divider: `${Menu.className}__divider`,
+    item: `${Menu.className}__item`,
   }
 
   static create: Function

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -143,7 +143,10 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
 
   static className = 'ui-menu__item'
 
-  static slotClassNames: MenuItemSlotClassNames
+  static slotClassNames: MenuItemSlotClassNames = {
+    submenu: `${MenuItem.className}__submenu`,
+    wrapper: `${MenuItem.className}__wrapper`,
+  }
 
   static create: Function
 
@@ -393,9 +396,5 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
 }
 
 MenuItem.create = createShorthandFactory({ Component: MenuItem, mappedProp: 'content' })
-MenuItem.slotClassNames = {
-  submenu: `${MenuItem.className}__submenu`,
-  wrapper: `${MenuItem.className}__wrapper`,
-}
 
 export default MenuItem

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -147,7 +147,7 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
   static className = 'ui-popup'
 
   static slotClassNames: PopupSlotClassNames = {
-    content: PopupContent.className,
+    content: `${Popup.className}__content`,
   }
 
   static Content = PopupContent

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -61,7 +61,7 @@ class RadioGroup extends AutoControlledComponent<ReactProps<RadioGroupProps>, an
   static className = 'ui-radiogroup'
 
   static slotClassNames: RadioGroupSlotClassNames = {
-    item: RadioGroupItem.className,
+    item: `${RadioGroup.className}__item`,
   }
 
   static create: Function

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -65,7 +65,7 @@ class Tree extends AutoControlledComponent<ReactProps<TreeProps>, TreeState> {
   static className = 'ui-tree'
 
   static slotClassNames: TreeSlotClassNames = {
-    item: TreeItem.className,
+    item: `${Tree.className}__item`,
   }
 
   static propTypes = {

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -75,7 +75,7 @@ class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
   static className = 'ui-tree__item'
 
   static slotClassNames: TreeItemSlotClassNames = {
-    title: TreeTitle.className,
+    title: `${TreeItem.className}__title`,
     subtree: `${TreeItem.className}__subtree`,
   }
 


### PR DESCRIPTION
TODO 
- [x] introduce changelog entry

--------

This PR temporarily removes static type references from `slotClassNames`, as it serves as a source of circular dependencies problem. This move doesn't introduce breaking changes to the client and, at the same time, provides us with some time to
- introduce necessary checks to detect malicious circular dependencies
- come up with better approach to handle potential duplications in `slotClassNames` strings (although, most of them have reasons to exist).

This fix also removes circular dependency between `Menu` -> `MenuItem` -> `Menu` that currently fails docs from start.