### PR TITLE
fix(Dropdown): reset highlighted index on input change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix the reset of the `highlightedIndex` when search query changes @silviuavram ([#1168](https://github.com/stardust-ui/react/pull/1168))
+
 <!--------------------------------[ v0.26.0 ]------------------------------- -->
 ## [v0.26.0](https://github.com/stardust-ui/react/tree/v0.26.0) (2019-04-03)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.25.1...v0.26.0)

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -643,6 +643,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   private handleSearchQueryChange = (searchQuery: string) => {
     this.trySetStateAndInvokeHandler('onSearchQueryChange', null, {
       searchQuery,
+      highlightedIndex: this.props.highlightFirstItemOnOpen ? 0 : null,
       open: searchQuery === '' ? false : this.state.open,
     })
   }

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -58,7 +58,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('has the provided prop value + 1 when opened by ArrowDown', () => {
+    it('has the (provided prop value + 1) when opened by ArrowDown', () => {
       const highlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -78,7 +78,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('has the provided prop value - 1 when opened by ArrowUp', () => {
+    it('has the provided (prop value - 1) when opened by ArrowUp', () => {
       const highlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -138,7 +138,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('is defaultHighlightedIndex value at first opening', () => {
+    it('is defaultHighlightedIndex prop value at first opening', () => {
       const defaultHighlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown
@@ -198,7 +198,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('is set to 0 at searchQuery change and when highlightFirstItemOnOpen prop is provided', () => {
+    it('is set to 0 on searchQuery change and when highlightFirstItemOnOpen prop is provided', () => {
       const onSearchQueryChange = jest.fn()
       const wrapper = mountWithProvider(
         <Dropdown

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -178,7 +178,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('is always 0 when highlightFirstItemOnOpen prop is provided', () => {
+    it('is 0 on first open when highlightFirstItemOnOpen prop is provided', () => {
       const wrapper = mountWithProvider(
         <Dropdown highlightFirstItemOnOpen onOpenChange={onOpenChange} items={items} />,
       )
@@ -193,7 +193,18 @@ describe('Dropdown', () => {
           open: true,
         }),
       )
-      triggerButton.simulate('click').simulate('click')
+    })
+
+    it('is 0 on second and subsequent open when highlightFirstItemOnOpen prop is provided', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown highlightFirstItemOnOpen onOpenChange={onOpenChange} items={items} />,
+      )
+      const triggerButton = wrapper.find({ className: Dropdown.slotClassNames.triggerButton })
+
+      triggerButton
+        .simulate('click')
+        .simulate('click')
+        .simulate('click')
       expect(onOpenChange).toBeCalledTimes(3)
       expect(onOpenChange).toHaveBeenCalledWith(
         null,
@@ -204,7 +215,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('is set to 0 on searchQuery change and when highlightFirstItemOnOpen prop is provided', () => {
+    it('is 0 on searchQuery first change and when highlightFirstItemOnOpen prop is provided', () => {
       const onSearchQueryChange = jest.fn()
       const wrapper = mountWithProvider(
         <Dropdown
@@ -234,11 +245,26 @@ describe('Dropdown', () => {
           highlightedIndex: 0,
         }),
       )
+    })
+
+    it('is reset to 0 on searchQuery change and when highlightFirstItemOnOpen prop is provided', () => {
+      const onSearchQueryChange = jest.fn()
+      const wrapper = mountWithProvider(
+        <Dropdown
+          search
+          highlightFirstItemOnOpen
+          onSearchQueryChange={onSearchQueryChange}
+          onOpenChange={onOpenChange}
+          items={items}
+        />,
+      )
+      const searchInput = wrapper.find(`input.${DropdownSearchInput.slotClassNames.input}`)
 
       searchInput
-        // now it's on index 1.
-        .simulate('keydown', { keyCode: keyboardKey.ArrowUp, key: 'ArrowUp' })
-        .simulate('change', { target: { value: 'in' } })
+        .simulate('click')
+        .simulate('change', { target: { value: 'i' } })
+        .simulate('keydown', { keyCode: keyboardKey.ArrowUp, key: 'ArrowUp' }) // now it's on index 1.
+        .simulate('change', { target: { value: 'in' } }) // now it should reset to 0.
       expect(onSearchQueryChange).toBeCalledTimes(2)
       expect(onSearchQueryChange).toHaveBeenCalledWith(
         null,
@@ -249,7 +275,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('is set to null at searchQuery change and when highlightFirstItemOnOpen prop is not provided', () => {
+    it('is null on searchQuery first change and when highlightFirstItemOnOpen prop is not provided', () => {
       const onSearchQueryChange = jest.fn()
       const wrapper = mountWithProvider(
         <Dropdown
@@ -278,10 +304,24 @@ describe('Dropdown', () => {
           highlightedIndex: null,
         }),
       )
+    })
+
+    it('is reset to null on searchQuery change and when highlightFirstItemOnOpen prop is not provided', () => {
+      const onSearchQueryChange = jest.fn()
+      const wrapper = mountWithProvider(
+        <Dropdown
+          search
+          onSearchQueryChange={onSearchQueryChange}
+          onOpenChange={onOpenChange}
+          items={items}
+        />,
+      )
+      const searchInput = wrapper.find(`input.${DropdownSearchInput.slotClassNames.input}`)
 
       searchInput
-        // now it's on index 0.
-        .simulate('keydown', { keyCode: keyboardKey.ArrowUp, key: 'ArrowUp' })
+        .simulate('click')
+        .simulate('change', { target: { value: 'i' } }) // no item highlighted.
+        .simulate('keydown', { keyCode: keyboardKey.ArrowUp, key: 'ArrowUp' }) // highlight on index 0.
         .simulate('change', { target: { value: 'in' } })
       expect(onSearchQueryChange).toBeCalledTimes(2)
       expect(onSearchQueryChange).toHaveBeenCalledWith(

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -157,9 +157,15 @@ describe('Dropdown', () => {
           open: true,
         }),
       )
+    })
 
+    it('is null on second and subsequent open even though defaultHighlightedIndex prop is passed', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown defaultHighlightedIndex={1} onOpenChange={onOpenChange} items={items} />,
+      )
       wrapper
         .find({ className: Dropdown.slotClassNames.triggerButton })
+        .simulate('click')
         .simulate('click')
         .simulate('click')
       expect(onOpenChange).toBeCalledTimes(3)

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
 import Dropdown from 'src/components/Dropdown/Dropdown'
+import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
 import { isConformant } from 'test/specs/commonTests'
 import { mountWithProvider } from 'test/utils'
 
@@ -40,7 +41,7 @@ describe('Dropdown', () => {
       onOpenChange.mockReset()
     })
 
-    it('calls onOpen with highlightedIndex on click', () => {
+    it('has the provided prop value when opened by click', () => {
       const highlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -57,7 +58,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('calls onOpen with highlightedIndex + 1 on arrow down', () => {
+    it('has the provided prop value + 1 when opened by ArrowDown', () => {
       const highlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -77,7 +78,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('calls onOpen with highlightedIndex - 1 on arrow down', () => {
+    it('has the provided prop value - 1 when opened by ArrowUp', () => {
       const highlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -97,7 +98,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('calls onOpen with highlightedIndex wrapped to 0 on arrow down', () => {
+    it('is 0 when the provided prop value is last item index and opened by ArrowDown', () => {
       const highlightedIndex = items.length - 1
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -117,7 +118,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('calls onOpen with highlightedIndex wrapped to items.length - 1 on arrow up', () => {
+    it('is last item index when the provided prop value is 0 and opened by ArrowUp', () => {
       const highlightedIndex = 0
       const wrapper = mountWithProvider(
         <Dropdown highlightedIndex={highlightedIndex} onOpenChange={onOpenChange} items={items} />,
@@ -137,7 +138,7 @@ describe('Dropdown', () => {
       )
     })
 
-    it('calls onOpen with highlightedIndex set to defaultHighlightedIndex', () => {
+    it('is defaultHighlightedIndex value at first opening', () => {
       const defaultHighlightedIndex = 1
       const wrapper = mountWithProvider(
         <Dropdown
@@ -156,11 +157,24 @@ describe('Dropdown', () => {
           open: true,
         }),
       )
+
+      wrapper
+        .find({ className: Dropdown.slotClassNames.triggerButton })
+        .simulate('click')
+        .simulate('click')
+      expect(onOpenChange).toBeCalledTimes(3)
+      expect(onOpenChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          highlightedIndex: null,
+          open: true,
+        }),
+      )
     })
 
-    it('calls onOpen with highlightedIndex always set to 0', () => {
+    it('is always 0 when highlightFirstItemOnOpen prop is provided', () => {
       const wrapper = mountWithProvider(
-        <Dropdown highlightFirstItemOnOpen={true} onOpenChange={onOpenChange} items={items} />,
+        <Dropdown highlightFirstItemOnOpen onOpenChange={onOpenChange} items={items} />,
       )
       const triggerButton = wrapper.find({ className: Dropdown.slotClassNames.triggerButton })
 
@@ -180,6 +194,95 @@ describe('Dropdown', () => {
         expect.objectContaining({
           highlightedIndex: 0,
           open: true,
+        }),
+      )
+    })
+
+    it('is set to 0 at searchQuery change and when highlightFirstItemOnOpen prop is provided', () => {
+      const onSearchQueryChange = jest.fn()
+      const wrapper = mountWithProvider(
+        <Dropdown
+          search
+          highlightFirstItemOnOpen
+          onSearchQueryChange={onSearchQueryChange}
+          onOpenChange={onOpenChange}
+          items={items}
+        />,
+      )
+      const searchInput = wrapper.find(`input.${DropdownSearchInput.slotClassNames.input}`)
+
+      searchInput.simulate('click').simulate('change', { target: { value: 'i' } })
+      expect(onOpenChange).toBeCalledTimes(1)
+      expect(onOpenChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          highlightedIndex: 0,
+          open: true,
+        }),
+      )
+      expect(onSearchQueryChange).toBeCalledTimes(1)
+      expect(onSearchQueryChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: 'i',
+          highlightedIndex: 0,
+        }),
+      )
+
+      searchInput
+        // now it's on index 1.
+        .simulate('keydown', { keyCode: keyboardKey.ArrowUp, key: 'ArrowUp' })
+        .simulate('change', { target: { value: 'in' } })
+      expect(onSearchQueryChange).toBeCalledTimes(2)
+      expect(onSearchQueryChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: 'in',
+          highlightedIndex: 0,
+        }),
+      )
+    })
+
+    it('is set to null at searchQuery change and when highlightFirstItemOnOpen prop is not provided', () => {
+      const onSearchQueryChange = jest.fn()
+      const wrapper = mountWithProvider(
+        <Dropdown
+          search
+          onSearchQueryChange={onSearchQueryChange}
+          onOpenChange={onOpenChange}
+          items={items}
+        />,
+      )
+      const searchInput = wrapper.find(`input.${DropdownSearchInput.slotClassNames.input}`)
+
+      searchInput.simulate('click').simulate('change', { target: { value: 'i' } })
+      expect(onOpenChange).toBeCalledTimes(1)
+      expect(onOpenChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          highlightedIndex: null,
+          open: true,
+        }),
+      )
+      expect(onSearchQueryChange).toBeCalledTimes(1)
+      expect(onSearchQueryChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: 'i',
+          highlightedIndex: null,
+        }),
+      )
+
+      searchInput
+        // now it's on index 0.
+        .simulate('keydown', { keyCode: keyboardKey.ArrowUp, key: 'ArrowUp' })
+        .simulate('change', { target: { value: 'in' } })
+      expect(onSearchQueryChange).toBeCalledTimes(2)
+      expect(onSearchQueryChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: 'in',
+          highlightedIndex: null,
         }),
       )
     })


### PR DESCRIPTION
This should reset the `highlightedIndex` to null or 0, depending whether` highlightFirstItemOnOpen` has been passed or not.