### PR TITLE
fix(FocusTrapZone): do not propagate any keyboard events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Truncate `content` and `header` of `ListItem` when used from `DropdownSelectedItem` @silviuavram ([#1161](https://github.com/stardust-ui/react/pull/1161))
+- `FocusTrapZone` - Do not propagate any keyboard events @sophieH29 ([#1180](https://github.com/stardust-ui/react/pull/1180))
 
 <!--------------------------------[ v0.26.0 ]------------------------------- -->
 ## [v0.26.0](https://github.com/stardust-ui/react/tree/v0.26.0) (2019-04-03)

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -452,13 +452,6 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
     const focusTrapProps = {
       ...(typeof accessibility.focusTrap === 'boolean' ? {} : accessibility.focusTrap),
       ...popupWrapperAttributes,
-      onKeyDown: (e: React.KeyboardEvent) => {
-        // No need to propagate keydown events outside Popup
-        // when focus trap behavior is used
-        // allow only keyboard actions to execute
-        _.invoke(accessibility.keyHandlers.popup, 'onKeyDown', e)
-        e.stopPropagation()
-      },
     } as FocusTrapZoneProps
 
     const autoFocusProps = {

--- a/packages/react/src/lib/accessibility/FocusZone/CHANGELOG.md
+++ b/packages/react/src/lib/accessibility/FocusZone/CHANGELOG.md
@@ -57,6 +57,8 @@ This is a list of changes made to the Stardust copy of FocusTrapZone in comparis
 ### fixes
 - Do not focus trigger on outside click @sophieH29 ([#627](https://github.com/stardust-ui/react/pull/627))
 - Do not hide aria-live regions from accessibility tree @sophieH29 ([#917](https://github.com/stardust-ui/react/pull/917))
+- Do not propagate any keyboard events @sophieH29 ([#1180](https://github.com/stardust-ui/react/pull/1180))
+
 ### features
 - Add focus trap zone [#239](https://github.com/stardust-ui/react/pull/239)
     - Used Stardust utils instead of Fabric utilities:

--- a/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -190,6 +190,9 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
   private _onKeyboardHandler = (ev: React.KeyboardEvent<HTMLDivElement>): void => {
     this.props.onKeyDown && this.props.onKeyDown(ev)
 
+    // do not propogate keyboard events outside focus trap zone
+    ev.stopPropagation()
+
     if (
       ev.isDefaultPrevented() ||
       keyboardKey.getCode(ev) !== keyboardKey.Tab ||
@@ -212,11 +215,9 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
     if (ev.shiftKey && _firstTabbableChild === ev.target) {
       focusAsync(_lastTabbableChild)
       ev.preventDefault()
-      ev.stopPropagation()
     } else if (!ev.shiftKey && _lastTabbableChild === ev.target) {
       focusAsync(_firstTabbableChild)
       ev.preventDefault()
-      ev.stopPropagation()
     }
   }
 


### PR DESCRIPTION
closes https://github.com/stardust-ui/react/issues/1156

## Issues caused:
Because of `Portal` events propagating to the parent components in React element tree, it caused post-effects: keyboard event was propagated outside `Portal`, and was handled by another component too. (Issue example https://github.com/stardust-ui/react/issues/1156)

## Why:
`FocusTrapZone` should not only trap focus but totally block user interaction outside of it - i.e. stop propagating keyboard events.