### PR TITLE
fix(grid): move focus outline inside grid items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix overflowing focus outline for `Grid` items for Teams theme @Bugaa92 ([#1195](https://github.com/stardust-ui/react/pull/1195))
+
 <!--------------------------------[ v0.27.0 ]------------------------------- -->
 ## [v0.27.0](https://github.com/stardust-ui/react/tree/v0.27.0) (2019-04-10)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.26.0...v0.27.0)

--- a/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.shorthand.tsx
+++ b/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.shorthand.tsx
@@ -43,7 +43,7 @@ const renderImages = () => {
 
 const renderImageButtons = () => {
   return _.map(imageNames, imageName => (
-    <Button key={imageName} text styles={imageButtonStyles}>
+    <Button key={imageName} styles={imageButtonStyles}>
       <Image fluid src={`public/images/avatar/large/${imageName}.jpg`} />
     </Button>
   ))

--- a/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.shorthand.tsx
+++ b/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.shorthand.tsx
@@ -28,8 +28,8 @@ const imageButtonStyles = {
   height: '72px',
   padding: '0',
   margin: '0',
-  background: '#fff',
 }
+
 const renderImages = () => {
   return _.map(imageNames, imageName => (
     <Image
@@ -43,31 +43,21 @@ const renderImages = () => {
 
 const renderImageButtons = () => {
   return _.map(imageNames, imageName => (
-    <Button key={imageName} styles={imageButtonStyles}>
+    <Button key={imageName} text styles={imageButtonStyles}>
       <Image fluid src={`public/images/avatar/large/${imageName}.jpg`} />
     </Button>
   ))
-}
-
-const gridStyles = {
-  gridColumnGap: '10px',
-  gridRowGap: '10px',
 }
 
 const GridExample = () => (
   <div>
     Grid with images, which are not natively focusable elements. Set 'data-is-focusable=true' to
     each item to make grid items focusable and navigable.
-    <Grid accessibility={gridBehavior} styles={gridStyles} columns="7" content={renderImages()} />
+    <Grid accessibility={gridBehavior} columns="7" content={renderImages()} />
     <br />
     Grid with images, wrapped with buttons, which are natively focusable elements. No need to add
     'data-is-focusable'='true'.
-    <Grid
-      accessibility={gridBehavior}
-      styles={gridStyles}
-      columns="7"
-      content={renderImageButtons()}
-    />
+    <Grid accessibility={gridBehavior} columns="7" content={renderImageButtons()} />
   </div>
 )
 

--- a/packages/react/src/themes/base/components/Grid/gridStyles.ts
+++ b/packages/react/src/themes/base/components/Grid/gridStyles.ts
@@ -24,6 +24,7 @@ const gridStyles: ComponentSlotStylesInput<GridProps, GridVariables> = {
       gridGap,
       display: 'grid',
       justifyContent: 'space-evenly',
+      '& > *': { outlineOffset: '-3px' },
 
       ...(rows && !columns && { gridAutoFlow: 'column' }),
       ...(rows && { gridTemplateRows: getCSSTemplateValue(rows) }),

--- a/packages/react/src/themes/base/components/Grid/gridStyles.ts
+++ b/packages/react/src/themes/base/components/Grid/gridStyles.ts
@@ -24,7 +24,6 @@ const gridStyles: ComponentSlotStylesInput<GridProps, GridVariables> = {
       gridGap,
       display: 'grid',
       justifyContent: 'space-evenly',
-      '& > *': { outlineOffset: '-3px' },
 
       ...(rows && !columns && { gridAutoFlow: 'column' }),
       ...(rows && { gridTemplateRows: getCSSTemplateValue(rows) }),

--- a/packages/react/src/themes/teams/componentStyles.ts
+++ b/packages/react/src/themes/teams/componentStyles.ts
@@ -28,6 +28,8 @@ export { default as FlexItem } from './components/Flex/flexItemStyles'
 export { default as Form } from './components/Form/formStyles'
 export { default as FormField } from './components/Form/formFieldStyles'
 
+export { default as Grid } from './components/Grid/gridStyles'
+
 export { default as Header } from './components/Header/headerStyles'
 export { default as HeaderDescription } from './components/Header/headerDescriptionStyles'
 

--- a/packages/react/src/themes/teams/components/Grid/gridStyles.ts
+++ b/packages/react/src/themes/teams/components/Grid/gridStyles.ts
@@ -1,0 +1,9 @@
+import { GridVariables } from '../../../base/components/Grid/gridVariables'
+import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
+import { GridProps } from '../../../../components/Grid/Grid'
+
+const gridStyles: ComponentSlotStylesInput<GridProps, GridVariables> = {
+  root: (): ICSSInJSStyle => ({ '& > *': { outlineOffset: '-3px' } }),
+}
+
+export default gridStyles


### PR DESCRIPTION
## fix(grid): move focus outline inside grid items

Fixes #1035 

### Before:

![Screenshot 2019-04-09 at 17 52 40](https://user-images.githubusercontent.com/5442794/55815745-18ba6e00-5af1-11e9-8018-a60f0aaad08d.png)

### After:

![Screenshot 2019-04-09 at 17 53 08](https://user-images.githubusercontent.com/5442794/55815752-1c4df500-5af1-11e9-8577-79c877ca10a0.png)

