### PR TITLE
fix(RadioGroup): Set label font size to smaller in Teams Theme

### DIFF
--- a/packages/react/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
+++ b/packages/react/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
@@ -26,7 +26,7 @@ export default (siteVars: any): RadioGroupItemVariables => ({
   focusInnerBorderColor: siteVars.colors.white,
   focusOuterBorderColor: siteVars.colors.black,
 
-  textFontSize: siteVars.fontSizes.medium,
+  textFontSize: siteVars.fontSizes.small,
 
   textColorDefault: siteVars.gray02,
   textColorDefaultHoverFocus: siteVars.colors.grey[900],


### PR DESCRIPTION
Set font size of Radio button label to `small` in Teams Theme.

Fixes #1220.

- [ ] changelog