### PR TITLE
fix(List): apply gaps on `ListItem.main`

### DIFF
--- a/docs/src/examples/components/List/Variations/ListExampleFixedTruncate.shorthand.tsx
+++ b/docs/src/examples/components/List/Variations/ListExampleFixedTruncate.shorthand.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { List } from '@stardust-ui/react'
+
+const items = [
+  {
+    key: 'header',
+    header: 'Use the online FTP application to input the multi-byte application!',
+    headerMedia: '7:26:56 AM',
+  },
+  {
+    key: 'content',
+    content:
+      'If we override the capacitor, we can get to the SMS pixel through the open-source FTP application!',
+    contentMedia: '7:26:56 AM',
+  },
+]
+
+const ListExample = () => (
+  <div style={{ width: '200px' }}>
+    <List truncateHeader truncateContent items={items} />
+  </div>
+)
+
+export default ListExample

--- a/docs/src/examples/components/List/Variations/index.tsx
+++ b/docs/src/examples/components/List/Variations/index.tsx
@@ -1,15 +1,22 @@
 import * as React from 'react'
+
 import ComponentExample from 'docs/src/components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
+import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
 
 const Variations = () => (
-  <ExampleSection title="Variations">
-    <ComponentExample
-      title="Truncate"
-      description="A list can truncate the header and content of items items."
-      examplePath="components/List/Variations/ListExampleTruncate"
-    />
-  </ExampleSection>
+  <>
+    <ExampleSection title="Variations">
+      <ComponentExample
+        title="Truncate"
+        description="A list can truncate the header and content of items items."
+        examplePath="components/List/Variations/ListExampleTruncate"
+      />
+    </ExampleSection>
+    <NonPublicSection title="Variations for visual tests">
+      <ComponentExample examplePath="components/List/Variations/ListExampleFixedTruncate" />
+    </NonPublicSection>
+  </>
 )
 
 export default Variations

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -212,7 +212,12 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>, ListItemState> {
         {mediaElement}
 
         <Flex.Item grow>
-          <Flex column={hasBothParts} className={ListItem.slotClassNames.main} styles={styles.main}>
+          <Flex
+            className={ListItem.slotClassNames.main}
+            column={hasBothParts}
+            gap={hasBothParts ? undefined : 'gap.small'}
+            styles={styles.main}
+          >
             {this.wrapWithFlex(headerPart, hasBothParts)}
             {this.wrapWithFlex(contentPart, hasBothParts)}
           </Flex>


### PR DESCRIPTION
Fixes a small regression introduced in #1218, see https://github.com/stardust-ui/react/pull/1218#discussion_r275259153

### Before

![image](https://user-images.githubusercontent.com/14183168/56122375-f5714200-5f7a-11e9-91e1-dd742b2ee586.png)

### After

![image](https://user-images.githubusercontent.com/14183168/56122336-e12d4500-5f7a-11e9-8013-6aa49c08b950.png)
