### PR TITLE
feat(theme): Export read-aloud icon in Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add file video icon on `Icon` component @luzhon  ([#1205](https://github.com/stardust-ui/react/pull/1250))
 - Export `call-missed-line` icon in Teams theme @96andrei ([#1203](https://github.com/stardust-ui/react/pull/1203))
 - Add `pointing` prop to `Popup` ([#1198](https://github.com/stardust-ui/react/pull/1198))
-- [Teams Theme] Export missing Messaging icons @joheredi ([#1225](https://github.com/stardust-ui/react/pull/1225))
+- [Teams Theme] Export missing read-aloud icon in Teams Theme @joheredi ([#1225](https://github.com/stardust-ui/react/pull/1225))
 
 <!--------------------------------[ v0.27.0 ]------------------------------- -->
 ## [v0.27.0](https://github.com/stardust-ui/react/tree/v0.27.0) (2019-04-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add file video icon on `Icon` component @luzhon  ([#1205](https://github.com/stardust-ui/react/pull/1250))
 - Export `call-missed-line` icon in Teams theme @96andrei ([#1203](https://github.com/stardust-ui/react/pull/1203))
 - Add `pointing` prop to `Popup` ([#1198](https://github.com/stardust-ui/react/pull/1198))
+- [Teams Theme] Export missing Messaging icons @joheredi ([#1225](https://github.com/stardust-ui/react/pull/1225))
 
 <!--------------------------------[ v0.27.0 ]------------------------------- -->
 ## [v0.27.0](https://github.com/stardust-ui/react/tree/v0.27.0) (2019-04-10)

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
@@ -84,6 +84,7 @@ import participantRemove from './participantRemove'
 import phoneClock from './phoneClock'
 import play from './play'
 import quote from './quote'
+import readAloud from './read-aloud'
 import redbang from './redbang'
 import redo from './redo'
 import removeFormat from './removeFormat'
@@ -188,6 +189,7 @@ export default {
   'phone-clock': phoneClock,
   play,
   quote,
+  'read-aloud': readAloud,
   redbang,
   redo,
   'remove-format': removeFormat,

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/read-aloud.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/read-aloud.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import cx from 'classnames'
-import { TeamsProcessedSvgIconSpec } from '../types'
+import { TeamsSvgIconSpec } from '../types'
 import { teamsIconClassNames } from '../teamsIconClassNames'
 
 export default {
@@ -19,5 +19,4 @@ export default {
     </svg>
   ),
   styles: {},
-  exportedAs: 'read-aloud',
-} as TeamsProcessedSvgIconSpec
+} as TeamsSvgIconSpec


### PR DESCRIPTION
Exporting read-aloud icon in Teams Theme
![image](https://user-images.githubusercontent.com/21109913/56160904-2a7e9400-5f7d-11e9-9b64-dcc64a4d2e7b.png)
