### PR TITLE
fix(dropdown): cleanup add and remove a11y messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
+### Fixes
+- Fix a11y message cleanup for add and remove items in `Dropdown` @silviuavram ([#1237](https://github.com/stardust-ui/react/pull/1237))
+
 ### Features
 - Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -317,6 +317,12 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     }
   }
 
+  a11yStatusTimeout: any
+
+  componentWillUnmount() {
+    clearTimeout(this.a11yStatusTimeout)
+  }
+
   public renderComponent({
     ElementType,
     classes,
@@ -952,9 +958,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
     if (getA11ySelectionMessage && getA11ySelectionMessage.onAdd) {
       this.setState({ a11ySelectionStatus: getA11ySelectionMessage.onAdd(item) })
-      setTimeout(() => {
-        this.setState({ a11ySelectionStatus: '' })
-      }, Dropdown.a11yStatusCleanupTime)
+      this.setA11ySelectionMessage()
     }
 
     if (multiple) {
@@ -1040,9 +1044,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
     if (getA11ySelectionMessage && getA11ySelectionMessage.onRemove) {
       this.setState({ a11ySelectionStatus: getA11ySelectionMessage.onRemove(poppedItem) })
-      setTimeout(() => {
-        this.setState({ a11ySelectionStatus: '' })
-      }, Dropdown.a11yStatusCleanupTime)
+      this.setA11ySelectionMessage()
     }
 
     this.trySetStateAndInvokeHandler('onSelectedChange', null, { value })
@@ -1137,6 +1139,17 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
     // otherwise, highlight no item.
     return null
+  }
+
+  /**
+   * Function that sets and cleans the selection message after it has been set,
+   * so it is not read anymore via virtual cursor.
+   */
+  private setA11ySelectionMessage = (): void => {
+    clearTimeout(this.a11yStatusTimeout)
+    this.a11yStatusTimeout = setTimeout(() => {
+      this.setState({ a11ySelectionStatus: '' })
+    }, Dropdown.a11yStatusCleanupTime)
   }
 }
 

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -226,6 +226,8 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
   static className = 'ui-dropdown'
 
+  static a11yStatusCleanupTime = 500
+
   static slotClassNames: DropdownSlotClassNames
 
   static propTypes = {
@@ -950,6 +952,9 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
     if (getA11ySelectionMessage && getA11ySelectionMessage.onAdd) {
       this.setState({ a11ySelectionStatus: getA11ySelectionMessage.onAdd(item) })
+      setTimeout(() => {
+        this.setState({ a11ySelectionStatus: '' })
+      }, Dropdown.a11yStatusCleanupTime)
     }
 
     if (multiple) {
@@ -1035,6 +1040,9 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
 
     if (getA11ySelectionMessage && getA11ySelectionMessage.onRemove) {
       this.setState({ a11ySelectionStatus: getA11ySelectionMessage.onRemove(poppedItem) })
+      setTimeout(() => {
+        this.setState({ a11ySelectionStatus: '' })
+      }, Dropdown.a11yStatusCleanupTime)
     }
 
     this.trySetStateAndInvokeHandler('onSelectedChange', null, { value })

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -795,7 +795,7 @@ describe('Dropdown', () => {
       ).toBeTruthy()
     })
 
-    it('has the onAdd message inserted after an item has been added to selection', () => {
+    it('has the onAdd message inserted and cleared after an item has been added to selection', () => {
       const wrapper = mountWithProvider(
         <Dropdown
           multiple
@@ -811,9 +811,13 @@ describe('Dropdown', () => {
       firstItem.simulate('click')
 
       expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla added')
+
+      jest.runAllTimers()
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('')
     })
 
-    it('has the onRemove message inserted after an item has been removed from selection', () => {
+    it('has the onRemove message inserted and cleared after an item has been removed from selection', () => {
       const wrapper = mountWithProvider(
         <Dropdown
           multiple
@@ -832,40 +836,7 @@ describe('Dropdown', () => {
       removeIcon.simulate('click')
 
       expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla removed')
-    })
 
-    it('has the onAdd message cleared after being displayed', () => {
-      const wrapper = mountWithProvider(
-        <Dropdown multiple items={items} getA11ySelectionMessage={{ onAdd: item => 'bla bla' }} />,
-      )
-      const dropdown = wrapper.find(Dropdown)
-      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
-
-      triggerButton.simulate('click')
-      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
-
-      jest.runAllTimers()
-      expect(dropdown.state('a11ySelectionStatus')).toBe('')
-    })
-
-    it('has the onRemove message cleared after being displayed', () => {
-      const wrapper = mountWithProvider(
-        <Dropdown
-          multiple
-          items={items}
-          getA11ySelectionMessage={{ onRemove: item => 'bla bla' }}
-        />,
-      )
-      const dropdown = wrapper.find(Dropdown)
-      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
-
-      triggerButton.simulate('click')
-      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
-      jest.runAllTimers()
-      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
-      removeIcon.simulate('click')
       jest.runAllTimers()
 
       expect(dropdown.state('a11ySelectionStatus')).toBe('')

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -4,10 +4,12 @@ import * as _ from 'lodash'
 
 import Dropdown from 'src/components/Dropdown/Dropdown'
 import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
+import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
 import { isConformant } from 'test/specs/commonTests'
 import { mountWithProvider } from 'test/utils'
 
 jest.dontMock('keyboard-key')
+jest.useFakeTimers()
 
 describe('Dropdown', () => {
   const items = ['item1', 'item2', 'item3', 'item4', 'item5']
@@ -955,6 +957,88 @@ describe('Dropdown', () => {
         .simulate('keydown', { keyCode: keyboardKey.Tab, key: 'Tab', preventDefault })
 
       expect(preventDefault).not.toBeCalled()
+    })
+  })
+
+  describe('getA11ySelectionMessage', () => {
+    afterEach(() => {
+      jest.runAllTimers()
+    })
+
+    it('has the onAdd message inserted after an item has been added to selection', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown
+          multiple
+          items={items}
+          getA11ySelectionMessage={{ onAdd: item => 'bla bla added' }}
+        />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla added')
+    })
+
+    it('has the onRemove message inserted after an item has been removed from selection', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown
+          multiple
+          items={items}
+          getA11ySelectionMessage={{ onRemove: item => 'bla bla removed' }}
+        />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+      jest.runAllTimers()
+      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
+      removeIcon.simulate('click')
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla removed')
+    })
+
+    it('has the onAdd message cleared after being displayed', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown multiple items={items} getA11ySelectionMessage={{ onAdd: item => 'bla bla' }} />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+
+      jest.runAllTimers()
+      expect(dropdown.state('a11ySelectionStatus')).toBe('')
+    })
+
+    it('has the onRemove message cleared after being displayed', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown
+          multiple
+          items={items}
+          getA11ySelectionMessage={{ onRemove: item => 'bla bla' }}
+        />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+      jest.runAllTimers()
+      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
+      removeIcon.simulate('click')
+      jest.runAllTimers()
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('')
     })
   })
 })

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -782,6 +782,10 @@ describe('Dropdown', () => {
   })
 
   describe('getA11ySelectionMessage', () => {
+    afterEach(() => {
+      jest.runAllTimers()
+    })
+
     it('creates message container element', () => {
       mountWithProvider(<Dropdown options={[]} getA11ySelectionMessage={{}} />)
       expect(
@@ -789,6 +793,82 @@ describe('Dropdown', () => {
           `[role="status"][aria-live="polite"][aria-relevant="additions text"]`,
         ),
       ).toBeTruthy()
+    })
+
+    it('has the onAdd message inserted after an item has been added to selection', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown
+          multiple
+          items={items}
+          getA11ySelectionMessage={{ onAdd: item => 'bla bla added' }}
+        />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla added')
+    })
+
+    it('has the onRemove message inserted after an item has been removed from selection', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown
+          multiple
+          items={items}
+          getA11ySelectionMessage={{ onRemove: item => 'bla bla removed' }}
+        />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+      jest.runAllTimers()
+      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
+      removeIcon.simulate('click')
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla removed')
+    })
+
+    it('has the onAdd message cleared after being displayed', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown multiple items={items} getA11ySelectionMessage={{ onAdd: item => 'bla bla' }} />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+
+      jest.runAllTimers()
+      expect(dropdown.state('a11ySelectionStatus')).toBe('')
+    })
+
+    it('has the onRemove message cleared after being displayed', () => {
+      const wrapper = mountWithProvider(
+        <Dropdown
+          multiple
+          items={items}
+          getA11ySelectionMessage={{ onRemove: item => 'bla bla' }}
+        />,
+      )
+      const dropdown = wrapper.find(Dropdown)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
+      firstItem.simulate('click')
+      jest.runAllTimers()
+      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
+      removeIcon.simulate('click')
+      jest.runAllTimers()
+
+      expect(dropdown.state('a11ySelectionStatus')).toBe('')
     })
   })
 
@@ -957,88 +1037,6 @@ describe('Dropdown', () => {
         .simulate('keydown', { keyCode: keyboardKey.Tab, key: 'Tab', preventDefault })
 
       expect(preventDefault).not.toBeCalled()
-    })
-  })
-
-  describe('getA11ySelectionMessage', () => {
-    afterEach(() => {
-      jest.runAllTimers()
-    })
-
-    it('has the onAdd message inserted after an item has been added to selection', () => {
-      const wrapper = mountWithProvider(
-        <Dropdown
-          multiple
-          items={items}
-          getA11ySelectionMessage={{ onAdd: item => 'bla bla added' }}
-        />,
-      )
-      const dropdown = wrapper.find(Dropdown)
-      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
-
-      triggerButton.simulate('click')
-      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
-
-      expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla added')
-    })
-
-    it('has the onRemove message inserted after an item has been removed from selection', () => {
-      const wrapper = mountWithProvider(
-        <Dropdown
-          multiple
-          items={items}
-          getA11ySelectionMessage={{ onRemove: item => 'bla bla removed' }}
-        />,
-      )
-      const dropdown = wrapper.find(Dropdown)
-      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
-
-      triggerButton.simulate('click')
-      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
-      jest.runAllTimers()
-      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
-      removeIcon.simulate('click')
-
-      expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla removed')
-    })
-
-    it('has the onAdd message cleared after being displayed', () => {
-      const wrapper = mountWithProvider(
-        <Dropdown multiple items={items} getA11ySelectionMessage={{ onAdd: item => 'bla bla' }} />,
-      )
-      const dropdown = wrapper.find(Dropdown)
-      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
-
-      triggerButton.simulate('click')
-      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
-
-      jest.runAllTimers()
-      expect(dropdown.state('a11ySelectionStatus')).toBe('')
-    })
-
-    it('has the onRemove message cleared after being displayed', () => {
-      const wrapper = mountWithProvider(
-        <Dropdown
-          multiple
-          items={items}
-          getA11ySelectionMessage={{ onRemove: item => 'bla bla' }}
-        />,
-      )
-      const dropdown = wrapper.find(Dropdown)
-      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
-
-      triggerButton.simulate('click')
-      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
-      jest.runAllTimers()
-      const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
-      removeIcon.simulate('click')
-      jest.runAllTimers()
-
-      expect(dropdown.state('a11ySelectionStatus')).toBe('')
     })
   })
 })


### PR DESCRIPTION
Clear the text added in the aria live container, so that virtual cursor will not read it afterwards.

Works only for the text that is added on add and on remove, in multiple selection cases. Should fix our issue for now. The other status text is generated by Downshift, will need to fix it as well in the future.