### PR TITLE
fix(Chat): update ChatMessage styles in Teams themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Update `ChatMessage` styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
+
 <!--------------------------------[ v0.29.0 ]------------------------------- -->
 ## [v0.29.0](https://github.com/stardust-ui/react/tree/v0.29.0) (2019-04-24)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.28.1...v0.29.0)
@@ -27,7 +30,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix onClick in `DropdownItem` to accept user callback and have its event propagation stopped @silviuavram ([#1248](https://github.com/stardust-ui/react/pull/1248))
 - Fix a11y message cleanup for add and remove items in `Dropdown` @silviuavram ([#1237](https://github.com/stardust-ui/react/pull/1237))
-- Update `ChatMessage` styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
 
 ### Features
 - Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
+### Fixes
+- Update `ChatMessage` styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
+
 ### Features
 - Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
@@ -46,7 +49,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Simplify DOM structure in `List` component when not all slot are defined @layershifter ([#1218](https://github.com/stardust-ui/react/pull/1218))
 - `Menu` as `Toolbar` - left/right arrow keys should not activate prev/next parent when focus in in the toolbar submenu @sophieH29 ([#1199](https://github.com/stardust-ui/react/pull/1199))
 - Add `isFromKeyboard` to `Alert` component @layershifter ([#1238](https://github.com/stardust-ui/react/pull/1238))
-- Update ChatMessage styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
 
 ### Features
 - Add `Embed` and `Video` components @stuartlong ([#1108](https://github.com/stardust-ui/react/pull/1108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Simplify DOM structure in `List` component when not all slot are defined @layershifter ([#1218](https://github.com/stardust-ui/react/pull/1218))
 - `Menu` as `Toolbar` - left/right arrow keys should not activate prev/next parent when focus in in the toolbar submenu @sophieH29 ([#1199](https://github.com/stardust-ui/react/pull/1199))
 - Add `isFromKeyboard` to `Alert` component @layershifter ([#1238](https://github.com/stardust-ui/react/pull/1238))
+- Update ChatMessage styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
 
 ### Features
 - Add `Embed` and `Video` components @stuartlong ([#1108](https://github.com/stardust-ui/react/pull/1108))

--- a/docs/src/examples/components/Chat/Content/ChatExampleReactionGroup.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Content/ChatExampleReactionGroup.shorthand.tsx
@@ -1,7 +1,10 @@
 import { Avatar, Chat } from '@stardust-ui/react'
 import * as React from 'react'
 
-const reactions = [{ icon: 'thumbs up', content: '1K' }, { icon: 'thumbs down', content: 5 }]
+const reactions = [
+  { key: 'up', icon: 'thumbs up', content: '1K' },
+  { key: 'down', icon: 'thumbs down', content: 5 },
+]
 
 const items = [
   {
@@ -27,7 +30,7 @@ const items = [
     message: {
       content: (
         <Chat.Message
-          reactionGroup={[{ icon: 'thumbs up', content: '8' }]}
+          reactionGroup={[{ key: 'up', icon: 'thumbs up', content: '8' }]}
           content="I'm back!"
           author="John Doe"
           timestamp="Yesterday, 10:15 PM"

--- a/docs/src/examples/components/Chat/Content/ChatExampleReactionGroupMeReacting.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Content/ChatExampleReactionGroupMeReacting.shorthand.tsx
@@ -33,8 +33,8 @@ const items = [
     message: {
       content: (
         <Chat.Message
-          reactionGroup={{ items: reactions }}
-          reactionGroupPosition={'end'}
+          reactionGroup={reactions}
+          reactionGroupPosition="end"
           content="I'm back!"
           author="John Doe"
           timestamp="Yesterday, 10:15 PM"
@@ -50,9 +50,7 @@ const items = [
     message: {
       content: (
         <Chat.Message
-          reactionGroup={{
-            items: reactions,
-          }}
+          reactionGroup={reactions}
           content="Hi"
           author="Jane Doe"
           timestamp="Yesterday, 10:15 PM"

--- a/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { Avatar, Chat, Provider } from '@stardust-ui/react'
 
-const reactions = [{ icon: 'thumbs up', content: '1K' }, { icon: 'thumbs down', content: 5 }]
+const reactions = [
+  { key: 'up', icon: 'thumbs up', content: '1K' },
+  { key: 'down', icon: 'thumbs down', content: 5 },
+]
 
 const janeAvatar = {
   image: 'public/images/avatar/small/ade.jpg',

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -121,7 +121,10 @@ class ChatMessage extends UIComponent<ReactProps<ChatMessageProps>, ChatMessageS
     timestamp: customPropTypes.itemShorthand,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
-    reactionGroup: customPropTypes.itemShorthand,
+    reactionGroup: PropTypes.oneOfType([
+      customPropTypes.collectionShorthand,
+      customPropTypes.itemShorthand,
+    ]),
     reactionGroupPosition: PropTypes.oneOf(['start', 'end']),
   }
 

--- a/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -4,7 +4,7 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
   return {
     backgroundColor: siteVars.gray10,
     backgroundColorMine: '#3B3C54',
-    authorColor: siteVars.gray02,
+    authorColor: siteVars.gray02, // will be gray[250] with new palette
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
     contentFocusOutlineColor: siteVars.brand,

--- a/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -4,6 +4,8 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
   return {
     backgroundColor: siteVars.gray10,
     backgroundColorMine: '#3B3C54',
+    authorColor: siteVars.gray02,
+    contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
     contentFocusOutlineColor: siteVars.brand,
     hasMentionNubbinColor: siteVars.naturalColors.orange[900], // orange[300] when the new palette pr is checked in

--- a/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
@@ -4,6 +4,8 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
   return {
     backgroundColor: siteVars.black,
     backgroundColorMine: siteVars.black,
+    authorColor: siteVars.white,
+    contentColor: siteVars.white,
     color: siteVars.white,
     contentFocusOutlineColor: siteVars.colors.yellow[900], // Red flag (should this be accessibleYellow?)
     border: `1px solid ${siteVars.white}`,

--- a/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -93,6 +93,7 @@ const chatMessageStyles: ComponentSlotStylesInput<
 
   author: ({ props: p, variables: v }): ICSSInJSStyle => ({
     ...((p.mine || p.attached === 'bottom' || p.attached === true) && screenReaderContainerStyles),
+    color: v.authorColor,
     marginRight: v.authorMarginRight,
     marginBottom: v.headerMarginBottom,
     fontWeight: v.authorFontWeight,
@@ -109,6 +110,7 @@ const chatMessageStyles: ComponentSlotStylesInput<
   }),
 
   content: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    color: v.contentColor,
     display: 'block',
     '& a:focus': {
       outline: 'none',

--- a/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -11,8 +11,10 @@ export interface ChatMessageVariables {
   offset: string
   padding: string
   authorMarginRight: string
+  authorColor: string
   authorFontWeight: number
   headerMarginBottom: string
+  contentColor: string
   contentFocusOutlineColor: string
   border: string
   badgeShadow: string
@@ -37,8 +39,10 @@ export default (siteVars): ChatMessageVariables => ({
   offset: pxToRem(100),
   padding: pxToRem(16),
   authorMarginRight: pxToRem(12),
-  authorFontWeight: siteVars.fontWeightBold,
+  authorColor: siteVars.gray02,
+  authorFontWeight: siteVars.fontWeightRegular,
   headerMarginBottom: pxToRem(2),
+  contentColor: siteVars.colors.grey[900],
   contentFocusOutlineColor: siteVars.colors.primary[500],
   border: 'none',
   badgeShadow: siteVars.shadowLevel1Darker,

--- a/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -39,10 +39,10 @@ export default (siteVars): ChatMessageVariables => ({
   offset: pxToRem(100),
   padding: pxToRem(16),
   authorMarginRight: pxToRem(12),
-  authorColor: siteVars.gray02,
+  authorColor: siteVars.gray02, // will be gray[500] with new palette
   authorFontWeight: siteVars.fontWeightRegular,
   headerMarginBottom: pxToRem(2),
-  contentColor: siteVars.colors.grey[900],
+  contentColor: '#252423', // will be gray[750] with new palette
   contentFocusOutlineColor: siteVars.colors.primary[500],
   border: 'none',
   badgeShadow: siteVars.shadowLevel1Darker,


### PR DESCRIPTION
This PR:
- updates styles for `ChatMessage` in Teams, Teams Dark and Teams HC themes
- fixes propTypes warnings in examples

---

### Teams theme

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/14183168/56494795-2bbf3c00-64fc-11e9-9787-281780c1032c.png) | ![image](https://user-images.githubusercontent.com/14183168/56494804-3083f000-64fc-11e9-9e9d-3ff819364df3.png) |

### Teams Dark theme

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/14183168/56494822-3f6aa280-64fc-11e9-825e-a5eab9dea8ee.png) | ![image](https://user-images.githubusercontent.com/14183168/56494831-472a4700-64fc-11e9-961f-3babea7b7ad7.png) |

### Teams HC theme 

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/14183168/56494853-5a3d1700-64fc-11e9-8748-fdf6e5f84f95.png) | ![image](https://user-images.githubusercontent.com/14183168/56494856-6032f800-64fc-11e9-8235-43f9bebc8835.png) |


