### PR TITLE
feat(Input): move styles to Base theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
+
+### Features
+- Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
+
 <!--------------------------------[ v0.28.1 ]------------------------------- -->
 ## [v0.28.1](https://github.com/stardust-ui/react/tree/v0.28.1) (2019-04-23)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.28.0...v0.28.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING CHANGES
 - Add `box-sizing: border-box` to all elements, as well as before and after pseudo elements in Teams theme @mnajdova ([#1057](https://github.com/stardust-ui/react/pull/1057))
-- Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
 ### Fixes
 - Fix overflowing focus outline for `Grid` items for Teams theme @Bugaa92 ([#1195](https://github.com/stardust-ui/react/pull/1195))
@@ -47,7 +46,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Simplify DOM structure in `List` component when not all slot are defined @layershifter ([#1218](https://github.com/stardust-ui/react/pull/1218))
 - `Menu` as `Toolbar` - left/right arrow keys should not activate prev/next parent when focus in in the toolbar submenu @sophieH29 ([#1199](https://github.com/stardust-ui/react/pull/1199))
 - Add `isFromKeyboard` to `Alert` component @layershifter ([#1238](https://github.com/stardust-ui/react/pull/1238))
-- Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
 ### Features
 - Add `Embed` and `Video` components @stuartlong ([#1108](https://github.com/stardust-ui/react/pull/1108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING CHANGES
 - Add `box-sizing: border-box` to all elements, as well as before and after pseudo elements in Teams theme @mnajdova ([#1057](https://github.com/stardust-ui/react/pull/1057))
+- Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
 ### Fixes
 - Fix overflowing focus outline for `Grid` items for Teams theme @Bugaa92 ([#1195](https://github.com/stardust-ui/react/pull/1195))
@@ -30,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Simplify DOM structure in `List` component when not all slot are defined @layershifter ([#1218](https://github.com/stardust-ui/react/pull/1218))
 - `Menu` as `Toolbar` - left/right arrow keys should not activate prev/next parent when focus in in the toolbar submenu @sophieH29 ([#1199](https://github.com/stardust-ui/react/pull/1199))
 - Add `isFromKeyboard` to `Alert` component @layershifter ([#1238](https://github.com/stardust-ui/react/pull/1238))
+- Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
 ### Features
 - Add `Embed` and `Video` components @stuartlong ([#1108](https://github.com/stardust-ui/react/pull/1108))

--- a/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
@@ -2,6 +2,7 @@ import { Input } from '@stardust-ui/react'
 
 const config: ScreenerTestsConfig = {
   steps: [builder => builder.focus(`.${Input.className} input`).snapshot('Can be focused')],
+  themes: ['base', 'teams', 'teamsDark', 'teamsHighContrast'],
 }
 
 export default config

--- a/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
@@ -2,7 +2,7 @@ import { Input } from '@stardust-ui/react'
 
 const config: ScreenerTestsConfig = {
   steps: [builder => builder.focus(`.${Input.className} input`).snapshot('Can be focused')],
-  themes: ['base', 'teams', 'teamsDark', 'teamsHighContrast'],
+  themes: ['teams', 'base'],
 }
 
 export default config

--- a/docs/src/examples/components/Input/Variations/InputExampleClearable.shorthand.steps.ts
+++ b/docs/src/examples/components/Input/Variations/InputExampleClearable.shorthand.steps.ts
@@ -1,0 +1,11 @@
+import { Input } from '@stardust-ui/react'
+
+const config: ScreenerTestsConfig = {
+  steps: [
+    builder =>
+      builder.setValue(`.${Input.className} input`, 'Some text...').snapshot('Can be clearable'),
+  ],
+  themes: ['teams', 'base'],
+}
+
+export default config

--- a/packages/react/src/themes/base/componentStyles.ts
+++ b/packages/react/src/themes/base/componentStyles.ts
@@ -5,6 +5,8 @@ export { default as FlexItem } from './components/Flex/flexItemStyles'
 
 export { default as Icon } from './components/Icon/iconStyles'
 
+export { default as Input } from './components/Input/inputStyles'
+
 export { default as Loader } from './components/Loader/loaderStyles'
 
 export { default as ProviderBox } from './components/Provider/providerBoxStyles'

--- a/packages/react/src/themes/base/componentVariables.ts
+++ b/packages/react/src/themes/base/componentVariables.ts
@@ -5,6 +5,8 @@ export { default as FlexItem } from './components/Flex/flexItemVariables'
 
 export { default as Icon } from './components/Icon/iconVariables'
 
+export { default as Input } from './components/Input/inputVariables'
+
 export { default as Loader } from './components/Loader/loaderVariables'
 
 export { default as ProviderBox } from './components/Provider/providerBoxVariables'

--- a/packages/react/src/themes/base/components/Input/inputStyles.ts
+++ b/packages/react/src/themes/base/components/Input/inputStyles.ts
@@ -5,30 +5,36 @@ import { PositionProperty } from 'csstype'
 
 const inputStyles: ComponentSlotStylesInput<InputProps, InputVariables> = {
   root: ({ props: p }): ICSSInJSStyle => ({
+    alignItems: 'center',
     display: 'inline-flex',
     position: 'relative',
-    alignItems: 'center',
     outline: 0,
+
     ...(p.fluid && { width: '100%' }),
   }),
 
   input: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    outline: 0,
-    borderStyle: 'solid',
-    borderColor: 'transparent',
-    borderWidth: v.borderWidth,
-    borderRadius: v.borderRadius,
-    color: v.fontColor,
     backgroundColor: v.backgroundColor,
-    position: 'relative',
+    color: v.fontColor,
+
+    borderColor: v.borderColor,
+    borderRadius: v.borderRadius,
+    borderStyle: 'solid',
+    borderWidth: v.borderWidth,
+
+    outline: 0,
     padding: v.inputPadding,
+    position: 'relative',
+
     ...(p.fluid && { width: '100%' }),
     ...(p.inline && { float: 'left' }),
+
     '::placeholder': {
       color: v.placeholderColor,
     },
+
     ':focus': {
-      borderBottomColor: v.inputFocusBorderBottomColor,
+      borderColor: v.inputFocusBorderColor,
     },
     ...(p.clearable && { padding: v.inputPaddingWithIconAtEnd }),
     ...(p.icon && {
@@ -37,16 +43,17 @@ const inputStyles: ComponentSlotStylesInput<InputProps, InputVariables> = {
     }),
   }),
 
-  icon: ({ props: { iconPosition }, variables: v }): ICSSInJSStyle => ({
-    position: v.iconPosition as PositionProperty,
+  icon: ({ props: p, variables: v }): ICSSInJSStyle => ({
     color: v.iconColor,
-    ...(iconPosition === 'start' && {
+    outline: 0,
+    position: v.iconPosition as PositionProperty,
+
+    ...(p.iconPosition === 'start' && {
       left: v.iconLeft,
     }),
-    ...(iconPosition === 'end' && {
+    ...(p.iconPosition === 'end' && {
       right: v.iconRight,
     }),
-    outline: 0,
   }),
 }
 

--- a/packages/react/src/themes/base/components/Input/inputVariables.ts
+++ b/packages/react/src/themes/base/components/Input/inputVariables.ts
@@ -1,0 +1,43 @@
+import { pxToRem } from '../../../../lib'
+
+export interface InputVariables {
+  backgroundColor: string
+  borderColor: string
+  borderRadius: string
+  borderWidth: string
+  fontColor: string
+  fontSize: string
+  iconColor: string
+  iconPosition: string
+  iconRight: string
+  iconLeft: string
+  inputPaddingWithIconAtStart: string
+  inputPaddingWithIconAtEnd: string
+  inputPadding: string
+  inputFocusBorderColor: string
+  inputFocusBorderRadius: string
+  placeholderColor: string
+}
+
+export default (siteVars): InputVariables => ({
+  backgroundColor: siteVars.colors.grey[50],
+  borderColor: siteVars.colors.grey[300],
+  borderRadius: `${pxToRem(3)} ${pxToRem(2)}`,
+  borderWidth: `1px`,
+
+  fontColor: siteVars.colors.grey[600],
+  fontSize: pxToRem(14),
+
+  iconPosition: 'absolute',
+  iconRight: pxToRem(10),
+  iconColor: siteVars.colors.grey[800],
+  iconLeft: pxToRem(6),
+  inputPaddingWithIconAtStart: `${pxToRem(7)} ${pxToRem(12)} ${pxToRem(7)} ${pxToRem(24)}`,
+  inputPaddingWithIconAtEnd: `${pxToRem(7)} ${pxToRem(24)} ${pxToRem(7)} ${pxToRem(12)}`,
+
+  inputPadding: `${pxToRem(7)} ${pxToRem(12)}`,
+  inputFocusBorderColor: siteVars.colors.primary[300],
+  inputFocusBorderRadius: `${pxToRem(3)} ${pxToRem(2)}`,
+
+  placeholderColor: siteVars.colors.grey[600],
+})

--- a/packages/react/src/themes/base/components/Input/inputVariables.ts
+++ b/packages/react/src/themes/base/components/Input/inputVariables.ts
@@ -22,7 +22,7 @@ export interface InputVariables {
 export default (siteVars): InputVariables => ({
   backgroundColor: siteVars.colors.grey[50],
   borderColor: siteVars.colors.grey[300],
-  borderRadius: `${pxToRem(3)} ${pxToRem(2)}`,
+  borderRadius: pxToRem(3),
   borderWidth: `1px`,
 
   fontColor: siteVars.colors.grey[600],
@@ -37,7 +37,7 @@ export default (siteVars): InputVariables => ({
 
   inputPadding: `${pxToRem(7)} ${pxToRem(12)}`,
   inputFocusBorderColor: siteVars.colors.primary[300],
-  inputFocusBorderRadius: `${pxToRem(3)} ${pxToRem(2)}`,
+  inputFocusBorderRadius: pxToRem(3),
 
   placeholderColor: siteVars.colors.grey[600],
 })

--- a/packages/react/src/themes/teams/componentStyles.ts
+++ b/packages/react/src/themes/teams/componentStyles.ts
@@ -34,8 +34,6 @@ export { default as HeaderDescription } from './components/Header/headerDescript
 
 export { default as Icon } from './components/Icon/iconStyles'
 
-export { default as Input } from './components/Input/inputStyles'
-
 export { default as Label } from './components/Label/labelStyles'
 
 export { default as Layout } from './components/Layout/layoutStyles'

--- a/packages/react/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/react/src/themes/teams/components/Input/inputVariables.ts
@@ -1,41 +1,15 @@
+import { InputVariables } from '../../../base/components/Input/inputVariables'
 import { pxToRem } from '../../../../lib'
 
-export interface InputVariables {
-  backgroundColor: string
-  borderRadius: string
-  borderWidth: string
-  fontColor: string
-  fontSize: string
-  iconColor: string
-  iconPosition: string
-  iconRight: string
-  iconLeft: string
-  inputPaddingWithIconAtStart: string
-  inputPaddingWithIconAtEnd: string
-  inputPadding: string
-  inputFocusBorderBottomColor: string
-  inputFocusBorderRadius: string
-  placeholderColor: string
-}
-
-export default (siteVars): InputVariables => ({
-  backgroundColor: siteVars.gray10,
-  borderRadius: `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`,
+export default (siteVars): Partial<InputVariables> => ({
+  borderColor: 'transparent',
   borderWidth: `0 0 ${pxToRem(2)} 0`,
+  backgroundColor: siteVars.gray10,
 
   fontColor: siteVars.gray02,
   fontSize: siteVars.fontSizes.medium,
 
-  iconPosition: 'absolute',
-  iconRight: pxToRem(10),
   iconColor: siteVars.bodyColor,
-  iconLeft: pxToRem(6),
-  inputPaddingWithIconAtStart: `${pxToRem(7)} ${pxToRem(12)} ${pxToRem(7)} ${pxToRem(24)}`,
-  inputPaddingWithIconAtEnd: `${pxToRem(7)} ${pxToRem(24)} ${pxToRem(7)} ${pxToRem(12)}`,
-
-  inputPadding: `${pxToRem(7)} ${pxToRem(12)}`,
-  inputFocusBorderBottomColor: siteVars.colors.primary[500],
-  inputFocusBorderRadius: `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`,
-
+  inputFocusBorderColor: `transparent transparent ${siteVars.colors.primary[500]} transparent`,
   placeholderColor: siteVars.gray02,
 })

--- a/packages/react/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/react/src/themes/teams/components/Input/inputVariables.ts
@@ -3,6 +3,7 @@ import { pxToRem } from '../../../../lib'
 
 export default (siteVars): Partial<InputVariables> => ({
   borderColor: 'transparent',
+  borderRadius: `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`,
   borderWidth: `0 0 ${pxToRem(2)} 0`,
   backgroundColor: siteVars.gray10,
 
@@ -11,5 +12,6 @@ export default (siteVars): Partial<InputVariables> => ({
 
   iconColor: siteVars.bodyColor,
   inputFocusBorderColor: `transparent transparent ${siteVars.colors.primary[500]} transparent`,
+  inputFocusBorderRadius: `${pxToRem(3)} ${pxToRem(3)} ${pxToRem(2)} ${pxToRem(2)}`,
   placeholderColor: siteVars.gray02,
 })


### PR DESCRIPTION
This PR moves `Input` styles to Base theme.

# BREAKING CHANGES

In `InputVariables` the `inputFocusBorderBottomColor` variables was renamed to `inputFocusBorderColor`. It allows to customize all borders instead of only `bottom`.

### Before

```
inputFocusBorderBottomColor: 'red',
```

### After
```
inputFocusBorderColor: 'transparent transparent red transparent`,
```