### PR TITLE
fix(Dropdown): added onClick override on DropdownItem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
 
 ### Fixes
-- Fix override onClick in shorthand for `DropdownItem` @silviuavram ([#1248](https://github.com/stardust-ui/react/pull/1248))
+- Fix onClick in `DropdownItem` to accept user callback and have its event propagation stopped @silviuavram ([#1248](https://github.com/stardust-ui/react/pull/1248))
 
 ### Features
 - Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixes
-
-- Fix override onClick in shorthand for `DropdownItem` @silviuavram ([#1248](https://github.com/stardust-ui/react/pull/1248))
 
 ### BREAKING CHANGES
 - Rename `inputFocusBorderBottomColor` to `inputFocusBorderColor` in `InputVariables` @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
+
+### Fixes
+- Fix override onClick in shorthand for `DropdownItem` @silviuavram ([#1248](https://github.com/stardust-ui/react/pull/1248))
 
 ### Features
 - Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+
+- Fix override onClick in shorthand for `DropdownItem` @silviuavram ([#1248](https://github.com/stardust-ui/react/pull/1248))
 
 ### BREAKING CHANGES
 - Add `box-sizing: border-box` to all elements, as well as before and after pseudo elements in Teams theme @mnajdova ([#1057](https://github.com/stardust-ui/react/pull/1057))

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -504,16 +504,14 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
         variables,
         inputRef: this.inputRef,
       },
-      overrideProps: (predefinedProps: DropdownSearchInputProps) =>
-        this.handleSearchInputOverrides(
-          predefinedProps,
-          highlightedIndex,
-          rtl,
-          selectItemAtIndex,
-          toggleMenu,
-          accessibilityComboboxProps,
-          getInputProps,
-        ),
+      overrideProps: this.handleSearchInputOverrides(
+        highlightedIndex,
+        rtl,
+        selectItemAtIndex,
+        toggleMenu,
+        accessibilityComboboxProps,
+        getInputProps,
+      ),
     })
   }
 
@@ -590,8 +588,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
               key: (item as any).header,
             }),
         },
-        overrideProps: (predefinedProps: DropdownItemProps) =>
-          this.handleItemOverrides(predefinedProps, item, index, getItemProps),
+        overrideProps: this.handleItemOverrides(item, index, getItemProps),
         render: renderItem,
       }),
     )
@@ -633,8 +630,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
               key: (item as any).header,
             }),
         },
-        overrideProps: (predefinedProps: DropdownSelectedItemProps) =>
-          this.handleSelectedItemOverrides(predefinedProps, item, rtl),
+        overrideProps: this.handleSelectedItemOverrides(item, rtl),
         render: renderSelectedItem,
       }),
     )
@@ -714,24 +710,22 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   }
 
   private handleItemOverrides = (
-    predefinedProps: DropdownItemProps,
     item: ShorthandValue,
     index: number,
     getItemProps: (options: GetItemPropsOptions<ShorthandValue>) => any,
-  ) => ({
+  ) => (predefinedProps: DropdownItemProps) => ({
     accessibilityItemProps: getItemProps({
       item,
       index,
       onClick: e => {
+        e.stopPropagation()
         _.invoke(predefinedProps, 'onClick', e, predefinedProps)
       },
     }),
   })
 
-  private handleSelectedItemOverrides = (
+  private handleSelectedItemOverrides = (item: ShorthandValue, rtl: boolean) => (
     predefinedProps: DropdownSelectedItemProps,
-    item: ShorthandValue,
-    rtl: boolean,
   ) => ({
     onRemove: (e: React.SyntheticEvent, dropdownSelectedItemProps: DropdownSelectedItemProps) => {
       this.handleSelectedItemRemove(e, item, predefinedProps, dropdownSelectedItemProps)
@@ -749,7 +743,6 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   })
 
   private handleSearchInputOverrides = (
-    predefinedProps: DropdownSearchInputProps,
     highlightedIndex: number,
     rtl: boolean,
     selectItemAtIndex: (
@@ -760,7 +753,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     toggleMenu: () => void,
     accessibilityComboboxProps: Object,
     getInputProps: (options?: GetInputPropsOptions) => any,
-  ) => {
+  ) => (predefinedProps: DropdownSearchInputProps) => {
     const handleInputBlur = (
       e: React.SyntheticEvent,
       searchInputProps: DropdownSearchInputProps,
@@ -1028,7 +1021,6 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
     this.removeItemFromValue(item)
     this.tryFocusSearchInput()
     this.tryFocusTriggerButton()
-    e.stopPropagation()
     _.invoke(predefinedProps, 'onRemove', e, DropdownSelectedItemProps)
   }
 

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -32,7 +32,7 @@ import {
 } from '../../lib'
 import List from '../List/List'
 import Ref from '../Ref/Ref'
-import DropdownItem from './DropdownItem'
+import DropdownItem, { DropdownItemProps } from './DropdownItem'
 import DropdownSelectedItem, { DropdownSelectedItemProps } from './DropdownSelectedItem'
 import DropdownSearchInput, { DropdownSearchInputProps } from './DropdownSearchInput'
 import Button from '../Button/Button'
@@ -590,7 +590,8 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
               key: (item as any).header,
             }),
         },
-        overrideProps: () => this.handleItemOverrides(item, index, getItemProps),
+        overrideProps: (predefinedProps: DropdownItemProps) =>
+          this.handleItemOverrides(predefinedProps, item, index, getItemProps),
         render: renderItem,
       }),
     )
@@ -713,10 +714,25 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
   }
 
   private handleItemOverrides = (
+    predefinedProps: DropdownItemProps,
     item: ShorthandValue,
     index: number,
     getItemProps: (options: GetItemPropsOptions<ShorthandValue>) => any,
-  ) => ({ accessibilityItemProps: getItemProps({ item, index }) })
+  ) => ({
+    accessibilityItemProps: getItemProps({
+      item,
+      index,
+      onClick: e => {
+        _.invoke(predefinedProps, 'onClick', e, predefinedProps)
+      },
+      onMouseDown: e => {
+        _.invoke(predefinedProps, 'onMouseDown', e, predefinedProps)
+      },
+      onMouseMove: e => {
+        _.invoke(predefinedProps, 'onMouseMove', e, predefinedProps)
+      },
+    }),
+  })
 
   private handleSelectedItemOverrides = (
     predefinedProps: DropdownSelectedItemProps,

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -719,6 +719,7 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
       index,
       onClick: e => {
         e.stopPropagation()
+        e.nativeEvent.stopImmediatePropagation()
         _.invoke(predefinedProps, 'onClick', e, predefinedProps)
       },
     }),

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -725,12 +725,6 @@ class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, Dropdo
       onClick: e => {
         _.invoke(predefinedProps, 'onClick', e, predefinedProps)
       },
-      onMouseDown: e => {
-        _.invoke(predefinedProps, 'onMouseDown', e, predefinedProps)
-      },
-      onMouseMove: e => {
-        _.invoke(predefinedProps, 'onMouseMove', e, predefinedProps)
-      },
     }),
   })
 

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -6,7 +6,7 @@ import Dropdown from 'src/components/Dropdown/Dropdown'
 import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
 import { isConformant } from 'test/specs/commonTests'
 import { mountWithProvider } from 'test/utils'
-import { DropdownSelectedItem } from '@stardust-ui/react/src'
+import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
 
 jest.dontMock('keyboard-key')
 

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -808,7 +808,7 @@ describe('Dropdown', () => {
 
       triggerButton.simulate('click')
       const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
+      firstItem.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(dropdown.state('a11ySelectionStatus')).toBe('bla bla added')
 
@@ -830,7 +830,7 @@ describe('Dropdown', () => {
 
       triggerButton.simulate('click')
       const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
+      firstItem.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
       jest.runAllTimers()
       const removeIcon = wrapper.find(`span.${DropdownSelectedItem.slotClassNames.icon}`)
       removeIcon.simulate('click')

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -7,7 +7,6 @@ import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
 import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
 import { isConformant } from 'test/specs/commonTests'
 import { mountWithProvider } from 'test/utils'
-import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
 
 jest.dontMock('keyboard-key')
 jest.useFakeTimers()

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -6,6 +6,7 @@ import Dropdown from 'src/components/Dropdown/Dropdown'
 import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
 import { isConformant } from 'test/specs/commonTests'
 import { mountWithProvider } from 'test/utils'
+import { DropdownSelectedItem } from '@stardust-ui/react/src'
 
 jest.dontMock('keyboard-key')
 
@@ -955,6 +956,40 @@ describe('Dropdown', () => {
         .simulate('keydown', { keyCode: keyboardKey.Tab, key: 'Tab', preventDefault })
 
       expect(preventDefault).not.toBeCalled()
+    })
+  })
+
+  describe('items', () => {
+    it('have onClick called when passed stop event from being propagated', () => {
+      const onClick = jest.fn()
+      const stopPropagation = jest.fn()
+      const mockedEvent = { stopPropagation }
+      const items = [{ header: 'Venom', onClick }]
+      const wrapper = mountWithProvider(<Dropdown items={items} />)
+      const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
+
+      triggerButton.simulate('click')
+      const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`)
+      firstItem.simulate('click', mockedEvent)
+
+      expect(onClick).toBeCalledTimes(1)
+      expect(stopPropagation).toBeCalledTimes(1)
+    })
+
+    it('when selected have onClick called when passed stop event from being propagated', () => {
+      const onClick = jest.fn()
+      const stopPropagation = jest.fn()
+      const mockedEvent = { stopPropagation }
+      const items = [{ header: 'Venom', onClick }]
+      const wrapper = mountWithProvider(<Dropdown items={items} value={items} multiple />)
+      const selectedItemHeaderAtIndex0 = wrapper
+        .find(`span.${DropdownSelectedItem.slotClassNames.header}`)
+        .at(0)
+
+      selectedItemHeaderAtIndex0.simulate('click', mockedEvent)
+
+      expect(onClick).toBeCalledTimes(1)
+      expect(stopPropagation).toBeCalledTimes(1)
     })
   })
 })

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -973,6 +973,12 @@ describe('Dropdown', () => {
       firstItem.simulate('click', mockedEvent)
 
       expect(onClick).toBeCalledTimes(1)
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining(mockedEvent),
+        expect.objectContaining({
+          header: 'Venom',
+        }),
+      )
       expect(stopPropagation).toBeCalledTimes(1)
     })
 
@@ -989,6 +995,12 @@ describe('Dropdown', () => {
       selectedItemHeaderAtIndex0.simulate('click', mockedEvent)
 
       expect(onClick).toBeCalledTimes(1)
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining(mockedEvent),
+        expect.objectContaining({
+          header: 'Venom',
+        }),
+      )
       expect(stopPropagation).toBeCalledTimes(1)
     })
   })

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -103,7 +103,7 @@ describe('Dropdown', () => {
 
       triggerButton.simulate('click')
       const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
+      firstItem.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(onOpenChange).toBeCalledTimes(2)
       expect(onOpenChange).toHaveBeenLastCalledWith(
@@ -629,7 +629,7 @@ describe('Dropdown', () => {
 
       triggerButton.simulate('click')
       const item = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(itemSelectedIndex)
-      item.simulate('click')
+      item.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(onSelectedChange).toHaveBeenCalledTimes(1)
       expect(onSelectedChange).toHaveBeenCalledWith(
@@ -715,10 +715,10 @@ describe('Dropdown', () => {
 
       triggerButton.simulate('click')
       const firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(1)
-      firstItem.simulate('click')
+      firstItem.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
       triggerButton.simulate('click')
       const itemAtIndex = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(itemSelectedIndex)
-      itemAtIndex.simulate('click')
+      itemAtIndex.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(onSelectedChange).toHaveBeenCalledTimes(2)
       expect(onSelectedChange).toHaveBeenLastCalledWith(
@@ -738,10 +738,10 @@ describe('Dropdown', () => {
 
       triggerButton.simulate('click')
       const itemAtIndex1 = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(1)
-      itemAtIndex1.simulate('click')
+      itemAtIndex1.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
       triggerButton.simulate('click')
       const itemAtIndex2 = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(3)
-      itemAtIndex2.simulate('click')
+      itemAtIndex2.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(onSelectedChange).toHaveBeenCalledTimes(2)
       expect(onSelectedChange).toHaveBeenLastCalledWith(
@@ -762,10 +762,10 @@ describe('Dropdown', () => {
 
       toggleIndicator.simulate('click')
       let firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
+      firstItem.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
       toggleIndicator.simulate('click')
       firstItem = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(0)
-      firstItem.simulate('click')
+      firstItem.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
       searchInput
         .simulate('click')
         .simulate('keydown', { keyCode: keyboardKey.Backspace, key: 'Backspace' })
@@ -814,7 +814,7 @@ describe('Dropdown', () => {
 
       toggleIndicator.simulate('click')
       const itemAtIndex = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(itemSelectedIndex)
-      itemAtIndex.simulate('click')
+      itemAtIndex.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(onSelectedChange).toHaveBeenCalledTimes(1)
       expect(onSelectedChange).toHaveBeenCalledWith(
@@ -857,7 +857,7 @@ describe('Dropdown', () => {
 
       toggleIndicator.simulate('click')
       const itemAtIndex = wrapper.find(`li.${Dropdown.slotClassNames.item}`).at(itemSelectedIndex)
-      itemAtIndex.simulate('click')
+      itemAtIndex.simulate('click', { nativeEvent: { stopImmediatePropagation: jest.fn() } })
 
       expect(onSelectedChange).toHaveBeenCalledTimes(1)
       expect(onSelectedChange).toHaveBeenCalledWith(
@@ -963,7 +963,8 @@ describe('Dropdown', () => {
     it('have onClick called when passed stop event from being propagated', () => {
       const onClick = jest.fn()
       const stopPropagation = jest.fn()
-      const mockedEvent = { stopPropagation }
+      const stopImmediatePropagation = jest.fn()
+      const mockedEvent = { stopPropagation, nativeEvent: { stopImmediatePropagation } }
       const items = [{ header: 'Venom', onClick }]
       const wrapper = mountWithProvider(<Dropdown items={items} />)
       const triggerButton = wrapper.find(`button.${Dropdown.slotClassNames.triggerButton}`)
@@ -980,12 +981,14 @@ describe('Dropdown', () => {
         }),
       )
       expect(stopPropagation).toBeCalledTimes(1)
+      expect(stopImmediatePropagation).toBeCalledTimes(1)
     })
 
     it('when selected have onClick called when passed stop event from being propagated', () => {
       const onClick = jest.fn()
       const stopPropagation = jest.fn()
-      const mockedEvent = { stopPropagation }
+      const stopImmediatePropagation = jest.fn()
+      const mockedEvent = { stopPropagation, nativeEvent: { stopImmediatePropagation } }
       const items = [{ header: 'Venom', onClick }]
       const wrapper = mountWithProvider(<Dropdown items={items} value={items} multiple />)
       const selectedItemHeaderAtIndex0 = wrapper


### PR DESCRIPTION
It allows supplying an override to onClick for a `DropdownItem`.

For now I am not sure if we want a default stopPropagation from our code, open to debate.