### PR TITLE
feat(Accessibility): Add roles to Popup's content in accessibility behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - Move `Input` styles to Base theme @layershifter ([#1247](https://github.com/stardust-ui/react/pull/1247))
+- Add `role` attribute to `Popup`'s content in accessibility behaviors @sophieH29 ([1253](https://github.com/stardust-ui/react/pull/1253))
 
 <!--------------------------------[ v0.28.1 ]------------------------------- -->
 ## [v0.28.1](https://github.com/stardust-ui/react/tree/v0.28.1) (2019-04-23)

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
@@ -8,6 +8,7 @@ import * as _ from 'lodash'
  *
  * @specification
  * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'role=complementary' to 'popup' component's part.
  */
 const popupBehavior: Accessibility = (props: any) => {
   const onAsArray = _.isArray(props.on) ? props.on : [props.on]
@@ -20,6 +21,9 @@ const popupBehavior: Accessibility = (props: any) => {
           : !!props['disabled']
           ? true
           : undefined,
+      },
+      popup: {
+        role: 'complementary',
       },
     },
     keyActions: {

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
@@ -9,6 +9,7 @@ import popupBehavior from './popupBehavior'
  * @specification
  * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
  * Adds attribute 'aria-modal=true' to 'popup' component's part.
+ * Adds attribute 'role=dialog' to 'popup' component's part.
  * Traps focus inside component.
  */
 const popupFocusTrapBehavior: Accessibility = (props: any) => {
@@ -16,6 +17,7 @@ const popupFocusTrapBehavior: Accessibility = (props: any) => {
   behaviorData.attributes.popup = {
     ...behaviorData.attributes.popup,
     'aria-modal': true,
+    role: 'dialog',
   }
   behaviorData.focusTrap = true
 


### PR DESCRIPTION
This PR enhances accessibility behaviors by setting correct role
- `popupBehavior`- role="complementary"
- `popupFocusTrapBehavior`- role="dialog"
