### PR TITLE
fix(List): fix propTypes warning in ListItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Update `ChatMessage` styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
+- Fix `propTypes` warning in `ListItem` styles in Teams themes @layershifter ([#1266](https://github.com/stardust-ui/react/pull/1266))
 
 <!--------------------------------[ v0.29.0 ]------------------------------- -->
 ## [v0.29.0](https://github.com/stardust-ui/react/tree/v0.29.0) (2019-04-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Update `ChatMessage` styles in Teams themes @layershifter ([#1246](https://github.com/stardust-ui/react/pull/1246))
-- Fix `propTypes` warning in `ListItem` styles in Teams themes @layershifter ([#1266](https://github.com/stardust-ui/react/pull/1266))
+- Fix `propTypes` warning in `ListItem` @layershifter ([#1266](https://github.com/stardust-ui/react/pull/1266))
 
 <!--------------------------------[ v0.29.0 ]------------------------------- -->
 ## [v0.29.0](https://github.com/stardust-ui/react/tree/v0.29.0) (2019-04-24)

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -178,7 +178,7 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>, ListItemState> {
       },
     })
 
-    const hasHeaderPart = headerElement || headerMediaElement
+    const hasHeaderPart = !!(headerElement || headerMediaElement)
     const headerPart = hasHeaderPart && (
       <>
         <Flex.Item grow>{headerElement}</Flex.Item>
@@ -186,7 +186,7 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>, ListItemState> {
       </>
     )
 
-    const hasContentPart = contentElement || contentMediaElement
+    const hasContentPart = !!(contentElement || contentMediaElement)
     const contentPart = hasContentPart && (
       <>
         <Flex.Item grow>{contentElement}</Flex.Item>


### PR DESCRIPTION
Picked from #1224.

Fixes this warning:
```
Warning: Failed prop type: Invalid prop `column` of type `object` supplied to `Flex`, expected `boolean`.
    in Flex (created by ListItem)
    in ListItem (created by List)
    in ul (created by List)
    in List (created by ListExampleSelectable)
```