### PR TITLE
feat(icon): export call-dialpad icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `propTypes` warning in `ListItem` @layershifter ([#1266](https://github.com/stardust-ui/react/pull/1266))
 - Expand css shorthands for correct merging of the styles @mnajdova ([#869](https://github.com/stardust-ui/react/pull/869))
 
+### Features
+- Export `call-dialpad` icon in Teams theme @assamad ([#1271](https://github.com/stardust-ui/react/pull/1271))
+
 <!--------------------------------[ v0.29.0 ]------------------------------- -->
 ## [v0.29.0](https://github.com/stardust-ui/react/tree/v0.29.0) (2019-04-24)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.28.1...v0.29.0)

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/callDialpad.tsx
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/callDialpad.tsx
@@ -8,5 +8,4 @@ export default {
     </svg>
   ),
   styles: {},
-  exportedAs: 'call-dialpad',
 } as TeamsProcessedSvgIconSpec

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
@@ -13,6 +13,7 @@ import calendar from './calendar'
 import call from './call'
 import callControlPresentNew from './callControlPresentNew'
 import callControlStopPresentingNew from './callControlStopPresentingNew'
+import callDialpad from './callDialpad'
 import callEnd from './callEnd'
 import callPstn from './callPstn'
 import callRecording from './callRecording'
@@ -123,6 +124,7 @@ export default {
   bullets,
   calendar,
   call,
+  'call-dialpad': callDialpad,
   'call-end': callEnd,
   'call-video': callVideo,
   'call-video-off': callVideoOff,


### PR DESCRIPTION
Introduces icon from the icon set of #1241

Export `call-dialpad` icon to Teams theme:

![image](https://user-images.githubusercontent.com/49996135/56768019-11869780-6762-11e9-954e-032b83e0beab.png)
