### PR TITLE
[DO NOT REVIEW] feat: add strict type checks for Stardust components' props

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
@@ -76,8 +76,6 @@ const ComponentControls: React.FC<ComponentControlsProps> = props => {
         {...rest}
         fluid
         color="green"
-        icon="labeled"
-        size="tiny"
         pills
         accessibility={toolbarBehavior}
         items={[

--- a/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -113,7 +113,7 @@ class ComponentDoc extends React.Component<any, any> {
                 <Flex.Item>
                   <Header
                     as="h1"
-                    aria-level="2"
+                    aria-level={2}
                     content={info.displayName}
                     variables={{ color: 'black' }}
                   />

--- a/docs/src/components/ComponentDoc/ComponentDocAccessibility.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDocAccessibility.tsx
@@ -21,7 +21,7 @@ const ComponentDocAccessibility = ({ info }) => {
     <Flex column>
       <Flex.Item>
         <>
-          <Header
+          <Header<'h2'>
             as="h2"
             className="no-anchor"
             content="Accessibility"

--- a/docs/src/components/ComponentDoc/ComponentDocSee.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDocSee.tsx
@@ -16,10 +16,10 @@ const ComponentDocSee: any = ({ displayName }) => {
     <List styles={listStyle}>
       {/* Heads up! Still render empty lists to reserve the whitespace */}
       <List.Item>
-        <Header color="grey" content={items.length > 0 ? 'See:' : ' '} size="tiny" />
+        <Header color="grey" content={items.length > 0 ? 'See:' : ' '} />
       </List.Item>
       {_.map(items, info => (
-        <List.Item
+        <List.Item<Link>
           as={Link}
           content={info.displayName}
           key={info.docblock.description}

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -406,7 +406,6 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
     return (
       <Menu
-        size="small"
         primary
         underlined
         activeIndex={-1}
@@ -438,10 +437,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
             } as React.CSSProperties
           }
         >
-          <Menu
-            size="small"
-            styles={{ display: 'flex', justifyContent: 'space-between', border: 'none' }}
-          >
+          <Menu styles={{ display: 'flex', justifyContent: 'space-between', border: 'none' }}>
             {this.renderAPIsMenu()}
             {this.renderLanguagesMenu()}
           </Menu>
@@ -459,7 +455,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       <SourceRender.Consumer>
         {({ error }) =>
           error && (
-            <Segment inverted color="red" size="small">
+            <Segment inverted color="red">
               <pre style={{ whiteSpace: 'pre-wrap' }}>{error.toString()}</pre>
             </Segment>
           )

--- a/docs/src/components/ComponentDoc/ComponentProps/ComponentProps.tsx
+++ b/docs/src/components/ComponentDoc/ComponentProps/ComponentProps.tsx
@@ -59,8 +59,10 @@ export default class ComponentProps extends React.Component<any, any> {
             <Flex.Item styles={{ display: 'inline-block' }}>
               <>
                 <Input
-                  type="checkbox"
-                  checked={!!activeDisplayName}
+                  input={{
+                    type: 'checkbox',
+                    checked: !!activeDisplayName,
+                  }}
                   onClick={this.handleToggle}
                   inline
                 />

--- a/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebar.tsx
+++ b/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebar.tsx
@@ -38,7 +38,7 @@ class ComponentSidebar extends React.Component<ComponentSidebarProps, any> {
   }
 
   render() {
-    const { activePath, examplesRef, onItemClick } = this.props
+    const { activePath, onItemClick } = this.props
     const { sections } = this.state
 
     const menuItems = _.map(sections, ({ examples, sectionName, index }) => ({
@@ -56,7 +56,7 @@ class ComponentSidebar extends React.Component<ComponentSidebarProps, any> {
 
     // TODO: use a Sticky component instead of position:fixed, when available
     return (
-      <Segment context={examplesRef} styles={{ padding: 0, position: 'fixed' }}>
+      <Segment styles={{ padding: 0, position: 'fixed' }}>
         <Menu fluid vertical items={menuItems} styles={{ ...sidebarStyle }} />
       </Segment>
     )

--- a/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebarSection.tsx
+++ b/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebarSection.tsx
@@ -96,14 +96,13 @@ export default class ComponentSidebarSection extends React.PureComponent<any, an
         {...restProps}
         styles={treeStyles}
         active={active}
+        onClick={this.handleTitleClick}
       >
         <span>{content}</span>
-        {hasSubtree && <Icon direction={name ? 'arrow-down' : 'arrow-end'} />}
+        {hasSubtree && <Icon name="arrow-down" />}
       </Component>
     )
 
-    return (
-      <Tree items={items} onTitleClick={this.handleTitleClick} renderItemTitle={titleRenderer} />
-    )
+    return <Tree items={items} renderItemTitle={titleRenderer} />
   }
 }

--- a/docs/src/components/DocPage/DocPage.tsx
+++ b/docs/src/components/DocPage/DocPage.tsx
@@ -11,7 +11,7 @@ interface DocPageProps {
 const DocPage = ({ title, description, children }: DocPageProps) => (
   <DocumentTitle title={`Stardust - ${title}`}>
     <div style={{ padding: '2rem', fontSize: '1.15rem', maxWidth: '80ch' }}>
-      <Header as="h1" aria-level="2" content={title} description={description} textAlign="center" />
+      <Header as="h1" aria-level={2} content={title} description={description} textAlign="center" />
       {children}
     </div>
   </DocumentTitle>

--- a/docs/src/components/DocsBehaviorRoot.tsx
+++ b/docs/src/components/DocsBehaviorRoot.tsx
@@ -37,7 +37,7 @@ class DocsBehaviorRoot extends React.Component<any, any> {
         <Segment>
           <Header
             as="h1"
-            aria-level="2"
+            aria-level={2}
             content={pageTitle}
             description={`Keyboard and Screenreader options for ${match.params.name} component.`}
           />

--- a/docs/src/components/GuidesNavigationFooter.tsx
+++ b/docs/src/components/GuidesNavigationFooter.tsx
@@ -19,7 +19,7 @@ const GuidesNavigationFooter: React.FC<GuidesNavigationFooterProps> = ({ previou
     <br />
     <Flex gap="gap.small">
       {previous && (
-        <Button
+        <Button<Link>
           as={Link}
           content={previous.name}
           icon="arrow left"
@@ -29,7 +29,7 @@ const GuidesNavigationFooter: React.FC<GuidesNavigationFooterProps> = ({ previou
         />
       )}
       {next && (
-        <Button
+        <Button<Link>
           as={Link}
           content={next.name}
           icon="arrow right"

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -471,7 +471,7 @@ class Sidebar extends React.Component<any, any> {
           <Logo width="32px" styles={logoStyles} />
           <Text
             role="heading"
-            aria-level="1"
+            aria-level={1}
             color="white"
             content="Stardust UI React &nbsp;"
             styles={logoStyles}

--- a/docs/src/examples/components/Header/Performance/HeaderDescription.perf.tsx
+++ b/docs/src/examples/components/Header/Performance/HeaderDescription.perf.tsx
@@ -2,7 +2,7 @@ import { Header } from '@stardust-ui/react'
 import * as React from 'react'
 
 const HeaderDescriptionPerf = () => (
-  <Header
+  <Header<'h2'>
     as="h2"
     content="Account Settings"
     description="Manage your account settings and set email preferences."

--- a/docs/src/examples/components/Header/Rtl/HeaderExample.rtl.tsx
+++ b/docs/src/examples/components/Header/Rtl/HeaderExample.rtl.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Header } from '@stardust-ui/react'
 
 const HeaderExampleRtl = () => (
-  <Header
+  <Header<'h2'>
     as="h2"
     content="إعدادات الحساب"
     description="إدارة إعدادات حسابك وتعيين تفضيلات البريد الإلكتروني."

--- a/docs/src/examples/components/Header/Variations/HeaderExampleColor.shorthand.tsx
+++ b/docs/src/examples/components/Header/Variations/HeaderExampleColor.shorthand.tsx
@@ -6,7 +6,7 @@ const HeaderExampleColor = () => (
   <ProviderConsumer
     render={({ siteVariables: { emphasisColors, naturalColors } }) =>
       _.keys({ ...emphasisColors, ...naturalColors }).map(color => (
-        <Header
+        <Header<'h4'>
           key={color}
           as="h4"
           color={color}

--- a/docs/src/examples/components/Header/Variations/HeaderExampleDescription.shorthand.tsx
+++ b/docs/src/examples/components/Header/Variations/HeaderExampleDescription.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Header } from '@stardust-ui/react'
 
 const HeaderExampleDescriptionShorthand = () => (
-  <Header
+  <Header<'h2'>
     as="h2"
     content="Account Settings"
     description="Manage your account settings and set email preferences."

--- a/docs/src/examples/components/Header/Variations/HeaderExampleDescriptionCustomization.shorthand.tsx
+++ b/docs/src/examples/components/Header/Variations/HeaderExampleDescriptionCustomization.shorthand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Header } from '@stardust-ui/react'
 
 const HeaderExampleDescriptionCustomizationShorthand = () => (
-  <Header
+  <Header<'h2'>
     as="h2"
     content="Account Settings"
     description={{ content: 'Manage your account settings and set email preferences', as: 'span' }}

--- a/docs/src/examples/components/ItemLayout/Types/ItemLayoutExampleSelection.shorthand.tsx
+++ b/docs/src/examples/components/ItemLayout/Types/ItemLayoutExampleSelection.shorthand.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react'
 import { ItemLayout, Image } from '@stardust-ui/react'
 
-const selection = knobs => (knobs === undefined ? true : knobs.selection)
-
 const ItemLayoutExampleSelectionShorthand = ({ knobs }) => (
   <ItemLayout
-    selection={selection(knobs)}
     media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
     header="Irving Kuhic"
     headerMedia="7:26:56 AM"

--- a/docs/src/examples/components/Portal/Types/PortalExample.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExample.shorthand.tsx
@@ -42,7 +42,7 @@ class PortalExamplePortal extends React.Component {
         <Divider />
         <div>
           <Flex gap="gap.small" vAlign="center">
-            <Button size="small" onClick={this.clearLog} content="Clear" />
+            <Button onClick={this.clearLog} content="Clear" />
             <span>
               Event Log <Label circular>{logCount}</Label>
             </span>

--- a/docs/src/examples/components/Portal/Types/PortalExample.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExample.tsx
@@ -39,7 +39,7 @@ class PortalExamplePortal extends React.Component {
         <Divider />
         <div>
           <Flex gap="gap.small" vAlign="center">
-            <Button size="small" onClick={this.clearLog} content="Clear" />
+            <Button onClick={this.clearLog} content="Clear" />
             <span>
               Event Log <Label circular>{logCount}</Label>
             </span>

--- a/docs/src/examples/components/Portal/Types/PortalExampleControlled.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleControlled.shorthand.tsx
@@ -28,7 +28,7 @@ class PortalExampleControlled extends React.Component {
           <Divider />
 
           <Flex gap="gap.small" vAlign="center">
-            <Button size="small" onClick={this.clearLog} content="Clear" />
+            <Button onClick={this.clearLog} content="Clear" />
             <span>
               Event Log <Label circular>{logCount}</Label>
             </span>

--- a/docs/src/examples/components/Portal/Types/PortalExampleControlled.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleControlled.tsx
@@ -28,7 +28,7 @@ class PortalExampleControlled extends React.Component {
           <Divider />
 
           <Flex gap="gap.small" vAlign="center">
-            <Button size="small" onClick={this.clearLog} content="Clear" />
+            <Button onClick={this.clearLog} content="Clear" />
             <span>
               Event Log <Label circular>{logCount}</Label>
             </span>

--- a/docs/src/examples/components/Portal/Types/PortalExampleFocusTrapped.shorthand.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleFocusTrapped.shorthand.tsx
@@ -64,8 +64,8 @@ class PortalExampleFocusTrapped extends React.Component {
                 Portal doesn't close on outside click. See passed focus trap props.
               </p>
               <p tabIndex={0}>To close, simply click the close button</p>
-              <Button size="small" content="Do nothing" />
-              <Button size="small" content="Close popup" onClick={this.closePortal} />
+              <Button content="Do nothing" />
+              <Button content="Close popup" onClick={this.closePortal} />
             </div>
           }
         />

--- a/docs/src/examples/components/Portal/Types/PortalExampleFocusTrapped.tsx
+++ b/docs/src/examples/components/Portal/Types/PortalExampleFocusTrapped.tsx
@@ -62,8 +62,8 @@ class PortalExamplePortal extends React.Component {
             <Header>This portal traps focus on appearance</Header>
             <p tabIndex={0}>Portal doesn't close on outside click. See passed focus trap props.</p>
             <p tabIndex={0}>To close, simply click the close button</p>
-            <Button size="small" content="Do nothing" />
-            <Button size="small" content="Close popup" onClick={this.closePortal} />
+            <Button content="Do nothing" />
+            <Button content="Close popup" onClick={this.closePortal} />
           </div>
         </Portal>
       </div>

--- a/docs/src/prototypes/AsyncShorthand/AsyncShorthand.tsx
+++ b/docs/src/prototypes/AsyncShorthand/AsyncShorthand.tsx
@@ -95,8 +95,7 @@ class CustomChatMessage extends React.Component {
                 { key: 'a', icon: 'thumbs up' },
                 { key: 'b', icon: 'user' },
                 { key: 'c', icon: 'ellipsis horizontal' },
-              ]}
-              renderItem={this.renderMenuItem}
+              ].map(item => render => render(item, this.renderMenuItem))}
             />
           </div>
         }

--- a/docs/src/prototypes/IconViewer/index.tsx
+++ b/docs/src/prototypes/IconViewer/index.tsx
@@ -51,7 +51,7 @@ class IconViewerExample extends React.Component<any, {}> {
   render() {
     return (
       <Segment styles={{ padding: '30px' }}>
-        <Header
+        <Header<'h3'>
           as="h3"
           content="Teams Icons"
           description={{
@@ -62,7 +62,7 @@ class IconViewerExample extends React.Component<any, {}> {
         />
 
         <div style={{ marginTop: '15px' }}>
-          <Menu tabular styles={{ margin: '15px 0' }}>
+          <Menu styles={{ margin: '15px 0' }}>
             {Object.keys(this.iconFilters).map(filterName => (
               <Menu.Item
                 content={filterName}

--- a/docs/src/prototypes/chatPane/chatPaneContent.tsx
+++ b/docs/src/prototypes/chatPane/chatPaneContent.tsx
@@ -63,7 +63,7 @@ class ChatPaneContainer extends React.PureComponent<ChatPaneContainerProps> {
                       {this.getMessagePreviewForScreenReader(props)}
                     </div>
                   )}
-                  <ElementType {...props} text={undefined} {...maybeAttributesForDivider} />
+                  <ElementType {...props} {...maybeAttributesForDivider} />
                 </>
               ),
             }}
@@ -73,7 +73,7 @@ class ChatPaneContainer extends React.PureComponent<ChatPaneContainerProps> {
     )
   }
 
-  private getElementType = (itemType: ChatItemTypes) => {
+  private getElementType = (itemType: ChatItemTypes): React.ElementType => {
     switch (itemType) {
       case ChatItemTypes.message:
         return Chat.Message

--- a/docs/src/prototypes/chatPane/composeMessage.tsx
+++ b/docs/src/prototypes/chatPane/composeMessage.tsx
@@ -94,7 +94,7 @@ const getMenuItems = (): MenuItemProps[] => {
     'aria-label': `${name} tool`,
   }))
 
-  items.splice(-1, 0, { key: 'separator', styles: { flex: 1 } })
+  items.splice(-1, 0, { key: 'separator', styles: { flex: 1 } } as any)
 
   return items
 }

--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -119,7 +119,7 @@ function createMessageContentWithAttachments(content: string, messageId: string)
     />
   )
 
-  const stopPropagationOnKeys = (keys: number[]) => (e: Event) => {
+  const stopPropagationOnKeys = (keys: number[]) => (e: React.KeyboardEvent) => {
     if (keys.indexOf(keyboardKey.getCode(e)) > -1) {
       e.stopPropagation()
     }

--- a/docs/src/prototypes/employeeCard/index.tsx
+++ b/docs/src/prototypes/employeeCard/index.tsx
@@ -20,14 +20,14 @@ class EmployeeCardPrototype extends React.Component<any, { popupOpen: boolean }>
     }
     return (
       <div style={{ margin: '20px' }}>
-        <Header
+        <Header<'h3'>
           as="h3"
           content="Employee Card"
           description={{ content: 'Simple employee card component.', styles: { fontSize: '16px' } }}
         />
         <EmployeeCard {...employee} />
         <Divider variables={{ dividerColor: 'transparent' }} />
-        <Header
+        <Header<'h3'>
           as="h3"
           content="Avatar Employee Card"
           description={{

--- a/docs/src/prototypes/meetingOptions/components/MSTeamsLink.tsx
+++ b/docs/src/prototypes/meetingOptions/components/MSTeamsLink.tsx
@@ -5,7 +5,7 @@ export default props => {
   const { content, children } = props
   return (
     <Provider.Consumer
-      render={({ siteVariables }) => (
+      render={() => (
         <Text as="a" content={content} color="primary">
           {children}
         </Text>

--- a/docs/src/prototypes/popups/GridImagePicker/GridImagePicker.tsx
+++ b/docs/src/prototypes/popups/GridImagePicker/GridImagePicker.tsx
@@ -50,7 +50,7 @@ class GridImagePicker extends React.Component<GridPickerProps> {
           placeholder={inputPlaceholder}
           inputRef={this.setInputNode}
         />
-        <Grid
+        <Grid<'ul'>
           as="ul"
           accessibility={gridBehavior}
           columns={gridColumns}

--- a/docs/src/views/AutoFocusZone.tsx
+++ b/docs/src/views/AutoFocusZone.tsx
@@ -68,9 +68,9 @@ export default () => (
       value={`
       const overridenAutoFocusBehavior: Accessibility = (props: any) => {
         const behavior = popupFocusTrapBehavior(props)
-      
+
         behavior.autoFocus.firstFocusableSelector = ".btn-submit";
-      
+
         return behavior
       }
       `}

--- a/docs/src/views/IntegrateCustomComponents.tsx
+++ b/docs/src/views/IntegrateCustomComponents.tsx
@@ -109,7 +109,7 @@ export default () => (
       customize styles and variables of these components, the same way they would do with the
       Stardust components.
     </p>
-    <Header
+    <Header<'h3'>
       as="h3"
       content={
         <>
@@ -150,7 +150,7 @@ export default () => (
       For more advanced theming scenarios, please take a look in the <b>Styles</b> section on the{' '}
       <NavLink to="theming">Theming guide</NavLink>.
     </p>
-    <Header
+    <Header<'h3'>
       as="h3"
       content={
         <>
@@ -237,7 +237,7 @@ export default () => (
       <NavLink to="theming">Theming guide</NavLink>.
     </p>
 
-    <Header
+    <Header<'h3'>
       as="h3"
       content={
         <>

--- a/docs/src/views/PageNotFound.tsx
+++ b/docs/src/views/PageNotFound.tsx
@@ -4,7 +4,7 @@ import { Grid, Segment, Header, Icon } from '@stardust-ui/react'
 const PageNotFound = () => (
   <Grid>
     <div>
-      <Header as="h1" icon textAlign="center">
+      <Header as="h1" styles={{ textAlign: 'center' }}>
         <Icon name="game" />
         404
         <Header.Description>How about some good old Atari?</Header.Description>
@@ -12,7 +12,7 @@ const PageNotFound = () => (
     </div>
 
     <div>
-      <Segment basic>
+      <Segment>
         <embed
           src="http://www.pizn.com/swf/classic-asteroids.swf"
           width="425"
@@ -28,7 +28,7 @@ const PageNotFound = () => (
       </Segment>
     </div>
     <div>
-      <Segment basic>
+      <Segment>
         <embed
           src="http://www.pizn.com/swf/1-space-invaders.swf"
           width="425"

--- a/docs/src/views/QuickStart.tsx
+++ b/docs/src/views/QuickStart.tsx
@@ -17,7 +17,7 @@ export default () => (
       Stardust components are styled using CSS in JS. This technique requires a style renderer to
       render JavaScript objects to CSS.{' '}
       <a href="https://reactjs.org/docs/context.html" target="_blank" rel="noopener nofollow">
-        React Context <Icon name="external" size="small" link fitted />
+        React Context <Icon name="external" size="small" />
       </a>{' '}
       is used to provide the style renderer and theme to components.
     </p>

--- a/docs/src/views/ShorthandProps.tsx
+++ b/docs/src/views/ShorthandProps.tsx
@@ -242,7 +242,13 @@ const ShorthandProps = props => (
     </p>
 
     <br />
-    <Button as={NavLink} content="Quick Start" icon="arrow right" primary to="quick-start" />
+    <Button<NavLink>
+      as={NavLink}
+      content="Quick Start"
+      icon="arrow right"
+      primary
+      to="quick-start"
+    />
   </DocPage>
 )
 

--- a/packages/react-proptypes/src/index.ts
+++ b/packages/react-proptypes/src/index.ts
@@ -456,7 +456,7 @@ export const deprecate = (help: string, validator: Function) => (
   return error
 }
 
-export const accessibility = PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+export const accessibility = PropTypes.func
 
 export const size = PropTypes.oneOf([
   'smallest',

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -18,7 +18,7 @@ import { Accessibility } from '../../lib/accessibility/types'
 
 import {
   ComponentEventHandler,
-  ReactProps,
+  StardustProps,
   ShorthandValue,
   ShorthandRenderFunction,
 } from '../../types'
@@ -81,7 +81,10 @@ export interface AccordionProps extends UIComponentProps, ChildrenComponentProps
  * Implements ARIA Accordion design pattern (keyboard navigation not yet supported).
  * Consider using Tree if you intend to wrap Lists in an Accordion.
  */
-class Accordion extends AutoControlledComponent<ReactProps<AccordionProps>, any> {
+class Accordion<TAs = 'div'> extends AutoControlledComponent<
+  StardustProps<AccordionProps, TAs>,
+  any
+> {
   static displayName = 'Accordion'
 
   static className = 'ui-accordion'

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -11,7 +11,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
 } from '../../lib'
-import { ReactProps, ComponentEventHandler } from '../../types'
+import { StardustProps, ComponentEventHandler } from '../../types'
 
 export interface AccordionContentProps
   extends UIComponentProps,
@@ -32,7 +32,10 @@ export interface AccordionContentProps
 /**
  * A standard AccordionContent.
  */
-class AccordionContent extends UIComponent<ReactProps<AccordionContentProps>, any> {
+class AccordionContent<TAs = 'div'> extends UIComponent<
+  StardustProps<AccordionContentProps, TAs>,
+  any
+> {
   static displayName = 'AccordionContent'
 
   static create: Function
@@ -60,7 +63,7 @@ class AccordionContent extends UIComponent<ReactProps<AccordionContentProps>, an
   }
 }
 
-AccordionContent.create = createShorthandFactory({
+AccordionContent.create = createShorthandFactory<AccordionContentProps>({
   Component: AccordionContent,
   mappedProp: 'content',
 })

--- a/packages/react/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/react/src/components/Accordion/AccordionTitle.tsx
@@ -13,7 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
 } from '../../lib'
-import { ReactProps, ComponentEventHandler, ShorthandValue } from '../../types'
+import { StardustProps, ComponentEventHandler, ShorthandValue } from '../../types'
 import Icon from '../Icon/Icon'
 import Layout from '../Layout/Layout'
 
@@ -42,7 +42,10 @@ export interface AccordionTitleProps
 /**
  * A standard AccordionTitle.
  */
-class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
+class AccordionTitle<TAs = 'div'> extends UIComponent<
+  StardustProps<AccordionTitleProps, TAs>,
+  any
+> {
   static displayName = 'AccordionTitle'
 
   static create: Function
@@ -90,6 +93,9 @@ class AccordionTitle extends UIComponent<ReactProps<AccordionTitleProps>, any> {
   }
 }
 
-AccordionTitle.create = createShorthandFactory({ Component: AccordionTitle, mappedProp: 'content' })
+AccordionTitle.create = createShorthandFactory<AccordionTitleProps>({
+  Component: AccordionTitle,
+  mappedProp: 'content',
+})
 
 export default AccordionTitle

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -15,7 +15,7 @@ import {
 import { RenderResultConfig } from '../../lib/renderComponent'
 import { alertBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 import Box from '../Box/Box'
 import Button, { ButtonProps } from '../Button/Button'
 
@@ -69,7 +69,7 @@ export interface AlertState {
  *  - by default, content from warning and danger variants is announced by the screen reader. To announce the content of other variants, a mechanism similar to react-aria-live can be used
  *  - if Alert contains action slot, textual representation needs to be provided by using 'title', 'aria-label' or 'aria-labelledby' attributes
  */
-class Alert extends UIComponent<ReactProps<AlertProps>, AlertState> {
+class Alert<TAs = 'div'> extends UIComponent<StardustProps<AlertProps, TAs>, AlertState> {
   static displayName = 'Alert'
   static className = 'ui-alert'
 

--- a/packages/react/src/components/Animation/Animation.tsx
+++ b/packages/react/src/components/Animation/Animation.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../lib'
 import { AnimationProp } from '../../themes/types'
 import createAnimationStyles from '../../lib/createAnimationStyles'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface AnimationProps
   extends StyledComponentProps,
@@ -82,7 +82,7 @@ export interface AnimationProps
 /**
  * An animation allows the user to animate their own components.
  */
-class Animation extends UIComponent<ReactProps<AnimationProps>, any> {
+class Animation<TAs = 'div'> extends UIComponent<StardustProps<AnimationProps, TAs>, any> {
   static create: Function
 
   static className = 'ui-animation'

--- a/packages/react/src/components/Attachment/Attachment.tsx
+++ b/packages/react/src/components/Attachment/Attachment.tsx
@@ -2,7 +2,7 @@ import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
-import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
+import { StardustProps, ShorthandValue, ComponentEventHandler } from '../../types'
 import {
   UIComponent,
   createShorthandFactory,
@@ -33,6 +33,9 @@ export interface AttachmentProps extends UIComponentProps, ChildrenComponentProp
 
   /** A string describing the attachment. */
   description?: ShorthandValue
+
+  /** An attachment can be disabled. */
+  disabled?: boolean
 
   /** The name of the attachment. */
   header?: ShorthandValue
@@ -65,7 +68,10 @@ export interface AttachmentState {
 /**
  * An Attachment displays a file attachment.
  */
-class Attachment extends UIComponent<ReactProps<AttachmentProps>, AttachmentState> {
+class Attachment<TAs = 'div'> extends UIComponent<
+  StardustProps<AttachmentProps, TAs>,
+  AttachmentState
+> {
   static create: Function
 
   static className = 'ui-attachment'
@@ -85,7 +91,7 @@ class Attachment extends UIComponent<ReactProps<AttachmentProps>, AttachmentStat
   }
 
   static defaultProps = {
-    accessibility: attachmentBehavior as Accessibility,
+    accessibility: attachmentBehavior,
   }
 
   public state = {
@@ -164,6 +170,9 @@ class Attachment extends UIComponent<ReactProps<AttachmentProps>, AttachmentStat
   }
 }
 
-Attachment.create = createShorthandFactory({ Component: Attachment, mappedProp: 'header' })
+Attachment.create = createShorthandFactory<AttachmentProps>({
+  Component: Attachment,
+  mappedProp: 'header',
+})
 
 export default Attachment

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -6,7 +6,7 @@ import Label from '../Label/Label'
 import Status, { StatusProps } from '../Status/Status'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import {
   createShorthandFactory,
   UIComponent,
@@ -44,7 +44,7 @@ export interface AvatarProps extends UIComponentProps {
 /**
  * An avatar is a graphic representation of user.
  */
-class Avatar extends UIComponent<ReactProps<AvatarProps>, any> {
+class Avatar<TAs = 'div'> extends UIComponent<StardustProps<AvatarProps, TAs>, any> {
   static create: Function
 
   static className = 'ui-avatar'
@@ -127,6 +127,9 @@ class Avatar extends UIComponent<ReactProps<AvatarProps>, any> {
   }
 }
 
-Avatar.create = createShorthandFactory({ Component: Avatar, mappedProp: 'name' })
+Avatar.create = createShorthandFactory<AvatarProps>({
+  Component: Avatar,
+  mappedProp: 'name',
+})
 
 export default Avatar

--- a/packages/react/src/components/Box/Box.tsx
+++ b/packages/react/src/components/Box/Box.tsx
@@ -8,8 +8,8 @@ import {
   commonPropTypes,
   rtlTextContainer,
 } from '../../lib'
-import createComponent, { CreateComponentReturnType } from '../../lib/createComponent'
-import { ReactProps } from '../../types'
+import createComponent from '../../lib/createComponent'
+import { StardustProps } from '../../types'
 
 export interface BoxProps
   extends UIComponentProps<BoxProps>,
@@ -20,7 +20,7 @@ export interface BoxProps
  * A Box is an abstract component, is frequently used for slots in other Stardust components.
  * By default it renders a `div` without any styles.
  */
-const Box: CreateComponentReturnType<ReactProps<BoxProps>> = createComponent<BoxProps>({
+const Box = createComponent<StardustProps<BoxProps, any>>({
   displayName: 'Box',
 
   className: 'ui-box',

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ import Icon from '../Icon/Icon'
 import Box from '../Box/Box'
 import { buttonBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 import ButtonGroup from './ButtonGroup'
 
 export interface ButtonProps
@@ -84,7 +84,7 @@ export interface ButtonState {
  *  - for disabled buttons, add 'disabled' attribute so that the state is properly recognized by the screen reader
  *  - if button includes icon only, textual representation needs to be provided by using 'title', 'aria-label' or 'aria-labelledby' attributes
  */
-class Button extends UIComponent<ReactProps<ButtonProps>, ButtonState> {
+class Button<TAs = 'button'> extends UIComponent<StardustProps<ButtonProps, TAs>, ButtonState> {
   static create: Function
 
   public static displayName = 'Button'
@@ -180,6 +180,9 @@ class Button extends UIComponent<ReactProps<ButtonProps>, ButtonState> {
   }
 }
 
-Button.create = createShorthandFactory({ Component: Button, mappedProp: 'content' })
+Button.create = createShorthandFactory<ButtonProps>({
+  Component: Button,
+  mappedProp: 'content',
+})
 
 export default Button

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as _ from 'lodash'
 
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import {
   UIComponent,
   childrenExist,
@@ -38,7 +38,7 @@ export interface ButtonGroupProps
 /**
  * A button group presents multiple related actions.
  */
-class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
+class ButtonGroup<TAs = 'div'> extends UIComponent<StardustProps<ButtonGroupProps, TAs>, any> {
   public static create: Function
 
   public static displayName = 'ButtonGroup'
@@ -106,7 +106,7 @@ class ButtonGroup extends UIComponent<ReactProps<ButtonGroupProps>, any> {
   }
 }
 
-ButtonGroup.create = createShorthandFactory({
+ButtonGroup.create = createShorthandFactory<ButtonGroupProps>({
   Component: ButtonGroup,
   mappedProp: 'content',
   mappedArrayProp: 'buttons',

--- a/packages/react/src/components/Chat/Chat.tsx
+++ b/packages/react/src/components/Chat/Chat.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../lib'
 import ChatItem from './ChatItem'
 import ChatMessage from './ChatMessage'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
 import { chatBehavior } from '../../lib/accessibility'
 import { UIComponentProps, ChildrenComponentProps } from '../../lib/commonPropInterfaces'
@@ -35,7 +35,7 @@ export interface ChatProps extends UIComponentProps, ChildrenComponentProps {
 /**
  * A Chat displays messages between users.
  */
-class Chat extends UIComponent<ReactProps<ChatProps>, any> {
+class Chat<TAs = 'ul'> extends UIComponent<StardustProps<ChatProps, TAs>, any> {
   static displayName = 'Chat'
 
   static className = 'ui-chat'

--- a/packages/react/src/components/Chat/ChatItem.tsx
+++ b/packages/react/src/components/Chat/ChatItem.tsx
@@ -2,7 +2,7 @@ import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import {
   childrenExist,
   createShorthandFactory,
@@ -48,7 +48,7 @@ export interface ChatItemProps extends UIComponentProps, ChildrenComponentProps 
 /**
  * A chat item represents a single event in a chat.
  */
-class ChatItem extends UIComponent<ReactProps<ChatItemProps>, any> {
+class ChatItem<TAs = 'li'> extends UIComponent<StardustProps<ChatItemProps, TAs>, any> {
   static className = 'ui-chat__item'
   static create: Function
   static displayName = 'ChatItem'
@@ -145,7 +145,11 @@ class ChatItem extends UIComponent<ReactProps<ChatItemProps>, any> {
   }
 }
 
-ChatItem.create = createShorthandFactory({ Component: ChatItem, mappedProp: 'message' })
+ChatItem.create = createShorthandFactory<ChatItemProps>({
+  Component: ChatItem,
+  mappedProp: 'message',
+})
+
 ChatItem.slotClassNames = {
   message: `${ChatItem.className}__message`,
   gutter: `${ChatItem.className}__gutter`,

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -17,7 +17,7 @@ import {
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
 } from '../../lib'
-import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
+import { StardustProps, ShorthandValue, ComponentEventHandler } from '../../types'
 import { chatMessageBehavior, toolbarBehavior } from '../../lib/accessibility'
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../lib/accessibility/FocusZone'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
@@ -97,7 +97,10 @@ export interface ChatMessageState {
 /**
  * A chat message represents a single statement communicated to a user.
  */
-class ChatMessage extends UIComponent<ReactProps<ChatMessageProps>, ChatMessageState> {
+class ChatMessage<TAs = 'div'> extends UIComponent<
+  StardustProps<ChatMessageProps, TAs>,
+  ChatMessageState
+> {
   static className = 'ui-chat__message'
 
   static create: Function
@@ -260,7 +263,11 @@ class ChatMessage extends UIComponent<ReactProps<ChatMessageProps>, ChatMessageS
   }
 }
 
-ChatMessage.create = createShorthandFactory({ Component: ChatMessage, mappedProp: 'content' })
+ChatMessage.create = createShorthandFactory<ChatMessageProps>({
+  Component: ChatMessage,
+  mappedProp: 'content',
+})
+
 ChatMessage.slotClassNames = {
   actionMenu: `${ChatMessage.className}__actions`,
   author: `${ChatMessage.className}__author`,

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -15,7 +15,7 @@ import {
 import { dialogBehavior } from '../../lib/accessibility'
 import { FocusTrapZoneProps } from '../../lib/accessibility/FocusZone'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 import Button, { ButtonProps } from '../Button/Button'
 import Box, { BoxProps } from '../Box/Box'
 import Header from '../Header/Header'
@@ -89,7 +89,10 @@ export interface DialogState {
 /**
  * A Dialog indicates a possible user action.
  */
-class Dialog extends AutoControlledComponent<ReactProps<DialogProps>, DialogState> {
+class Dialog<TAs = 'div'> extends AutoControlledComponent<
+  StardustProps<DialogProps, TAs>,
+  DialogState
+> {
   static displayName = 'Dialog'
   static className = 'ui-dialog'
 

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface DividerProps
   extends UIComponentProps,
@@ -40,7 +40,7 @@ export interface DividerProps
 /**
  * A divider visually segments content into groups.
  */
-class Divider extends UIComponent<ReactProps<DividerProps>, any> {
+class Divider<TAs = 'div'> extends UIComponent<StardustProps<DividerProps, TAs>, any> {
   static displayName = 'Divider'
 
   static create: Function
@@ -75,7 +75,10 @@ class Divider extends UIComponent<ReactProps<DividerProps>, any> {
   }
 }
 
-Divider.create = createShorthandFactory({ Component: Divider, mappedProp: 'content' })
+Divider.create = createShorthandFactory<DividerProps>({
+  Component: Divider,
+  mappedProp: 'content',
+})
 
 export default Divider
 

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -6,11 +6,11 @@ import cx from 'classnames'
 import * as keyboardKey from 'keyboard-key'
 
 import {
-  Extendable,
   ShorthandRenderFunction,
   ShorthandValue,
   ComponentEventHandler,
   ShorthandCollection,
+  StardustProps,
 } from '../../types'
 import { ComponentSlotStylesInput, ComponentVariablesInput } from '../../themes/types'
 import Downshift, {
@@ -216,7 +216,11 @@ export interface DropdownState {
  * @accessibility
  * Implements ARIA collapsible Listbox design pattern, uses aria-live to announce state changes.
  */
-class Dropdown extends AutoControlledComponent<Extendable<DropdownProps>, DropdownState> {
+
+class Dropdown<TAs = 'div'> extends AutoControlledComponent<
+  StardustProps<DropdownProps, TAs>,
+  DropdownState
+> {
   private buttonRef = React.createRef<HTMLElement>()
   private inputRef = React.createRef<HTMLInputElement>()
   private listRef = React.createRef<HTMLElement>()

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
 import { UIComponent, RenderResultConfig, createShorthandFactory, commonPropTypes } from '../../lib'
-import { ShorthandValue, ComponentEventHandler, ReactProps } from '../../types'
+import { ShorthandValue, ComponentEventHandler, StardustProps } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import ListItem from '../List/ListItem'
 import Image from '../Image/Image'
@@ -17,6 +17,9 @@ export interface DropdownItemSlotClassNames {
 }
 
 export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
+  /** Accessibility props of dropdown item. */
+  accessibilityItemProps?: any
+
   /** A dropdown item can be active. */
   active?: boolean
 
@@ -42,7 +45,7 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
  * A DropdownItem is a sub-component of the Dropdown,
  * used to display items of the dropdown list.
  */
-class DropdownItem extends UIComponent<ReactProps<DropdownItemProps>, any> {
+class DropdownItem<TAs = 'div'> extends UIComponent<StardustProps<DropdownItemProps, TAs>, any> {
   static displayName = 'DropdownItem'
 
   static create: Function
@@ -113,6 +116,9 @@ DropdownItem.slotClassNames = {
   image: `${DropdownItem.className}__image`,
 }
 
-DropdownItem.create = createShorthandFactory({ Component: DropdownItem, mappedProp: 'header' })
+DropdownItem.create = createShorthandFactory<DropdownItemProps>({
+  Component: DropdownItem,
+  mappedProp: 'header',
+})
 
 export default DropdownItem

--- a/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
 import { UIComponent, RenderResultConfig, createShorthandFactory, commonPropTypes } from '../../lib'
-import { ComponentEventHandler, ReactProps } from '../../types'
+import { ComponentEventHandler, StardustProps } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import Input from '../Input/Input'
 
@@ -14,6 +14,12 @@ export interface DropdownSearchInputSlotClassNames {
 }
 
 export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearchInputProps> {
+  /** Accessibility props of combobox. */
+  accessibilityComboboxProps?: any
+
+  /** Accessibility props of input. */
+  accessibilityInputProps?: any
+
   /** A dropdown search input can be formatted to appear inline in the context of a Dropdown. */
   inline?: boolean
 
@@ -59,7 +65,10 @@ export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearc
 /**
  * A DropdownSearchInput is a sub-component of a Dropdown that also has a search function, used to display the search input field.
  */
-class DropdownSearchInput extends UIComponent<ReactProps<DropdownSearchInputProps>, any> {
+class DropdownSearchInput<TAs = 'div'> extends UIComponent<
+  StardustProps<DropdownSearchInputProps, TAs>,
+  any
+> {
   static displayName = 'DropdownSearchInput'
   static create: Function
   static slotClassNames: DropdownSearchInputSlotClassNames

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
 import keyboardKey from 'keyboard-key'
-import { ComponentEventHandler, ShorthandValue, ReactProps } from '../../types'
+import { ComponentEventHandler, ShorthandValue, StardustProps } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import { createShorthandFactory, UIComponent, RenderResultConfig, commonPropTypes } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
@@ -61,7 +61,10 @@ export interface DropdownSelectedItemProps extends UIComponentProps<DropdownSele
  * A DropdownSelectedItem is a sub-component of a multiple selection Dropdown.
  * It is used to display selected item.
  */
-class DropdownSelectedItem extends UIComponent<ReactProps<DropdownSelectedItemProps>, any> {
+class DropdownSelectedItem<TAs = 'div'> extends UIComponent<
+  StardustProps<DropdownSelectedItemProps, TAs>,
+  any
+> {
   private itemRef = React.createRef<HTMLElement>()
 
   static displayName = 'DropdownSelectedItem'
@@ -169,7 +172,7 @@ DropdownSelectedItem.slotClassNames = {
   image: `${DropdownSelectedItem.className}__image`,
 }
 
-DropdownSelectedItem.create = createShorthandFactory({
+DropdownSelectedItem.create = createShorthandFactory<DropdownSelectedItemProps>({
   Component: DropdownSelectedItem,
   mappedProp: 'header',
 })

--- a/packages/react/src/components/Embed/Embed.tsx
+++ b/packages/react/src/components/Embed/Embed.tsx
@@ -16,7 +16,7 @@ import Icon, { IconProps } from '../Icon/Icon'
 import Image, { ImageProps } from '../Image/Image'
 import Video, { VideoProps } from '../Video/Video'
 import Box from '../Box/Box'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 
 export interface EmbedSlotClassNames {
   control: string
@@ -75,7 +75,10 @@ export interface EmbedState {
  * Other considerations:
  *  - when alt and title property are empty, then Narrator in scan mode navigates to the gif and narrates it as empty paragraph
  */
-class Embed extends AutoControlledComponent<ReactProps<EmbedProps>, EmbedState> {
+class Embed<TAs = 'span'> extends AutoControlledComponent<
+  StardustProps<EmbedProps, TAs>,
+  EmbedState
+> {
   static create: Function
 
   static className = 'ui-embed'

--- a/packages/react/src/components/Flex/Flex.tsx
+++ b/packages/react/src/components/Flex/Flex.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as _ from 'lodash'
 
 import { UIComponent, commonPropTypes, UIComponentProps, ChildrenComponentProps } from '../../lib'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 import FlexItem from './FlexItem'
 
 export interface FlexProps extends UIComponentProps, ChildrenComponentProps {
@@ -41,7 +41,7 @@ export interface FlexProps extends UIComponentProps, ChildrenComponentProps {
 /**
  * Arrange group of items aligned towards common direction.
  */
-class Flex extends UIComponent<ReactProps<FlexProps>> {
+class Flex<TAs = 'div'> extends UIComponent<StardustProps<FlexProps, TAs>> {
   static Item = FlexItem
 
   static displayName = 'Flex'

--- a/packages/react/src/components/Flex/FlexItem.tsx
+++ b/packages/react/src/components/Flex/FlexItem.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import * as _ from 'lodash'
 import { UIComponent, commonPropTypes, UIComponentProps, ChildrenComponentProps } from '../../lib'
 import { mergeStyles } from '../../lib/mergeThemes'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export type FlexItemChildren =
   | React.ReactElement<any>
@@ -42,13 +42,14 @@ export interface FlexItemProps extends UIComponentProps, ChildrenComponentProps<
   flexDirection?: 'row' | 'column'
 }
 
-class FlexItem extends UIComponent<ReactProps<FlexItemProps>> {
+class FlexItem extends UIComponent<StardustProps<FlexItemProps, false>> {
   static className = 'ui-flex__item'
 
   static displayName = 'FlexItem'
 
   static propTypes = {
     ...commonPropTypes.createCommon({
+      as: false,
       accessibility: false,
       content: false,
     }),

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 import FormField from './FormField'
 
 export interface FormSlotClassNames {
@@ -46,7 +46,7 @@ export interface FormProps extends UIComponentProps, ChildrenComponentProps {
  * @accessibility
  * Label needs to be provided by using 'aria-label', or 'aria-labelledby' attributes on the <form> element.
  */
-class Form extends UIComponent<ReactProps<FormProps>, any> {
+class Form<TAs = 'form'> extends UIComponent<StardustProps<FormProps, TAs>, any> {
   static create: Function
 
   public static displayName = 'Form'

--- a/packages/react/src/components/Form/FormField.tsx
+++ b/packages/react/src/components/Form/FormField.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import Text from '../Text/Text'
 import Input from '../Input/Input'
 import Box from '../Box/Box'
@@ -52,7 +52,7 @@ export interface FormFieldProps extends UIComponentProps, ChildrenComponentProps
 /**
  * A field is a form element containing a label and an input.
  */
-class FormField extends UIComponent<ReactProps<FormFieldProps>, any> {
+class FormField<TAs = 'div'> extends UIComponent<StardustProps<FormFieldProps, TAs>, any> {
   public static displayName = 'FormField'
 
   public static className = 'ui-form__field'
@@ -129,6 +129,9 @@ class FormField extends UIComponent<ReactProps<FormFieldProps>, any> {
   }
 }
 
-FormField.create = createShorthandFactory({ Component: FormField, mappedProp: 'label' })
+FormField.create = createShorthandFactory<FormFieldProps>({
+  Component: FormField,
+  mappedProp: 'label',
+})
 
 export default FormField

--- a/packages/react/src/components/Grid/Grid.tsx
+++ b/packages/react/src/components/Grid/Grid.tsx
@@ -11,7 +11,7 @@ import {
   ContentComponentProps,
   rtlTextContainer,
 } from '../../lib'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
 
@@ -38,7 +38,7 @@ export interface GridProps
  * @accessibility This is example usage of the accessibility tag.
  * This should be replaced with the actual description after the PR is merged
  */
-class Grid extends UIComponent<ReactProps<GridProps>, any> {
+class Grid<TAs = 'div'> extends UIComponent<StardustProps<GridProps, TAs>, any> {
   public static displayName = 'Grid'
 
   public static className = 'ui-grid'

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -16,7 +16,7 @@ import {
 import HeaderDescription from './HeaderDescription'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 
 export interface HeaderSlotClassNames {
   description: string
@@ -50,7 +50,7 @@ export interface HeaderProps
  *  - when the description property is used in header, readers will narrate both header content and description within the element.
  *    In addition to that, both will be displayed in the list of headings.
  */
-class Header extends UIComponent<ReactProps<HeaderProps>, any> {
+class Header<TAs = 'h1'> extends UIComponent<StardustProps<HeaderProps, TAs>, any> {
   static displayName = 'Header'
 
   static className = 'ui-header'
@@ -106,6 +106,9 @@ class Header extends UIComponent<ReactProps<HeaderProps>, any> {
   }
 }
 
-Header.create = createShorthandFactory({ Component: Header, mappedProp: 'content' })
+Header.create = createShorthandFactory<HeaderProps>({
+  Component: Header,
+  mappedProp: 'content',
+})
 
 export default Header

--- a/packages/react/src/components/Header/HeaderDescription.tsx
+++ b/packages/react/src/components/Header/HeaderDescription.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface HeaderDescriptionProps
   extends UIComponentProps,
@@ -30,7 +30,10 @@ export interface HeaderDescriptionProps
 /**
  * A header's description provides more detailed information.
  */
-class HeaderDescription extends UIComponent<ReactProps<HeaderDescriptionProps>, any> {
+class HeaderDescription<TAs = 'p'> extends UIComponent<
+  StardustProps<HeaderDescriptionProps, TAs>,
+  any
+> {
   static create: Function
 
   static className = 'ui-header__description'
@@ -61,7 +64,7 @@ class HeaderDescription extends UIComponent<ReactProps<HeaderDescriptionProps>, 
   }
 }
 
-HeaderDescription.create = createShorthandFactory({
+HeaderDescription.create = createShorthandFactory<HeaderDescriptionProps>({
   Component: HeaderDescription,
   mappedProp: 'content',
 })

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -14,7 +14,7 @@ import { iconBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 
 import { SvgIconSpec } from '../../themes/types'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export type IconXSpacing = 'none' | 'before' | 'after' | 'both'
 
@@ -53,7 +53,7 @@ export interface IconProps extends UIComponentProps, ColorComponentProps {
 /**
  * An icon is a glyph used to represent something else.
  */
-class Icon extends UIComponent<ReactProps<IconProps>, any> {
+class Icon<TAs = 'span'> extends UIComponent<StardustProps<IconProps, TAs>, any> {
   static create: Function
 
   static className = 'ui-icon'
@@ -126,6 +126,9 @@ class Icon extends UIComponent<ReactProps<IconProps>, any> {
   }
 }
 
-Icon.create = createShorthandFactory({ Component: Icon, mappedProp: 'name' })
+Icon.create = createShorthandFactory<IconProps>({
+  Component: Icon,
+  mappedProp: 'name',
+})
 
 export default Icon

--- a/packages/react/src/components/Image/Image.tsx
+++ b/packages/react/src/components/Image/Image.tsx
@@ -5,7 +5,7 @@ import { createShorthandFactory, UIComponent, UIComponentProps, commonPropTypes 
 import { imageBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface ImageProps extends UIComponentProps {
   /**
@@ -37,7 +37,7 @@ export interface ImageProps extends UIComponentProps {
  *  - when image has role='presentation' then screen readers navigate to the element in scan/virtual mode. To avoid this, the attribute "aria-hidden='true'" is applied by the default image behavior
  *  - when alt property is used in combination with aria-label, arialabbeledby or title, additional screen readers verification is needed as each screen reader handles this combination differently.
  */
-class Image extends UIComponent<ReactProps<ImageProps>, any> {
+class Image<TAs = 'img'> extends UIComponent<StardustProps<ImageProps, TAs>, any> {
   static create: Function
 
   static className = 'ui-image'
@@ -70,6 +70,9 @@ class Image extends UIComponent<ReactProps<ImageProps>, any> {
   }
 }
 
-Image.create = createShorthandFactory({ Component: Image, mappedProp: 'src' })
+Image.create = createShorthandFactory<ImageProps>({
+  Component: Image,
+  mappedProp: 'src',
+})
 
 export default Image

--- a/packages/react/src/components/Input/Input.tsx
+++ b/packages/react/src/components/Input/Input.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
+import { StardustProps, ShorthandValue, ComponentEventHandler } from '../../types'
 import Icon from '../Icon/Icon'
 import Ref from '../Ref/Ref'
 import Box from '../Box/Box'
@@ -85,7 +85,10 @@ export interface InputState {
  * Other considerations:
  *  - if input is search, then use "role='search'"
  */
-class Input extends AutoControlledComponent<ReactProps<InputProps>, InputState> {
+class Input<TAs = 'div'> extends AutoControlledComponent<
+  StardustProps<InputProps, TAs>,
+  InputState
+> {
   private inputRef = React.createRef<HTMLElement>()
 
   static className = 'ui-input'

--- a/packages/react/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/react/src/components/ItemLayout/ItemLayout.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../lib'
 import Layout from '../Layout/Layout'
 import { ComponentSlotClasses, ICSSInJSStyle } from '../../themes/types'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface ItemLayoutSlotClassNames {
   header: string
@@ -67,7 +67,7 @@ export interface ItemLayoutProps extends UIComponentProps, ContentComponentProps
 /**
  * (DEPRECATED) The Item Layout handles layout styles for menu items, list items and other similar item templates.
  */
-class ItemLayout extends UIComponent<ReactProps<ItemLayoutProps>, any> {
+class ItemLayout<TAs = 'div'> extends UIComponent<StardustProps<ItemLayoutProps, TAs>, any> {
   static create: Function
 
   static displayName = 'ItemLayout'
@@ -176,7 +176,7 @@ class ItemLayout extends UIComponent<ReactProps<ItemLayoutProps>, any> {
 
   renderComponent({ ElementType, classes, unhandledProps, styles }) {
     const { as, debug, endMedia, media, renderMainArea, rootCSS, mediaCSS, endMediaCSS } = this
-      .props as ItemLayoutPropsWithDefaults
+      .props as ItemLayoutProps
 
     const startArea = media
     const mainArea = renderMainArea(this.props, this.state, classes)
@@ -216,7 +216,11 @@ class ItemLayout extends UIComponent<ReactProps<ItemLayoutProps>, any> {
   }
 }
 
-ItemLayout.create = createShorthandFactory({ Component: ItemLayout, mappedProp: 'content' })
+ItemLayout.create = createShorthandFactory<ItemLayoutProps>({
+  Component: ItemLayout,
+  mappedProp: 'content',
+})
+
 ItemLayout.slotClassNames = {
   header: `${ItemLayout.className}__header`,
   headerMedia: `${ItemLayout.className}__headerMedia`,
@@ -228,5 +232,3 @@ ItemLayout.slotClassNames = {
 }
 
 export default ItemLayout
-
-export type ItemLayoutPropsWithDefaults = ItemLayoutProps & typeof ItemLayout.defaultProps

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -20,7 +20,7 @@ import Image from '../Image/Image'
 import Layout from '../Layout/Layout'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import {
   ComplexColorPropType,
   ColorValuesWithPrimitiveColors,
@@ -59,7 +59,7 @@ export interface LabelProps
 /**
  * A Label is used to classify content.
  */
-class Label extends UIComponent<ReactProps<LabelProps>, any> {
+class Label<TAs = 'span'> extends UIComponent<StardustProps<LabelProps, TAs>, any> {
   static displayName = 'Label'
 
   static create: Function
@@ -156,6 +156,9 @@ class Label extends UIComponent<ReactProps<LabelProps>, any> {
   }
 }
 
-Label.create = createShorthandFactory({ Component: Label, mappedProp: 'content' })
+Label.create = createShorthandFactory<LabelProps>({
+  Component: Label,
+  mappedProp: 'content',
+})
 
 export default Label

--- a/packages/react/src/components/Layout/Layout.tsx
+++ b/packages/react/src/components/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import { UIComponent, UIComponentProps, commonPropTypes, rtlTextContainer } from '../../lib'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 import { ICSSInJSStyle } from '../../themes/types'
 
 export interface LayoutSlotClassNames {
@@ -49,7 +49,7 @@ export interface LayoutProps extends UIComponentProps {
 /**
  * (DEPRECATED) A layout is a utility for arranging the content of a component.
  */
-class Layout extends UIComponent<ReactProps<LayoutProps>, any> {
+class Layout<TAs = 'div'> extends UIComponent<StardustProps<LayoutProps, TAs>, any> {
   static className = 'ui-layout'
 
   static displayName = 'Layout'

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -17,7 +17,7 @@ import ListItem, { ListItemProps } from './ListItem'
 import { listBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
 import { ContainerFocusHandler } from '../../lib/accessibility/FocusHandling/FocusContainer'
-import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
+import { StardustProps, ShorthandValue, ComponentEventHandler } from '../../types'
 
 export interface ListSlotClassNames {
   item: string
@@ -67,7 +67,7 @@ export interface ListState {
 /**
  * A list displays a group of related content.
  */
-class List extends AutoControlledComponent<ReactProps<ListProps>, ListState> {
+class List<TAs = 'ul'> extends AutoControlledComponent<StardustProps<ListProps, TAs>, ListState> {
   static displayName = 'List'
 
   static className = 'ui-list'

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -13,7 +13,7 @@ import {
 import Flex from '../Flex/Flex'
 import { listItemBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
-import { ShorthandValue, ReactProps, ComponentEventHandler } from '../../types'
+import { ShorthandValue, StardustProps, ComponentEventHandler } from '../../types'
 import Box from '../Box/Box'
 
 export interface ListItemSlotClassNames {
@@ -74,7 +74,7 @@ export interface ListItemState {
 /**
  * A list item contains a single piece of content within a list.
  */
-class ListItem extends UIComponent<ReactProps<ListItemProps>, ListItemState> {
+class ListItem<TAs = 'li'> extends UIComponent<StardustProps<ListItemProps, TAs>, ListItemState> {
   static create: Function
 
   static displayName = 'ListItem'
@@ -228,7 +228,11 @@ class ListItem extends UIComponent<ReactProps<ListItemProps>, ListItemState> {
   }
 }
 
-ListItem.create = createShorthandFactory({ Component: ListItem, mappedProp: 'content' })
+ListItem.create = createShorthandFactory<ListItemProps>({
+  Component: ListItem,
+  mappedProp: 'content',
+})
+
 ListItem.slotClassNames = {
   header: `${ListItem.className}__header`,
   headerMedia: `${ListItem.className}__headerMedia`,

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../lib'
 import { loaderBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import Box from '../Box/Box'
 
 export type LoaderPosition = 'above' | 'below' | 'start' | 'end'
@@ -59,7 +59,7 @@ export interface LoaderState {
 /**
  * A Loader indicates a possible user action.
  */
-class Loader extends UIComponent<ReactProps<LoaderProps>, LoaderState> {
+class Loader<TAs = 'div'> extends UIComponent<StardustProps<LoaderProps, TAs>, LoaderState> {
   static create: Function
   static displayName = 'Loader'
   static className = 'ui-loader'

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -18,7 +18,7 @@ import { menuBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 
 import { ComponentVariablesObject, ComponentSlotStylesPrepared } from '../../themes/types'
-import { ReactProps, ShorthandCollection, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandCollection, ShorthandValue } from '../../types'
 import MenuDivider from './MenuDivider'
 
 export type MenuShorthandKinds = 'divider' | 'item'
@@ -88,7 +88,7 @@ export interface MenuState {
  * @accessibility
  * Implements ARIA Menu, Toolbar or Tabs design pattern, depending on the behavior used.
  */
-class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
+class Menu<TAs = 'ul'> extends AutoControlledComponent<StardustProps<MenuProps, TAs>, MenuState> {
   static displayName = 'Menu'
 
   static className = 'ui-menu'
@@ -224,6 +224,9 @@ class Menu extends AutoControlledComponent<ReactProps<MenuProps>, MenuState> {
   }
 }
 
-Menu.create = createShorthandFactory({ Component: Menu, mappedArrayProp: 'items' })
+Menu.create = createShorthandFactory<MenuProps>({
+  Component: Menu,
+  mappedArrayProp: 'items',
+})
 
 export default Menu

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -14,7 +14,7 @@ import {
   ContentComponentProps,
   rtlTextContainer,
 } from '../../lib'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface MenuDividerProps
   extends UIComponentProps,
@@ -36,7 +36,7 @@ export interface MenuDividerProps
 /**
  * A menu divider visually segments menu items inside menu.
  */
-class MenuDivider extends UIComponent<ReactProps<MenuDividerProps>> {
+class MenuDivider<TAs = 'li'> extends UIComponent<StardustProps<MenuDividerProps, TAs>> {
   static displayName = 'MenuDivider'
 
   static create: Function
@@ -72,6 +72,9 @@ class MenuDivider extends UIComponent<ReactProps<MenuDividerProps>> {
   }
 }
 
-MenuDivider.create = createShorthandFactory({ Component: MenuDivider, mappedProp: 'color' })
+MenuDivider.create = createShorthandFactory<MenuDividerProps>({
+  Component: MenuDivider,
+  mappedProp: 'color',
+})
 
 export default MenuDivider

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -23,7 +23,12 @@ import Menu from './Menu'
 import Box from '../Box/Box'
 import { menuItemBehavior, submenuBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
-import { ComponentEventHandler, ReactProps, ShorthandValue, ShorthandCollection } from '../../types'
+import {
+  ComponentEventHandler,
+  StardustProps,
+  ShorthandValue,
+  ShorthandCollection,
+} from '../../types'
 import { focusAsync } from '../../lib/accessibility/FocusZone'
 import Ref from '../Ref/Ref'
 
@@ -138,7 +143,10 @@ export interface MenuItemState {
 /**
  * A menu item is an actionable navigation item within a menu.
  */
-class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuItemState> {
+class MenuItem<TAs = 'a'> extends AutoControlledComponent<
+  StardustProps<MenuItemProps, TAs>,
+  MenuItemState
+> {
   static displayName = 'MenuItem'
 
   static className = 'ui-menu__item'
@@ -407,6 +415,9 @@ class MenuItem extends AutoControlledComponent<ReactProps<MenuItemProps>, MenuIt
   }
 }
 
-MenuItem.create = createShorthandFactory({ Component: MenuItem, mappedProp: 'content' })
+MenuItem.create = createShorthandFactory<MenuItemProps>({
+  Component: MenuItem,
+  mappedProp: 'content',
+})
 
 export default MenuItem

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -23,7 +23,7 @@ import {
   doesNodeContainClick,
   setWhatInputSource,
 } from '../../lib'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 
 import Ref from '../Ref/Ref'
 import { getPopupPlacement, applyRtlToOffset, Alignment, Position } from './positioningHelper'
@@ -145,7 +145,10 @@ export interface PopupState {
  * @accessibility This is example usage of the accessibility tag.
  * This should be replaced with the actual description after the PR is merged
  */
-export default class Popup extends AutoControlledComponent<ReactProps<PopupProps>, PopupState> {
+export default class Popup extends AutoControlledComponent<
+  StardustProps<PopupProps, false>,
+  PopupState
+> {
   static displayName = 'Popup'
 
   static className = 'ui-popup'
@@ -224,7 +227,7 @@ export default class Popup extends AutoControlledComponent<ReactProps<PopupProps
     classes,
     rtl,
     accessibility,
-  }: RenderResultConfig<PopupProps>): React.ReactNode {
+  }: RenderResultConfig<PopupProps, never>): React.ReactNode {
     const { inline } = this.props
     const popupContent = this.renderPopupContent(classes.popup, rtl, accessibility)
 

--- a/packages/react/src/components/Popup/PopupContent.tsx
+++ b/packages/react/src/components/Popup/PopupContent.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ComponentEventHandler } from '../../types'
+import { StardustProps, ComponentEventHandler } from '../../types'
 import Box from '../Box/Box'
 import Ref from '../Ref/Ref'
 
@@ -62,7 +62,7 @@ export interface PopupContentProps
  * @accessibility This is example usage of the accessibility tag.
  * This should be replaced with the actual description after the PR is merged
  */
-class PopupContent extends UIComponent<ReactProps<PopupContentProps>, any> {
+class PopupContent<TAs = 'div'> extends UIComponent<StardustProps<PopupContentProps, TAs>, any> {
   public static create: Function
 
   public static displayName = 'PopupContent'
@@ -136,6 +136,9 @@ class PopupContent extends UIComponent<ReactProps<PopupContentProps>, any> {
   }
 }
 
-PopupContent.create = createShorthandFactory({ Component: PopupContent, mappedProp: 'content' })
+PopupContent.create = createShorthandFactory<PopupContentProps>({
+  Component: PopupContent,
+  mappedProp: 'content',
+})
 
 export default PopupContent

--- a/packages/react/src/components/Portal/Portal.tsx
+++ b/packages/react/src/components/Portal/Portal.tsx
@@ -18,7 +18,7 @@ import Ref from '../Ref/Ref'
 import PortalInner from './PortalInner'
 import { FocusTrapZone, FocusTrapZoneProps } from '../../lib/accessibility/FocusZone'
 import { AccessibilityAttributes, OnKeyDownHandler } from '../../lib/accessibility/types'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 type ReactMouseEvent = React.MouseEvent<HTMLElement>
 export type TriggerAccessibility = {
@@ -81,7 +81,7 @@ export interface PortalState {
 /**
  * A component that allows you to render children outside their parent.
  */
-class Portal extends AutoControlledComponent<ReactProps<PortalProps>, PortalState> {
+class Portal extends AutoControlledComponent<StardustProps<PortalProps, false>, PortalState> {
   private portalNode: HTMLElement
   private triggerNode: HTMLElement
 
@@ -124,7 +124,7 @@ class Portal extends AutoControlledComponent<ReactProps<PortalProps>, PortalStat
     const { children, content, trapFocus } = this.props
     const { open } = this.state
     const contentToRender = childrenExist(children) ? children : content
-    const focusTrapZoneProps = (_.keys(trapFocus).length && trapFocus) || {}
+    const focusTrapZoneProps = (_.keys(trapFocus).length && (trapFocus as FocusTrapZoneProps)) || {}
 
     return (
       open && (

--- a/packages/react/src/components/Portal/PortalInner.tsx
+++ b/packages/react/src/components/Portal/PortalInner.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { isBrowser, ChildrenComponentProps, commonPropTypes } from '../../lib'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface PortalInnerProps extends ChildrenComponentProps {
   /** Existing element the portal should be bound to. */
@@ -27,7 +27,7 @@ export interface PortalInnerProps extends ChildrenComponentProps {
 /**
  * An inner component that allows you to render children outside their parent.
  */
-class PortalInner extends React.Component<ReactProps<PortalInnerProps>> {
+class PortalInner extends React.Component<StardustProps<PortalInnerProps, false>> {
   public static propTypes = {
     ...commonPropTypes.createCommon({
       accessibility: false,

--- a/packages/react/src/components/Provider/ProviderBox.tsx
+++ b/packages/react/src/components/Provider/ProviderBox.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { commonPropTypes } from '../../lib'
-import createComponent, { CreateComponentReturnType } from '../../lib/createComponent'
-import { ReactProps } from '../../types'
+import createComponent from '../../lib/createComponent'
+import { StardustProps } from '../../types'
 
-const ProviderBox: CreateComponentReturnType<ReactProps<{}>> = createComponent<any>({
+const ProviderBox = createComponent<StardustProps<React.PropsWithChildren<{}>, any>>({
   displayName: 'ProviderBox',
 
   className: 'ui-provider__box',

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -17,7 +17,7 @@ import {
 import RadioGroupItem, { RadioGroupItemProps } from './RadioGroupItem'
 import { radioGroupBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
-import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
+import { StardustProps, ShorthandValue, ComponentEventHandler } from '../../types'
 
 export interface RadioGroupSlotClassNames {
   item: string
@@ -55,7 +55,10 @@ export interface RadioGroupProps extends UIComponentProps, ChildrenComponentProp
  * @accessibility
  * Implements ARIA Radio Group design pattern.
  */
-class RadioGroup extends AutoControlledComponent<ReactProps<RadioGroupProps>, any> {
+class RadioGroup<TAs = 'div'> extends AutoControlledComponent<
+  StardustProps<RadioGroupProps, TAs>,
+  any
+> {
   static displayName = 'RadioGroup'
 
   static className = 'ui-radiogroup'

--- a/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
@@ -13,7 +13,7 @@ import {
   applyAccessibilityKeyHandlers,
 } from '../../lib'
 import Box from '../Box/Box'
-import { ComponentEventHandler, ReactProps, ShorthandValue } from '../../types'
+import { ComponentEventHandler, StardustProps, ShorthandValue } from '../../types'
 import Icon from '../Icon/Icon'
 import Ref from '../Ref/Ref'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -92,8 +92,8 @@ export interface RadioGroupItemState {
  * @accessibility
  * Radio items need to be grouped in RadioGroup component to correctly handle accessibility.
  */
-class RadioGroupItem extends AutoControlledComponent<
-  ReactProps<RadioGroupItemProps>,
+class RadioGroupItem<TAs = 'div'> extends AutoControlledComponent<
+  StardustProps<RadioGroupItemProps, TAs>,
   RadioGroupItemState
 > {
   private elementRef = React.createRef<HTMLElement>()
@@ -185,6 +185,9 @@ class RadioGroupItem extends AutoControlledComponent<
   }
 }
 
-RadioGroupItem.create = createShorthandFactory({ Component: RadioGroupItem, mappedProp: 'label' })
+RadioGroupItem.create = createShorthandFactory<RadioGroupItemProps>({
+  Component: RadioGroupItem,
+  mappedProp: 'label',
+})
 
 export default RadioGroupItem

--- a/packages/react/src/components/Reaction/Reaction.tsx
+++ b/packages/react/src/components/Reaction/Reaction.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue, ComponentEventHandler } from '../../types'
+import { StardustProps, ShorthandValue, ComponentEventHandler } from '../../types'
 import Icon from '../Icon/Icon'
 import Box from '../Box/Box'
 import ReactionGroup from './ReactionGroup'
@@ -56,7 +56,7 @@ export interface ReactionState {
 /**
  * A reaction is used to indicate user's reaction.
  */
-class Reaction extends UIComponent<ReactProps<ReactionProps>, ReactionState> {
+class Reaction<TAs = 'span'> extends UIComponent<StardustProps<ReactionProps, TAs>, ReactionState> {
   static create: Function
 
   static className = 'ui-reaction'
@@ -123,7 +123,11 @@ class Reaction extends UIComponent<ReactProps<ReactionProps>, ReactionState> {
   }
 }
 
-Reaction.create = createShorthandFactory({ Component: Reaction, mappedProp: 'content' })
+Reaction.create = createShorthandFactory<ReactionProps>({
+  Component: Reaction,
+  mappedProp: 'content',
+})
+
 Reaction.slotClassNames = {
   icon: `${Reaction.className}__icon`,
   content: `${Reaction.className}__content`,

--- a/packages/react/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/react/src/components/Reaction/ReactionGroup.tsx
@@ -2,7 +2,7 @@ import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as React from 'react'
 import * as _ from 'lodash'
 
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import {
   UIComponent,
   childrenExist,
@@ -34,7 +34,7 @@ export interface ReactionGroupProps
 /**
  * A reaction group presents multiple reactions as a group.
  */
-class ReactionGroup extends UIComponent<ReactProps<ReactionGroupProps>> {
+class ReactionGroup<TAs = 'div'> extends UIComponent<StardustProps<ReactionGroupProps, TAs>> {
   static create: Function
 
   public static displayName = 'ReactionGroup'
@@ -85,7 +85,7 @@ class ReactionGroup extends UIComponent<ReactProps<ReactionGroupProps>> {
   }
 }
 
-ReactionGroup.create = createShorthandFactory({
+ReactionGroup.create = createShorthandFactory<ReactionGroupProps>({
   Component: ReactionGroup,
   mappedProp: 'content',
   mappedArrayProp: 'items',

--- a/packages/react/src/components/Segment/Segment.tsx
+++ b/packages/react/src/components/Segment/Segment.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 import Box from '../Box/Box'
 
 export interface SegmentProps
@@ -31,7 +31,7 @@ export interface SegmentProps
 /**
  * A segment is used to create a grouping of related content.
  */
-class Segment extends UIComponent<ReactProps<SegmentProps>, any> {
+class Segment<TAs = 'div'> extends UIComponent<StardustProps<SegmentProps, TAs>, any> {
   static className = 'ui-segment'
 
   static displayName = 'Segment'

--- a/packages/react/src/components/Status/Status.tsx
+++ b/packages/react/src/components/Status/Status.tsx
@@ -12,7 +12,7 @@ import {
   commonPropTypes,
   SizeValue,
 } from '../../lib'
-import { ReactProps, ShorthandValue } from '../../types'
+import { StardustProps, ShorthandValue } from '../../types'
 
 export interface StatusProps extends UIComponentProps {
   /**
@@ -39,7 +39,7 @@ export interface StatusProps extends UIComponentProps {
  * @accessibility
  * The 'img' role is used to identify an element as image. 'Title' attribute have to be provided on status component. Then reader narrate content of 'title' attribute.
  */
-class Status extends UIComponent<ReactProps<StatusProps>, any> {
+class Status<TAs = 'span'> extends UIComponent<StardustProps<StatusProps, TAs>, any> {
   static create: Function
 
   static className = 'ui-status'
@@ -81,6 +81,9 @@ class Status extends UIComponent<ReactProps<StatusProps>, any> {
   }
 }
 
-Status.create = createShorthandFactory({ Component: Status, mappedProp: 'state' })
+Status.create = createShorthandFactory<StatusProps>({
+  Component: Status,
+  mappedProp: 'state',
+})
 
 export default Status

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { defaultBehavior } from '../../lib/accessibility'
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 
 export interface TextProps
   extends UIComponentProps,
@@ -70,7 +70,7 @@ export interface TextProps
  * - 'content' is provided as plain string (then dir="auto" attribute will be applied automatically)
  * - for other 'content' value types (i.e. that use elements inside) ensure that dir="auto" attribute is applied for all places in content where necessary
  */
-class Text extends UIComponent<ReactProps<TextProps>, any> {
+class Text<TAs = 'span'> extends UIComponent<StardustProps<TextProps, TAs>, any> {
   static create: Function
 
   static className = 'ui-text'
@@ -112,6 +112,9 @@ class Text extends UIComponent<ReactProps<TextProps>, any> {
   }
 }
 
-Text.create = createShorthandFactory({ Component: Text, mappedProp: 'content' })
+Text.create = createShorthandFactory<TextProps>({
+  Component: Text,
+  mappedProp: 'content',
+})
 
 export default Text

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -13,7 +13,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
 } from '../../lib'
-import { ShorthandValue, ShorthandRenderFunction, ReactProps } from '../../types'
+import { ShorthandValue, ShorthandRenderFunction, StardustProps } from '../../types'
 import { Accessibility } from '../../lib/accessibility/types'
 import { treeBehavior } from '../../lib/accessibility'
 
@@ -38,7 +38,7 @@ export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
   exclusive?: boolean
 
   /** Shorthand array of props for Tree. */
-  items: ShorthandValue[]
+  items?: ShorthandValue[]
 
   /**
    * A custom render function for the title slot.
@@ -57,7 +57,7 @@ export interface TreeState {
 /**
  * Allows users to display data organised in tree-hierarchy.
  */
-class Tree extends AutoControlledComponent<ReactProps<TreeProps>, TreeState> {
+class Tree<TAs = 'ul'> extends AutoControlledComponent<StardustProps<TreeProps, TAs>, TreeState> {
   static create: Function
 
   static displayName = 'Tree'
@@ -157,6 +157,9 @@ class Tree extends AutoControlledComponent<ReactProps<TreeProps>, TreeState> {
   }
 }
 
-Tree.create = createShorthandFactory({ Component: Tree, mappedArrayProp: 'items' })
+Tree.create = createShorthandFactory<TreeProps>({
+  Component: Tree,
+  mappedArrayProp: 'items',
+})
 
 export default Tree

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../lib'
 import {
   ComponentEventHandler,
-  ReactProps,
+  StardustProps,
   ShorthandRenderFunction,
   ShorthandValue,
 } from '../../types'
@@ -67,7 +67,7 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   title?: ShorthandValue
 }
 
-class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
+class TreeItem<TAs = 'li'> extends UIComponent<StardustProps<TreeItemProps, TAs>> {
   static create: Function
 
   static displayName = 'TreeItem'
@@ -152,6 +152,9 @@ class TreeItem extends UIComponent<ReactProps<TreeItemProps>> {
   }
 }
 
-TreeItem.create = createShorthandFactory({ Component: TreeItem, mappedProp: 'title' })
+TreeItem.create = createShorthandFactory<TreeItemProps>({
+  Component: TreeItem,
+  mappedProp: 'title',
+})
 
 export default TreeItem

--- a/packages/react/src/components/Tree/TreeTitle.tsx
+++ b/packages/react/src/components/Tree/TreeTitle.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../lib'
 import { treeTitleBehavior } from '../../lib/accessibility'
 import { Accessibility, AccessibilityActionHandlers } from '../../lib/accessibility/types'
-import { ComponentEventHandler, ReactProps } from '../../types'
+import { ComponentEventHandler, StardustProps } from '../../types'
 
 export interface TreeTitleProps
   extends UIComponentProps,
@@ -42,7 +42,7 @@ export interface TreeTitleProps
   hasSubtree?: boolean
 }
 
-class TreeTitle extends UIComponent<ReactProps<TreeTitleProps>> {
+class TreeTitle<TAs = 'a'> extends UIComponent<StardustProps<TreeTitleProps, TAs>> {
   static create: Function
 
   static className = 'ui-tree__title'
@@ -90,6 +90,9 @@ class TreeTitle extends UIComponent<ReactProps<TreeTitleProps>> {
   }
 }
 
-TreeTitle.create = createShorthandFactory({ Component: TreeTitle, mappedProp: 'content' })
+TreeTitle.create = createShorthandFactory<TreeTitleProps>({
+  Component: TreeTitle,
+  mappedProp: 'content',
+})
 
 export default TreeTitle

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { createShorthandFactory, UIComponent, UIComponentProps, commonPropTypes } from '../../lib'
 
-import { ReactProps } from '../../types'
+import { StardustProps } from '../../types'
 import { defaultBehavior } from '../../lib/accessibility'
 import Ref from '../Ref/Ref'
 
@@ -30,7 +30,7 @@ export interface VideoProps extends UIComponentProps {
 /**
  * An video is a graphicical and audio representation of something.
  */
-class Video extends UIComponent<ReactProps<VideoProps>> {
+class Video<TAs = 'video'> extends UIComponent<StardustProps<VideoProps, TAs>> {
   static create: Function
 
   static className = 'ui-video'
@@ -100,6 +100,9 @@ class Video extends UIComponent<ReactProps<VideoProps>> {
   }
 }
 
-Video.create = createShorthandFactory({ Component: Video, mappedProp: 'src' })
+Video.create = createShorthandFactory<VideoProps>({
+  Component: Video,
+  mappedProp: 'src',
+})
 
 export default Video

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -84,7 +84,6 @@ export { default as Input, InputState, InputProps } from './components/Input/Inp
 
 export {
   default as ItemLayout,
-  ItemLayoutPropsWithDefaults,
   ItemLayoutProps,
   ItemLayoutSlotClassNames,
 } from './components/ItemLayout/ItemLayout'

--- a/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -18,12 +18,16 @@ import {
 import { FocusTrapZoneProps } from './FocusTrapZone.types'
 import getUnhandledProps from '../../getUnhandledProps'
 import getElementType from '../../getElementType'
+import { StardustProps } from '../../../types'
 
 /** FocusTrapZone is used to trap the focus in any html element placed in body
  *  and hide other elements outside of Focus Trap Zone from accessibility tree.
  *  Pressing tab will circle focus within the inner focusable elements of the FocusTrapZone. */
-export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
-  private static _focusStack: FocusTrapZone[] = []
+export class FocusTrapZone<TAs = 'div'> extends React.Component<
+  StardustProps<FocusTrapZoneProps, TAs>,
+  {}
+> {
+  private static _focusStack: FocusTrapZone<any>[] = []
   private _root: { current: HTMLElement | null } = { current: null }
   private _previouslyFocusedElementOutsideTrapZone: HTMLElement
   private _previouslyFocusedElementInTrapZone?: HTMLElement
@@ -162,7 +166,7 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
       firstFocusableSelector &&
       (typeof firstFocusableSelector === 'string'
         ? firstFocusableSelector
-        : firstFocusableSelector())
+        : (firstFocusableSelector as Function)())
 
     const firstFocusableChild = focusSelector
       ? (this._root.current.querySelector(`.${focusSelector}`) as HTMLElement)

--- a/packages/react/src/lib/commonPropInterfaces.ts
+++ b/packages/react/src/lib/commonPropInterfaces.ts
@@ -18,8 +18,6 @@ export interface AnimatedComponentProps {
 export interface UIComponentProps<P = any, V = any>
   extends StyledComponentProps<P, V>,
     AnimatedComponentProps {
-  [key: string]: any
-
   /** An element type to render as (string or function). */
   as?: any
 

--- a/packages/react/src/lib/createComponent.tsx
+++ b/packages/react/src/lib/createComponent.tsx
@@ -22,6 +22,12 @@ export interface CreateComponentConfig<P> {
   render: (config: RenderResultConfig<P>, props: P) => React.ReactNode
 }
 
+// export type StardustFunctionComponent<P={}> = <TAs='div'>(props: ReactProps<P, TAs>) => JSX.Element
+
+// export type CreateComponentReturnType<P> = StardustFunctionComponent<P> & {
+//   create: Function
+// }
+
 export type CreateComponentReturnType<P> = React.FunctionComponent<P> & {
   create: Function
 }
@@ -42,7 +48,8 @@ const createComponent = <P extends ObjectOf<any> = any>({
     ...(defaultProps as any),
   }
 
-  const StardustComponent: CreateComponentReturnType<P> = (props): React.ReactElement<P> => {
+  // const StardustComponent = function<TAs='div'>(props: ReactProps<P, TAs>): JSX.Element {
+  const StardustComponent = (props: P): JSX.Element => {
     const theme: ThemePrepared = React.useContext(ThemeContext)
 
     return renderComponent(
@@ -55,7 +62,7 @@ const createComponent = <P extends ObjectOf<any> = any>({
         state: {},
         actionHandlers,
         focusZoneRef,
-        render: config => render(config, props),
+        render: config => render(config, props as P),
       },
       theme,
     )

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -4,7 +4,6 @@ import * as React from 'react'
 import {
   ShorthandValue,
   Props,
-  PropsOf,
   ShorthandRenderCallback,
   ShorthandRenderFunction,
   ShorthandRenderer,
@@ -54,8 +53,8 @@ export function createShorthand({
   options = CREATE_SHORTHAND_DEFAULT_OPTIONS,
 }: {
   Component: React.ReactType
-  mappedProp?: string
-  mappedArrayProp?: string
+  mappedProp?: string | number | symbol
+  mappedArrayProp?: string | number | symbol
   valueOrRenderCallback?: ShorthandValue | ShorthandRenderCallback
   options?: CreateShorthandOptions
 }): React.ReactElement<Props> | null | undefined {
@@ -80,12 +79,11 @@ export function createShorthand({
   })
 }
 
-type CreateShorthandFactoryConfigInner<TPropName = string> = {
-  Component: React.ReactType
-  mappedProp?: TPropName
-  mappedArrayProp?: TPropName
+export type CreateShorthandFactoryConfig<TProps> = {
+  Component: React.ComponentType<{ [K in keyof TProps]?: TProps[K] }>
+  mappedProp?: keyof TProps
+  mappedArrayProp?: keyof TProps
 }
-export type CreateShorthandFactoryConfig = CreateShorthandFactoryConfigInner
 // ============================================================
 // Factory Creators
 // ============================================================
@@ -95,26 +93,11 @@ export type CreateShorthandFactoryConfig = CreateShorthandFactoryConfigInner
  * * @param {string} mappedArrayProp A function that maps an array value to the Component props
  * @returns {function} A shorthand factory function waiting for `val` and `defaultProps`.
  */
-export function createShorthandFactory<TStringElement extends keyof JSX.IntrinsicElements>(config: {
-  Component: TStringElement
-  mappedProp?: keyof PropsOf<TStringElement>
-  mappedArrayProp?: keyof PropsOf<TStringElement>
-})
-export function createShorthandFactory<TFunctionComponent extends React.FunctionComponent>(config: {
-  Component: TFunctionComponent
-  mappedProp?: keyof PropsOf<TFunctionComponent>
-  mappedArrayProp?: keyof PropsOf<TFunctionComponent>
-})
-export function createShorthandFactory<TInstance extends React.Component>(config: {
-  Component: { new (...args: any[]): TInstance }
-  mappedProp?: keyof PropsOf<TInstance>
-  mappedArrayProp?: keyof PropsOf<TInstance>
-})
-export function createShorthandFactory({
+export function createShorthandFactory<TProps>({
   Component,
   mappedProp,
   mappedArrayProp,
-}: CreateShorthandFactoryConfigInner<any>) {
+}: CreateShorthandFactoryConfig<any>) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
     throw new Error('createShorthandFactory() Component must be a string or function.')
   }
@@ -135,8 +118,8 @@ function createShorthandFromValue({
   options,
 }: {
   Component: React.ReactType
-  mappedProp?: string
-  mappedArrayProp?: string
+  mappedProp?: string | number | symbol
+  mappedArrayProp?: string | number | symbol
   value?: ShorthandValue
   options?: CreateShorthandOptions
 }) {
@@ -265,8 +248,8 @@ function createShorthandFromRenderCallback({
 }: {
   Component: React.ReactType
   renderCallback: ShorthandRenderCallback
-  mappedProp?: string
-  mappedArrayProp?: string
+  mappedProp?: string | number | symbol
+  mappedArrayProp?: string | number | symbol
   options?: CreateShorthandOptions
 }) {
   const render: ShorthandRenderer = (shorthandValue, renderTree) => {

--- a/packages/react/src/lib/renderComponent.tsx
+++ b/packages/react/src/lib/renderComponent.tsx
@@ -17,7 +17,7 @@ import {
   State,
   ThemePrepared,
 } from '../themes/types'
-import { Props } from '../types'
+import { Props, StardustProps } from '../types'
 import {
   AccessibilityBehavior,
   AccessibilityDefinition,
@@ -33,8 +33,8 @@ import { FOCUSZONE_WRAP_ATTRIBUTE } from './accessibility/FocusZone/focusUtiliti
 import createAnimationStyles from './createAnimationStyles'
 import { generateColorScheme } from './colorUtils'
 
-export interface RenderResultConfig<P> {
-  ElementType: React.ElementType<P>
+export interface RenderResultConfig<P, TAs = any> {
+  ElementType: React.ElementType<StardustProps<P, TAs>>
   classes: ComponentSlotClasses
   unhandledProps: Props
   variables: ComponentVariablesObject

--- a/packages/react/test/specs/commonTests/implementsWrapperProp.tsx
+++ b/packages/react/test/specs/commonTests/implementsWrapperProp.tsx
@@ -3,7 +3,7 @@ import { ReactWrapper } from 'enzyme'
 import { mountWithProvider as mount } from 'test/utils'
 
 import Box from 'src/components/Box/Box'
-import { ReactProps, ShorthandValue } from 'src/types'
+import { StardustProps, ShorthandValue } from 'src/types'
 
 export interface ImplementsWrapperPropOptions {
   wrapppedComponentSelector: any
@@ -15,7 +15,7 @@ type WrapperProps = {
 }
 
 const implementsWrapperProp = (
-  Component: React.ComponentType<ReactProps<WrapperProps>>,
+  Component: React.ComponentType<StardustProps<WrapperProps>>,
   options: ImplementsWrapperPropOptions,
 ) => {
   const { wrapppedComponentSelector, WrapperComponent = Box } = options


### PR DESCRIPTION
This PR demos the approach we could use for introducing strict type checks for Stardust components' props. Lets consider it a starting point for discussing the approach to types we might want to introduce.

## Important note
Unfortunately, precommit checks had stripping out some of the generic types used, need to address this issue.

## Type files to review
- types.ts

## Problems discovered (files list)
- ComponentDocSee
- ComponentControls
- ComponentExample
- ComponentProps
- ComponentSidebar
- ComponentSidebarSection
- ItemLayoutExampleSelection
- PortalExample
- PortalExampleControlled
- PortalExampleFocusTrapped
- AsyncShorthand
- IconViewerExample/index
- ChatPaneContent
- PageNotFound
- QuickStart
- DropdownItem