### PR TITLE
feat(dropdown): align, position, offset props + automatic position

### DIFF
--- a/docs/src/examples/components/Dropdown/Variations/DropdownExampleOffset.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Variations/DropdownExampleOffset.shorthand.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { Grid, Dropdown } from '@stardust-ui/react'
+
+const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange', 'Alfred Pennyworth']
+
+const DropdownExamplePosition = () => (
+  <Grid columns="1, 80px" variables={{ padding: '30px' }}>
+    <Dropdown
+      items={inputItems}
+      placeholder="Select your hero"
+      align="start"
+      position="above"
+      offset="-100%p"
+    />
+  </Grid>
+)
+
+export default DropdownExamplePosition

--- a/docs/src/examples/components/Dropdown/Variations/DropdownExamplePosition.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Variations/DropdownExamplePosition.shorthand.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { Grid, Dropdown } from '@stardust-ui/react'
+
+const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange', 'Alfred Pennyworth']
+
+const DropdownArrowExample = props => {
+  const { position, align } = props
+
+  return (
+    <Dropdown
+      items={inputItems}
+      placeholder={`${position} the trigger aligned to the ${align}.`}
+      align={align}
+      position={position}
+    />
+  )
+}
+
+const triggers = [
+  { position: 'above', align: 'start' },
+  { position: 'above', align: 'end' },
+  { position: 'below', align: 'start' },
+  { position: 'below', align: 'end' },
+  { position: 'before', align: 'top' },
+  { position: 'before', align: 'bottom' },
+  { position: 'after', align: 'top' },
+  { position: 'after', align: 'bottom' },
+]
+
+const DropdownExamplePosition = () => (
+  <Grid columns="repeat(2, 1fr)" variables={{ padding: '100px', gridGap: '100px' }}>
+    {triggers.map(({ position, align }) => (
+      <DropdownArrowExample position={position} align={align} key={`${position}-${align}`} />
+    ))}
+  </Grid>
+)
+
+export default DropdownExamplePosition

--- a/docs/src/examples/components/Dropdown/Variations/index.tsx
+++ b/docs/src/examples/components/Dropdown/Variations/index.tsx
@@ -19,6 +19,16 @@ const Variations = () => (
       description="A multiple search dropdown that uses French to provide information and accessibility."
       examplePath="components/Dropdown/Variations/DropdownExampleSearchMultipleFrenchLanguage"
     />
+    <ComponentExample
+      title="Alignment and Position"
+      description="A dropdown can be positioned around its trigger and aligned relative to the trigger's margins. Click on a button to open a dropdown on a specific position and alignment."
+      examplePath="components/Dropdown/Variations/DropdownExamplePosition"
+    />
+    <ComponentExample
+      title="Offset"
+      description="Dropdown position could be further customized by providing offset value. Note that percentage values of both trigger and dropdown elements' lengths are supported."
+      examplePath="components/Dropdown/Variations/DropdownExampleOffset"
+    />
   </ExampleSection>
 )
 

--- a/packages/react-component-ref/src/Ref.tsx
+++ b/packages/react-component-ref/src/Ref.tsx
@@ -14,7 +14,7 @@ export interface RefProps {
    *
    * @param {HTMLElement} node - Referred node.
    */
-  innerRef: React.Ref<any>
+  innerRef: React.Ref<HTMLElement>
 }
 
 const Ref: React.FunctionComponent<RefProps> = props => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -123,7 +123,7 @@ export {
   PopupEventsArray,
 } from './components/Popup/Popup'
 export { default as PopupContent, PopupContentProps } from './components/Popup/PopupContent'
-export { Placement, Alignment, Position } from './components/Popup/positioningHelper'
+export { Alignment, Position } from './lib/positioner'
 
 export {
   default as Portal,

--- a/packages/react/src/lib/positioner/Positioner.tsx
+++ b/packages/react/src/lib/positioner/Positioner.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+import { Popper, PopperChildrenProps, PopperProps } from 'react-popper'
+import { Modifiers } from 'popper.js'
+
+import { Alignment, Position } from './index'
+import { getPlacement, applyRtlToOffset } from './positioningHelper'
+import createPopperReferenceProxy from './createPopperReferenceProxy'
+
+export interface PositionCommonProps {
+  /** Alignment for the component. */
+  align?: Alignment
+
+  /** Offset value to apply to rendered component. Accepts the following units:
+   * - px or unit-less, interpreted as pixels
+   * - %, percentage relative to the length of the trigger element
+   * - %p, percentage relative to the length of the component element
+   * - vw, CSS viewport width unit
+   * - vh, CSS viewport height unit
+   */
+  offset?: string
+
+  /**
+   * Position for the component. Position has higher priority than align. If position is vertical ('above' | 'below')
+   * and align is also vertical ('top' | 'bottom') or if both position and align are horizontal ('before' | 'after'
+   * and 'start' | 'end' respectively), then provided value for 'align' will be ignored and 'center' will be used instead.
+   */
+  position?: Position
+}
+
+interface PositionerProps extends PopperProps, PositionCommonProps {
+  /**
+   * Content for children using render props API
+   */
+  children: (props: PopperChildrenProps) => React.ReactNode
+
+  /**
+   * rtl attribute for the component
+   */
+  rtl?: boolean
+
+  target?: HTMLElement | React.RefObject<HTMLElement>
+}
+
+const Positioner: React.FunctionComponent<PositionerProps> = props => {
+  const { align, children, position, offset, rtl, target, ...rest } = props
+  // https://popper.js.org/popper-documentation.html#modifiers..offset
+  const popperModifiers: Modifiers = offset && {
+    offset: { offset: rtl ? applyRtlToOffset(offset, position) : offset },
+    keepTogether: { enabled: false },
+  }
+
+  return (
+    <Popper
+      positionFixed
+      children={children}
+      referenceElement={createPopperReferenceProxy(target)}
+      placement={getPlacement({ align, position, rtl })}
+      modifiers={popperModifiers}
+      {...rest}
+    />
+  )
+}
+
+export default Positioner

--- a/packages/react/src/lib/positioner/UpdatableComponent.tsx
+++ b/packages/react/src/lib/positioner/UpdatableComponent.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { Ref } from '@stardust-ui/react-component-ref'
+
+import { Extendable } from '../../types'
+
+interface UpdatableListProps {
+  /**
+   * Component that will be rendered.
+   */
+  Component: React.ComponentType
+
+  /**
+   * Called when a child component will be mounted or updated.
+   *
+   * @param {HTMLElement} node - Referred node.
+   */
+  innerRef?: React.Ref<HTMLElement>
+
+  /**
+   * Function that will trigger the rerender.
+   */
+  scheduleUpdate: Function
+
+  /**
+   * Array of conditions to be met in order to trigger a subsequent render.
+   */
+  updateDependencies: any[]
+}
+
+const UpdatableComponent: React.FunctionComponent<Extendable<UpdatableListProps>> = props => {
+  const { Component, innerRef, scheduleUpdate, updateDependencies, ...rest } = props
+
+  React.useEffect(() => scheduleUpdate && scheduleUpdate(), updateDependencies)
+
+  if (!innerRef) return <Component {...rest} />
+  return (
+    <Ref innerRef={innerRef}>
+      <Component {...rest} />
+    </Ref>
+  )
+}
+
+export default UpdatableComponent

--- a/packages/react/src/lib/positioner/createPopperReferenceProxy.ts
+++ b/packages/react/src/lib/positioner/createPopperReferenceProxy.ts
@@ -4,11 +4,7 @@ import * as React from 'react'
 import * as PopperJS from 'popper.js'
 
 class ReferenceProxy implements PopperJS.ReferenceObject {
-  ref: React.RefObject<HTMLElement>
-
-  constructor(refObject) {
-    this.ref = refObject
-  }
+  constructor(private ref: React.RefObject<HTMLElement>) {}
 
   getBoundingClientRect() {
     return _.invoke(this.ref.current, 'getBoundingClientRect', {})

--- a/packages/react/src/lib/positioner/index.ts
+++ b/packages/react/src/lib/positioner/index.ts
@@ -1,0 +1,7 @@
+export type Position = 'above' | 'below' | 'before' | 'after'
+export type Alignment = 'top' | 'bottom' | 'start' | 'end' | 'center'
+export const POSITIONS: Position[] = ['above', 'below', 'before', 'after']
+export const ALIGNMENTS: Alignment[] = ['top', 'bottom', 'start', 'end', 'center']
+
+export { default as Positioner, PositionCommonProps } from './Positioner'
+export { default as UpdatableComponent } from './UpdatableComponent'

--- a/packages/react/src/lib/positioner/positioningHelper.ts
+++ b/packages/react/src/lib/positioner/positioningHelper.ts
@@ -1,8 +1,6 @@
-export { Placement } from 'popper.js'
 import { Placement } from 'popper.js'
 
-export type Position = 'above' | 'below' | 'before' | 'after'
-export type Alignment = 'top' | 'bottom' | 'start' | 'end' | 'center'
+import { Alignment, Position } from './index'
 
 enum PlacementParts {
   top = 'top',
@@ -56,7 +54,7 @@ const shouldAlignToCenter = (p: Position, a: Alignment) => {
  * | after    | center    |  right          |  left
  * | after    | bottom    |  right-end      |  left-end
  */
-export const getPopupPlacement = ({
+export const getPlacement = ({
   align,
   position,
   rtl,

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -122,7 +122,6 @@ const dropdownStyles: ComponentSlotStylesInput<DropdownPropsAndState, DropdownVa
     maxHeight: v.listMaxHeight,
     overflowY: 'auto',
     width: getWidth(p, v),
-    top: 'calc(100% + 2px)', // leave room for container + its border
     background: v.listBackgroundColor,
     ...(p.open && {
       boxShadow: v.listBoxShadow,

--- a/packages/react/test/specs/components/Popup/Popup-test.tsx
+++ b/packages/react/test/specs/components/Popup/Popup-test.tsx
@@ -1,12 +1,5 @@
-import { Placement } from 'popper.js'
 import * as React from 'react'
 
-import {
-  getPopupPlacement,
-  applyRtlToOffset,
-  Position,
-  Alignment,
-} from 'src/components/Popup/positioningHelper'
 import Popup, { PopupEvents } from 'src/components/Popup/Popup'
 import { Accessibility } from 'src/lib/accessibility/types'
 import { popupFocusTrapBehavior, popupBehavior, dialogBehavior } from 'src/lib/accessibility/index'
@@ -15,33 +8,9 @@ import { domEvent, mountWithProvider } from '../../../utils'
 import * as keyboardKey from 'keyboard-key'
 import { ReactWrapper } from 'enzyme'
 
-type PositionTestInput = {
-  align: Alignment
-  position: Position
-  expectedPlacement: Placement
-  rtl?: boolean
-}
-
 describe('Popup', () => {
   const triggerId = 'triggerElement'
   const contentId = 'contentId'
-  const testPopupPosition = ({
-    align,
-    position,
-    expectedPlacement,
-    rtl = false,
-  }: PositionTestInput) =>
-    it(`Popup ${position} position is transformed to ${expectedPlacement} Popper's placement`, () => {
-      const actualPlacement = getPopupPlacement({ align, position, rtl })
-      expect(actualPlacement).toEqual(expectedPlacement)
-    })
-
-  const testPopupPositionInRtl = ({
-    align,
-    position,
-    expectedPlacement,
-  }: PositionTestInput & { rtl?: never }) =>
-    testPopupPosition({ align, position, expectedPlacement, rtl: true })
 
   const getPopupContent = (popup: ReactWrapper) => {
     return popup.find(`div#${contentId}`)
@@ -75,77 +44,6 @@ describe('Popup', () => {
     popupTriggerElement.simulate('keydown', { keyCode: keyboardKeyToClose })
     expect(getPopupContent(popup).exists()).toBe(false)
   }
-
-  describe('handles Popup position correctly in ltr', () => {
-    testPopupPosition({ position: 'above', align: 'start', expectedPlacement: 'top-start' })
-    testPopupPosition({ position: 'above', align: 'center', expectedPlacement: 'top' })
-    testPopupPosition({ position: 'above', align: 'end', expectedPlacement: 'top-end' })
-    testPopupPosition({ position: 'below', align: 'start', expectedPlacement: 'bottom-start' })
-    testPopupPosition({ position: 'below', align: 'center', expectedPlacement: 'bottom' })
-    testPopupPosition({ position: 'below', align: 'end', expectedPlacement: 'bottom-end' })
-    testPopupPosition({ position: 'before', align: 'top', expectedPlacement: 'left-start' })
-    testPopupPosition({ position: 'before', align: 'center', expectedPlacement: 'left' })
-    testPopupPosition({ position: 'before', align: 'bottom', expectedPlacement: 'left-end' })
-    testPopupPosition({ position: 'after', align: 'top', expectedPlacement: 'right-start' })
-    testPopupPosition({ position: 'after', align: 'center', expectedPlacement: 'right' })
-    testPopupPosition({ position: 'after', align: 'bottom', expectedPlacement: 'right-end' })
-  })
-
-  describe('handles Popup position correctly in rtl', () => {
-    testPopupPositionInRtl({ position: 'above', align: 'start', expectedPlacement: 'top-end' })
-    testPopupPositionInRtl({ position: 'above', align: 'center', expectedPlacement: 'top' })
-    testPopupPositionInRtl({ position: 'above', align: 'end', expectedPlacement: 'top-start' })
-    testPopupPositionInRtl({ position: 'below', align: 'start', expectedPlacement: 'bottom-end' })
-    testPopupPositionInRtl({ position: 'below', align: 'center', expectedPlacement: 'bottom' })
-    testPopupPositionInRtl({ position: 'below', align: 'end', expectedPlacement: 'bottom-start' })
-    testPopupPositionInRtl({ position: 'before', align: 'top', expectedPlacement: 'right-start' })
-    testPopupPositionInRtl({ position: 'before', align: 'center', expectedPlacement: 'right' })
-    testPopupPositionInRtl({ position: 'before', align: 'bottom', expectedPlacement: 'right-end' })
-    testPopupPositionInRtl({ position: 'after', align: 'top', expectedPlacement: 'left-start' })
-    testPopupPositionInRtl({ position: 'after', align: 'center', expectedPlacement: 'left' })
-    testPopupPositionInRtl({ position: 'after', align: 'bottom', expectedPlacement: 'left-end' })
-  })
-
-  describe('Popup offset transformed correctly in RTL', () => {
-    it("applies transform only for 'above' and 'below' postioning", () => {
-      const originalOffsetValue = '100%'
-
-      expect(applyRtlToOffset(originalOffsetValue, 'above')).not.toBe(originalOffsetValue)
-      expect(applyRtlToOffset(originalOffsetValue, 'below')).not.toBe(originalOffsetValue)
-
-      expect(applyRtlToOffset(originalOffsetValue, 'before')).toBe(originalOffsetValue)
-      expect(applyRtlToOffset(originalOffsetValue, 'after')).toBe(originalOffsetValue)
-    })
-
-    const expectOffsetTransformResult = (originalOffset, resultOffset) => {
-      expect(applyRtlToOffset(originalOffset, 'above')).toBe(resultOffset)
-    }
-
-    it('flips sign of simple expressions', () => {
-      expectOffsetTransformResult('100%', '-100%')
-      expectOffsetTransformResult('  2000%p ', '-2000%p')
-      expectOffsetTransformResult('100  ', '-100')
-      expectOffsetTransformResult(' - 200vh', '200vh')
-    })
-
-    it('flips sign of complex expressions', () => {
-      expectOffsetTransformResult('100% + 200', '-100% - 200')
-      expectOffsetTransformResult(' - 2000%p - 400 +800vh ', '2000%p + 400 -800vh')
-    })
-
-    it('transforms only horizontal offset value', () => {
-      const xOffset = '-100%'
-      const yOffset = '800vh'
-
-      const offsetValue = [xOffset, yOffset].join(',')
-      const [xOffsetTransformed, yOffsetTransformed] = applyRtlToOffset(offsetValue, 'above').split(
-        ',',
-      )
-
-      expect(xOffsetTransformed.trim()).not.toBe(xOffset)
-      expect(yOffsetTransformed.trim()).toBe(yOffset)
-    })
-  })
 
   describe('onOpenChange', () => {
     test('is called on click', () => {

--- a/packages/react/test/specs/lib/positioner/positioningHelper-test.ts
+++ b/packages/react/test/specs/lib/positioner/positioningHelper-test.ts
@@ -1,0 +1,122 @@
+import { Placement } from 'popper.js'
+
+import { Alignment, Position } from 'src/lib/positioner'
+import { getPlacement, applyRtlToOffset } from 'src/lib/positioner/positioningHelper'
+
+type PositionTestInput = {
+  align: Alignment
+  position: Position
+  expectedPlacement: Placement
+  rtl?: boolean
+}
+
+describe('positioningHelper', () => {
+  const testPositioningHelper = ({
+    align,
+    position,
+    expectedPlacement,
+    rtl = false,
+  }: PositionTestInput) =>
+    it(`positioningHelper ${position} position argument is transformed to ${expectedPlacement} Popper's placement`, () => {
+      const actualPlacement = getPlacement({ align, position, rtl })
+      expect(actualPlacement).toEqual(expectedPlacement)
+    })
+
+  const testPositioningHelperInRtl = ({
+    align,
+    position,
+    expectedPlacement,
+  }: PositionTestInput & { rtl?: never }) =>
+    testPositioningHelper({ align, position, expectedPlacement, rtl: true })
+
+  describe('handles positioningHelper position argument correctly in ltr', () => {
+    testPositioningHelper({ position: 'above', align: 'start', expectedPlacement: 'top-start' })
+    testPositioningHelper({ position: 'above', align: 'center', expectedPlacement: 'top' })
+    testPositioningHelper({ position: 'above', align: 'end', expectedPlacement: 'top-end' })
+    testPositioningHelper({ position: 'below', align: 'start', expectedPlacement: 'bottom-start' })
+    testPositioningHelper({ position: 'below', align: 'center', expectedPlacement: 'bottom' })
+    testPositioningHelper({ position: 'below', align: 'end', expectedPlacement: 'bottom-end' })
+    testPositioningHelper({ position: 'before', align: 'top', expectedPlacement: 'left-start' })
+    testPositioningHelper({ position: 'before', align: 'center', expectedPlacement: 'left' })
+    testPositioningHelper({ position: 'before', align: 'bottom', expectedPlacement: 'left-end' })
+    testPositioningHelper({ position: 'after', align: 'top', expectedPlacement: 'right-start' })
+    testPositioningHelper({ position: 'after', align: 'center', expectedPlacement: 'right' })
+    testPositioningHelper({ position: 'after', align: 'bottom', expectedPlacement: 'right-end' })
+  })
+
+  describe('handles positioningHelper position argument correctly in rtl', () => {
+    testPositioningHelperInRtl({ position: 'above', align: 'start', expectedPlacement: 'top-end' })
+    testPositioningHelperInRtl({ position: 'above', align: 'center', expectedPlacement: 'top' })
+    testPositioningHelperInRtl({ position: 'above', align: 'end', expectedPlacement: 'top-start' })
+    testPositioningHelperInRtl({
+      position: 'below',
+      align: 'start',
+      expectedPlacement: 'bottom-end',
+    })
+    testPositioningHelperInRtl({ position: 'below', align: 'center', expectedPlacement: 'bottom' })
+    testPositioningHelperInRtl({
+      position: 'below',
+      align: 'end',
+      expectedPlacement: 'bottom-start',
+    })
+    testPositioningHelperInRtl({
+      position: 'before',
+      align: 'top',
+      expectedPlacement: 'right-start',
+    })
+    testPositioningHelperInRtl({ position: 'before', align: 'center', expectedPlacement: 'right' })
+    testPositioningHelperInRtl({
+      position: 'before',
+      align: 'bottom',
+      expectedPlacement: 'right-end',
+    })
+    testPositioningHelperInRtl({ position: 'after', align: 'top', expectedPlacement: 'left-start' })
+    testPositioningHelperInRtl({ position: 'after', align: 'center', expectedPlacement: 'left' })
+    testPositioningHelperInRtl({
+      position: 'after',
+      align: 'bottom',
+      expectedPlacement: 'left-end',
+    })
+  })
+
+  describe('positioningHelper offset argument transformed correctly in RTL', () => {
+    it("applies transform only for 'above' and 'below' postioning", () => {
+      const originalOffsetValue = '100%'
+
+      expect(applyRtlToOffset(originalOffsetValue, 'above')).not.toBe(originalOffsetValue)
+      expect(applyRtlToOffset(originalOffsetValue, 'below')).not.toBe(originalOffsetValue)
+
+      expect(applyRtlToOffset(originalOffsetValue, 'before')).toBe(originalOffsetValue)
+      expect(applyRtlToOffset(originalOffsetValue, 'after')).toBe(originalOffsetValue)
+    })
+
+    const expectOffsetTransformResult = (originalOffset, resultOffset) => {
+      expect(applyRtlToOffset(originalOffset, 'above')).toBe(resultOffset)
+    }
+
+    it('flips sign of simple expressions', () => {
+      expectOffsetTransformResult('100%', '-100%')
+      expectOffsetTransformResult('  2000%p ', '-2000%p')
+      expectOffsetTransformResult('100  ', '-100')
+      expectOffsetTransformResult(' - 200vh', '200vh')
+    })
+
+    it('flips sign of complex expressions', () => {
+      expectOffsetTransformResult('100% + 200', '-100% - 200')
+      expectOffsetTransformResult(' - 2000%p - 400 +800vh ', '2000%p + 400 -800vh')
+    })
+
+    it('transforms only horizontal offset value', () => {
+      const xOffset = '-100%'
+      const yOffset = '800vh'
+
+      const offsetValue = [xOffset, yOffset].join(',')
+      const [xOffsetTransformed, yOffsetTransformed] = applyRtlToOffset(offsetValue, 'above').split(
+        ',',
+      )
+
+      expect(xOffsetTransformed.trim()).not.toBe(xOffset)
+      expect(yOffsetTransformed.trim()).toBe(yOffset)
+    })
+  })
+})


### PR DESCRIPTION
## feat(dropdown): align, position, offset props + automatic position

#### This PR tackles:
- introducing `align`, `position`, `offset` props for `Dropdown` component
- automatic positioning for `Dropdown` results
- reuses code from #1153 to avoid double render and simplify code

#### TODO:
- [x] Refactor method names and clean code
- [x] Extract common code for positioning elements to `src/lib/positioner`
- [x] Integrate new `Positioner` helper component to `Popup` and `Dropdown`
- [x] Refactor unit tests for `positionerHelper` (move from `Popup-test.tsx` to dedicated file)
- [ ] Figure out way how to add some extra padding between `Dropdown` trigger and list of results
**any ideas?**