### PR TITLE
fix(docs): fixed styles on the editor menus

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -225,15 +225,13 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
     }
   }
 
-  exampleMenuVariables = {
-    primaryActiveBackgroundColor: 'transparent',
-    primaryActiveBorderColor: 'white',
-    primaryActiveColor: 'white',
-    primaryBorderColor: 'white',
-    activeColor: 'white',
-    disabledColor: '#ffffff80',
-    color: '#ffffff80',
-  }
+  exampleMenuVariables = siteVars => ({
+    backgroundColorActive: 'transparent',
+    borderColorActive: siteVars.colors.white,
+    colorActive: siteVars.colors.white,
+    primaryBorderColor: siteVars.colors.white,
+    color: siteVars.colors.white,
+  })
 
   renderAPIsMenu = (): JSX.Element => {
     const { componentAPIs, currentCodeAPI } = this.props
@@ -252,7 +250,6 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
     return (
       <Menu
-        primary
         underlined
         items={menuItems}
         variables={this.exampleMenuVariables}
@@ -280,7 +277,6 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
     return (
       <Menu
-        primary
         underlined
         items={menuItems}
         variables={this.exampleMenuVariables}
@@ -365,15 +361,10 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
     return (
       <Menu
         size="small"
-        primary
         underlined
         activeIndex={-1}
         styles={codeEditorStyle}
-        variables={{
-          activeColor: 'white',
-          disabledColor: '#ffffff60',
-          color: '#ffffffb0',
-        }}
+        variables={this.exampleMenuVariables}
         items={menuItems}
       />
     )


### PR DESCRIPTION
Fixed regressions on the menus used in the editor, after merging the color updates.

Prev:
![image](https://user-images.githubusercontent.com/4512430/57521542-db7c1280-7320-11e9-988f-38ba363ee66c.png)


Now:
![image](https://user-images.githubusercontent.com/4512430/57521353-55f86280-7320-11e9-8f97-e4a1356ff905.png)
