### PR TITLE
fix(DropdownItem): remove 'avatar' prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix double rendering of `Popup` component @layershifter ([#1153](https://github.com/stardust-ui/react/pull/1153))
+- Remove non-existent `avatar` prop passed to `Image` in `DropdownItem` @kuzhelov ([#1316](https://github.com/stardust-ui/react/pull/1316))
 
 <!--------------------------------[ v0.29.1 ]------------------------------- -->
 ## [v0.29.1](https://github.com/stardust-ui/react/tree/v0.29.1) (2019-05-01)

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -87,7 +87,6 @@ class DropdownItem extends UIComponent<ReactProps<DropdownItemProps>, any> {
         onClick={this.handleClick}
         media={Image.create(image, {
           defaultProps: {
-            avatar: true,
             className: DropdownItem.slotClassNames.image,
             styles: styles.image,
           },


### PR DESCRIPTION
This PR removes non-existent `avatar` prop of `Image` component. While being provided, this prop is passed to DOM element and results in console error:

> received 'true' for non-boolean attribute 'avatar'