### PR TITLE
fix(docs): Set maximum width for examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### BREAKING CHANGES
 - Rename `context` prop to `mountNode` in `PortalInner` @layershifter ([#1288](https://github.com/stardust-ui/react/pull/1288))
 - Updated Teams' theme color palette values, removed color related site variables @mnajdova ([#1069](https://github.com/stardust-ui/react/pull/1069))
 - Remove `defaultTarget` prop in `Popup` component @layershifter ([#1153](https://github.com/stardust-ui/react/pull/1153))
 - Add focus border styling mechanism @Bugaa92 in Teams theme ([#1269](https://github.com/stardust-ui/react/pull/1269))
+
+### Fixes
+- Fix double rendering of `Popup` component @layershifter ([#1153](https://github.com/stardust-ui/react/pull/1153))
+- Docs: fix(docs): Set maximum width for examples @miroslavstastny ([#1319](https://github.com/stardust-ui/react/pull/1319))
 
 ### Features
 - Add default child a11y behavior to `Menu` related behaviors @silviuavram ([#1282](https://github.com/stardust-ui/react/pull/1282))
@@ -31,9 +36,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `mountNode` and `mountDocument` props to allow proper multi-window rendering ([#1288](https://github.com/stardust-ui/react/pull/1288))
 - Added default and brand color schemes in Teams' theme @mnajdova ([#1069](https://github.com/stardust-ui/react/pull/1069))
 - Export `files-upload` SVG icon for `Teams` theme @manindr ([#1293](https://github.com/stardust-ui/react/pull/1293))
-
-### Fixes
-- Fix double rendering of `Popup` component @layershifter ([#1153](https://github.com/stardust-ui/react/pull/1153))
 
 <!--------------------------------[ v0.29.1 ]------------------------------- -->
 ## [v0.29.1](https://github.com/stardust-ui/react/tree/v0.29.1) (2019-05-01)

--- a/docs/src/components/ComponentDoc/ExampleSection.tsx
+++ b/docs/src/components/ComponentDoc/ExampleSection.tsx
@@ -14,12 +14,13 @@ export type ExampleSectionProps = Extendable<{
   title: string
 }>
 
+// minmax = prevent example overflow - https://stackoverflow.com/a/43312314
 const ExampleSection: React.FC<ExampleSectionProps> = ({ title, children }) => (
   <>
     <Header as="h2" styles={headerStyle} className="no-anchor">
       {title}
     </Header>
-    <Grid variables={{ gridGap: '2rem' }} columns="1">
+    <Grid variables={{ gridGap: '2rem' }} columns="minmax(550px, 1fr)">
       {children}
     </Grid>
   </>

--- a/docs/src/examples/components/Text/States/TextExampleTruncated.shorthand.tsx
+++ b/docs/src/examples/components/Text/States/TextExampleTruncated.shorthand.tsx
@@ -11,7 +11,7 @@ const [notTruncatedText, truncatedText] = [
 )
 
 const TextExampleTruncatedShorthand = () => (
-  <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', width: 500 }}>
+  <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
     <Text content={notTruncatedText} />
     <br />
     <br />

--- a/docs/src/examples/components/Text/States/TextExampleTruncated.tsx
+++ b/docs/src/examples/components/Text/States/TextExampleTruncated.tsx
@@ -11,7 +11,7 @@ const [notTruncatedText, truncatedText] = [
 )
 
 const TextExampleTruncated = () => (
-  <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', width: 500 }}>
+  <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
     <Text>{notTruncatedText}</Text>
     <br />
     <br />


### PR DESCRIPTION
Fixes #1317.

Before:
![image](https://user-images.githubusercontent.com/9615899/57524363-de2e3600-7327-11e9-9a37-7b8f249dea5d.png)

After:
![image](https://user-images.githubusercontent.com/9615899/57524370-e2f2ea00-7327-11e9-939b-fd81c8b3dc2c.png)

The visible overflow is intentional.