### PR TITLE
feat(chat): focus outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `selected`, `isFromKeyboard` props to `DropdownItem` @mnajdova ([#1299](https://github.com/stardust-ui/react/pull/1299))
 - Add styles for the dark and high contrast Teams themes for the `Dropdown` component @mnajdova ([#1299](https://github.com/stardust-ui/react/pull/1299))
 - Highlight options by character keys in `Dropdown` non-search versions @silviuavram ([#1270](https://github.com/stardust-ui/react/pull/1270))
+- Aligned link styles for `Chat.Message` component with latest Teams theme design @Bugaa92 ([#1269](https://github.com/stardust-ui/react/pull/1269))
 
 <!--------------------------------[ v0.30.0 ]------------------------------- -->
 ## [v0.30.0](https://github.com/stardust-ui/react/tree/v0.30.0) (2019-05-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### BREAKING CHANGES
+- Aligned focus styles for `Chat.Message` component with latest Teams theme design @Bugaa92 ([#1269](https://github.com/stardust-ui/react/pull/1269))
 
 ### BREAKING CHANGES
 - Restrict Typescript checks for component props @kuzhelov ([#1290](https://github.com/stardust-ui/react/pull/1290))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### BREAKING CHANGES
-- Aligned focus styles for `Chat.Message` component with latest Teams theme design @Bugaa92 ([#1269](https://github.com/stardust-ui/react/pull/1269))
-
-### BREAKING CHANGES
 - Restrict Typescript checks for component props @kuzhelov ([#1290](https://github.com/stardust-ui/react/pull/1290))
+- Aligned focus styles for `Chat.Message` component with latest Teams theme design @Bugaa92 ([#1269](https://github.com/stardust-ui/react/pull/1269))
 
 ### Fixes
 - Fixed `Flex.Item` children prop type @mnajdova ([#1320](https://github.com/stardust-ui/react/pull/1320))

--- a/docs/src/examples/components/Chat/Types/ChatExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Chat/Types/ChatExample.shorthand.steps.ts
@@ -1,0 +1,3 @@
+const config: ScreenerTestsConfig = { themes: ['teams', 'teamsDark', 'teamsHighContrast'] }
+
+export default config

--- a/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
+++ b/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
@@ -31,7 +31,13 @@ const items = [
     message: {
       content: (
         <Chat.Message
-          content="Thanks for waiting!"
+          content={{
+            content: (
+              <div>
+                What do you think about <a href="#">www.goodFood.com</a>?
+              </div>
+            ),
+          }}
           author="John Doe"
           timestamp="Yesterday, 10:15 PM"
           mine
@@ -54,7 +60,7 @@ const items = [
     gutter: { content: <Avatar {...janeAvatar} /> },
     message: {
       content: (
-        <Chat.Message content="No problem!" author="Jane Doe" timestamp="Yesterday, 10:15 PM" />
+        <Chat.Message content="Looks good!" author="Jane Doe" timestamp="Yesterday, 10:15 PM" />
       ),
     },
     attached: true,
@@ -64,7 +70,17 @@ const items = [
     gutter: { content: <Avatar {...janeAvatar} /> },
     message: {
       content: (
-        <Chat.Message content="What's up?" author="Jane Doe" timestamp="Yesterday, 10:15 PM" />
+        <Chat.Message
+          content={{
+            content: (
+              <div>
+                I also like <a href="#">www.goodFood2.com</a>.
+              </div>
+            ),
+          }}
+          author="Jane Doe"
+          timestamp="Yesterday, 10:15 PM"
+        />
       ),
     },
     attached: 'bottom',
@@ -74,7 +90,7 @@ const items = [
     message: {
       content: (
         <Chat.Message
-          content="Would you like to grab a lunch?"
+          content="Would you like to grab lunch there?"
           author="John Doe"
           timestamp="Yesterday, 10:16 PM"
           mine
@@ -89,7 +105,7 @@ const items = [
     message: {
       content: (
         <Chat.Message
-          content="Sure! Let's try the new place downtown."
+          content="Sure! Let's try it."
           author="Jane Doe"
           timestamp="Yesterday, 10:15 PM"
         />

--- a/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -8,7 +8,7 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
     timestampColorMine: siteVars.colors.grey[250],
-    contentFocusOutlineColor: siteVars.colors.brand[600],
+    contentColorFocus: siteVars.colors.brand[600],
     hasMentionNubbinColor: siteVars.colors.orange[300],
     isImportantColor: siteVars.colors.red[300],
   }

--- a/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -8,7 +8,6 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
     timestampColorMine: siteVars.colors.grey[250],
-    linkColor: siteVars.colors.brand[600],
     hasMentionNubbinColor: siteVars.colors.orange[300],
     isImportantColor: siteVars.colors.red[300],
   }

--- a/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -8,7 +8,7 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
     timestampColorMine: siteVars.colors.grey[250],
-    contentColorFocus: siteVars.colors.brand[600],
+    linkColor: siteVars.colors.brand[600],
     hasMentionNubbinColor: siteVars.colors.orange[300],
     isImportantColor: siteVars.colors.red[300],
   }

--- a/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
@@ -7,7 +7,7 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
     authorColor: siteVars.colors.white,
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
-    contentFocusOutlineColor: siteVars.colors.yellow[900], // Red flag (should this be accessibleYellow?)
+    contentColorFocus: siteVars.colors.yellow[900], // Red flag (should this be accessibleYellow?)
     border: `1px solid ${siteVars.colors.white}`,
     hasMentionColor: siteVars.accessibleYellow,
     hasMentionNubbinColor: siteVars.accessibleYellow,

--- a/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
@@ -7,7 +7,6 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
     authorColor: siteVars.colors.white,
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
-    linkColor: siteVars.accessibleYellow,
     border: `1px solid ${siteVars.colors.white}`,
     hasMentionColor: siteVars.accessibleYellow,
     hasMentionNubbinColor: siteVars.accessibleYellow,

--- a/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
@@ -7,7 +7,7 @@ export default (siteVars: any): Partial<ChatMessageVariables> => {
     authorColor: siteVars.colors.white,
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
-    contentColorFocus: siteVars.colors.yellow[900], // Red flag (should this be accessibleYellow?)
+    linkColor: siteVars.accessibleYellow,
     border: `1px solid ${siteVars.colors.white}`,
     hasMentionColor: siteVars.accessibleYellow,
     hasMentionNubbinColor: siteVars.accessibleYellow,

--- a/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -7,12 +7,13 @@ import {
 import { ChatMessageVariables } from './chatMessageVariables'
 import { screenReaderContainerStyles } from '../../../../lib/accessibility/Styles/accessibilityStyles'
 import { pxToRem } from '../../../../lib'
+import getBorderFocusStyles from '../../getBorderFocusStyles'
 
 const chatMessageStyles: ComponentSlotStylesInput<
   ChatMessageProps & ChatMessageState,
   ChatMessageVariables
 > = {
-  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
+  root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
     display: 'inline-block',
     position: 'relative',
 
@@ -50,11 +51,8 @@ const chatMessageStyles: ComponentSlotStylesInput<
       },
     }),
 
-    ':focus': {
-      ...(p.isFromKeyboard && {
-        outline: `.2rem solid ${v.contentFocusOutlineColor}`,
-      }),
-    },
+    ...getBorderFocusStyles({ siteVariables, isFromKeyboard: p.isFromKeyboard }),
+
     ':hover': {
       [`& .${ChatMessage.slotClassNames.actionMenu}`]: {
         opacity: 1,
@@ -112,10 +110,12 @@ const chatMessageStyles: ComponentSlotStylesInput<
   content: ({ props: p, variables: v }): ICSSInJSStyle => ({
     color: v.contentColor,
     display: 'block',
-    '& a:focus': {
+    '& a': {
       outline: 'none',
-      color: v.contentFocusOutlineColor,
-      textDecoration: 'underline',
+      color: v.contentColorFocus,
+      ':focus': {
+        textDecoration: 'underline',
+      },
     },
     ...(p.badge &&
       p.badgePosition === 'end' && {

--- a/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -112,7 +112,7 @@ const chatMessageStyles: ComponentSlotStylesInput<
     display: 'block',
     '& a': {
       outline: 'none',
-      color: v.contentColorFocus,
+      color: v.linkColor,
       ':focus': {
         textDecoration: 'underline',
       },

--- a/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -112,7 +112,7 @@ const chatMessageStyles: ComponentSlotStylesInput<
     display: 'block',
     '& a': {
       outline: 'none',
-      color: v.linkColor,
+      color: p.mine ? v.linkColorMine : v.linkColor,
       ':focus': {
         textDecoration: 'underline',
       },

--- a/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -15,7 +15,7 @@ export interface ChatMessageVariables {
   authorFontWeight: number
   headerMarginBottom: string
   contentColor: string
-  contentFocusOutlineColor: string
+  contentColorFocus: string
   border: string
   badgeShadow: string
   isImportant: boolean
@@ -43,7 +43,7 @@ export default (siteVars): ChatMessageVariables => ({
   authorFontWeight: siteVars.fontWeightRegular,
   headerMarginBottom: pxToRem(2),
   contentColor: siteVars.colors.grey[750],
-  contentFocusOutlineColor: siteVars.colors.brand[600],
+  contentColorFocus: siteVars.colors.brand[600],
   border: 'none',
   badgeShadow: siteVars.shadowLevel1Darker,
   isImportant: false,

--- a/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -15,7 +15,7 @@ export interface ChatMessageVariables {
   authorFontWeight: number
   headerMarginBottom: string
   contentColor: string
-  contentColorFocus: string
+  linkColor: string
   border: string
   badgeShadow: string
   isImportant: boolean
@@ -43,7 +43,7 @@ export default (siteVars): ChatMessageVariables => ({
   authorFontWeight: siteVars.fontWeightRegular,
   headerMarginBottom: pxToRem(2),
   contentColor: siteVars.colors.grey[750],
-  contentColorFocus: siteVars.colors.brand[600],
+  linkColor: siteVars.colors.brand[600],
   border: 'none',
   badgeShadow: siteVars.shadowLevel1Darker,
   isImportant: false,

--- a/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/react/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -16,6 +16,7 @@ export interface ChatMessageVariables {
   headerMarginBottom: string
   contentColor: string
   linkColor: string
+  linkColorMine: string
   border: string
   badgeShadow: string
   isImportant: boolean
@@ -43,7 +44,8 @@ export default (siteVars): ChatMessageVariables => ({
   authorFontWeight: siteVars.fontWeightRegular,
   headerMarginBottom: pxToRem(2),
   contentColor: siteVars.colors.grey[750],
-  linkColor: siteVars.colors.brand[600],
+  linkColor: siteVars.colorScheme.brand.foreground1,
+  linkColorMine: siteVars.colorScheme.brand.foreground2,
   border: 'none',
   badgeShadow: siteVars.shadowLevel1Darker,
   isImportant: false,


### PR DESCRIPTION
# feat(chat): focus outline

## BREAKING CHANGES MITIGATION

Rename `Chat.Message` variable: ~~`contentFocusOutlineColor`~~ &rightarrow; `linkColor`

## Description

This PR:
- fixes issue: **Chat: focus border is not fully visible when `attached` prop is used #800**
- aligns `Chat` components to the latest design for borders (as outlined in #1269)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/5442794/57545319-3bdb7600-735a-11e9-9a7d-b81d3af4877c.png)

### After
![Screenshot 2019-05-10 at 19 24 45](https://user-images.githubusercontent.com/5442794/57545152-c374b500-7359-11e9-980b-c1e73e8393e2.png)
