### PR TITLE
fix(Ref): handle refs on updates of `innerRef` prop

### DIFF
--- a/packages/react-component-ref/src/RefFindNode.tsx
+++ b/packages/react-component-ref/src/RefFindNode.tsx
@@ -32,11 +32,15 @@ export default class RefFindNode extends React.Component<RefFindNodeProps> {
     handleRef(this.props.innerRef, this.prevNode)
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: RefFindNodeProps) {
     const currentNode = ReactDOM.findDOMNode(this)
 
     if (this.prevNode !== currentNode) {
       this.prevNode = currentNode
+      handleRef(this.props.innerRef, currentNode)
+    }
+
+    if (prevProps.innerRef !== this.props.innerRef) {
       handleRef(this.props.innerRef, currentNode)
     }
   }

--- a/packages/react-component-ref/test/RefFindNode-test.tsx
+++ b/packages/react-component-ref/test/RefFindNode-test.tsx
@@ -78,5 +78,24 @@ describe('RefFindNode', () => {
       expect(innerRef).toHaveBeenCalledTimes(1)
       expect(innerRef).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'DIV' }))
     })
+
+    it('handles updates of props', () => {
+      const initialRef = jest.fn()
+      const updatedRef = jest.fn()
+      const wrapper = mount(
+        <RefFindNode innerRef={initialRef}>
+          <div />
+        </RefFindNode>,
+      )
+
+      expect(initialRef).toHaveBeenCalled()
+      expect(updatedRef).not.toHaveBeenCalled()
+
+      jest.resetAllMocks()
+      wrapper.setProps({ innerRef: updatedRef })
+
+      expect(initialRef).not.toHaveBeenCalled()
+      expect(updatedRef).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
Fixes #1328.

Align existing behavior with React's, see the issue for more context and explanation.