### PR TITLE
fix(Popup): fix positioning in scrollable container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed `Flex.Item` children prop type @mnajdova ([#1320](https://github.com/stardust-ui/react/pull/1320))
 - Fixed `Icon`'s color example to align with the latest color updates @mnajdova([#1336](https://github.com/stardust-ui/react/pull/1336))
 - Fixed handle refs on updates of `innerRef` prop in `Ref` component @layershifter ([#1331](https://github.com/stardust-ui/react/pull/1331))
+- Fixed positioing of `Popup` in scrollable container @layershifter ([#1341](https://github.com/stardust-ui/react/pull/1341))
 
 ### Features
 - Add `selected`, `isFromKeyboard` props to `DropdownItem` @mnajdova ([#1299](https://github.com/stardust-ui/react/pull/1299))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fixed `Flex.Item` children prop type @mnajdova ([#1320](https://github.com/stardust-ui/react/pull/1320))
 - Fixed `Icon`'s color example to align with the latest color updates @mnajdova([#1336](https://github.com/stardust-ui/react/pull/1336))
+- Fixed handle refs on updates of `innerRef` prop in `Ref` component @layershifter ([#1331](https://github.com/stardust-ui/react/pull/1331))
 
 ### Features
 - Add `selected`, `isFromKeyboard` props to `DropdownItem` @mnajdova ([#1299](https://github.com/stardust-ui/react/pull/1299))

--- a/packages/react/src/components/Popup/createPopperReferenceProxy.ts
+++ b/packages/react/src/components/Popup/createPopperReferenceProxy.ts
@@ -21,6 +21,15 @@ class ReferenceProxy implements PopperJS.ReferenceObject {
   get clientHeight() {
     return this.getBoundingClientRect().height
   }
+
+  /**
+   * Required to allow properly finding a node to attach scroll.
+   *
+   * @see https://github.com/FezVrasta/popper.js/blob/v1.15.0/packages/popper/src/utils/getParentNode.js#L12
+   */
+  get parentNode() {
+    return this.ref.current ? this.ref.current.parentNode : undefined
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #1335.

`Popper.JS` relies on [`getScrollParent()`](https://github.com/FezVrasta/popper.js/blob/master/packages/popper/src/utils/getScrollParent.js) function which recursively uses [`getParentNode()`](https://github.com/FezVrasta/popper.js/blob/master/packages/popper/src/utils/getParentNode.js) under hood. `getParentNode()` uses `parentNode` field and our `ReferenceProxy` doesn't have it before 😢 