### PR TITLE
fix(flex): fill styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Restrict Typescript checks for component props @kuzhelov ([#1290](https://github.com/stardust-ui/react/pull/1290))
 - Aligned focus styles for `Chat.Message` component with latest Teams theme design @Bugaa92 ([#1269](https://github.com/stardust-ui/react/pull/1269))
+- Fix styles for `fill` prop of `Flex` @kuzhelov ([#1352](https://github.com/stardust-ui/react/pull/1352))
 
 ### Fixes
 - Fixed `Flex.Item` children prop type @mnajdova ([#1320](https://github.com/stardust-ui/react/pull/1320))

--- a/packages/react/src/themes/base/components/Flex/flexStyles.ts
+++ b/packages/react/src/themes/base/components/Flex/flexStyles.ts
@@ -27,6 +27,7 @@ const flexStyles: ComponentSlotStylesInput<FlexProps, FlexVariables> = {
     ...(p.wrap && { flexWrap: 'wrap' }),
 
     ...(p.fill && {
+      width: '100%',
       height: '100%',
     }),
 


### PR DESCRIPTION
Fixes #1348 

This PR addresses the issue of expected behavior of `<Flex fill />`, and makes it aligned with the behavior suggested by spec:

> fill - Orders container to fill all parent's space available.

## BREAKING CHANGES

Effect of this fix is changed behavior of `fill` prop of `Flex` component in case if it is a child of other `Flex`. 

```jsx
<Flex>
  <Flex fill>
  </Flex>
</Flex>
```

![image](https://user-images.githubusercontent.com/9024564/57917220-e98bdf00-789c-11e9-9cfb-2bf40a4651d2.png)

**If client would like to preserve this look**, i.e. inner `Flex` to take only the minimal width necessary (and not the entire space provided by outer `Flex`), then 
- `fill` prop should be removed for inner `Flex`
- provide `vAlign=stretch` prop to outer `Flex`

```jsx
<Flex vAlign='stretch'>
  <Flex></Flex>
</Flex>
```

------------------------

## Description

From https://codesandbox.io/s/ulrbd?module=/example.js :
```jsx
// outer
<Flex debug .. >
  <Flex fill .. >
     Inner Flex
  </Flex>  
</Flex>
```

### Was
![image](https://user-images.githubusercontent.com/9024564/57917220-e98bdf00-789c-11e9-9cfb-2bf40a4651d2.png)

### Now
![image](https://user-images.githubusercontent.com/9024564/57917204-e09b0d80-789c-11e9-9760-881e842c7ab2.png)
