### PR TITLE
fix(Popup): filter out NaN values from Popper's styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed handle refs on updates of `innerRef` prop in `Ref` component @layershifter ([#1331](https://github.com/stardust-ui/react/pull/1331))
 - Fixed positioing of `Popup` in scrollable container @layershifter ([#1341](https://github.com/stardust-ui/react/pull/1341))
 - Add Teams dark and hc themeing for `Dialog` [redlines] @codepretty ([#1297](https://github.com/stardust-ui/react/pull/1297))
-- Remove `Nan` values from positioning styles in `Popup` @kuzhelov ([#1365](https://github.com/stardust-ui/react/pull/1365))
+- Remove `NaN` values from positioning styles in `Popup` @kuzhelov ([#1365](https://github.com/stardust-ui/react/pull/1365))
 
 ### Features
 - Add `selected`, `isFromKeyboard` props to `DropdownItem` @mnajdova ([#1299](https://github.com/stardust-ui/react/pull/1299))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed handle refs on updates of `innerRef` prop in `Ref` component @layershifter ([#1331](https://github.com/stardust-ui/react/pull/1331))
 - Fixed positioing of `Popup` in scrollable container @layershifter ([#1341](https://github.com/stardust-ui/react/pull/1341))
 - Add Teams dark and hc themeing for `Dialog` [redlines] @codepretty ([#1297](https://github.com/stardust-ui/react/pull/1297))
+- Remove `Nan` values from positioning styles in `Popup` @kuzhelov ([#1365](https://github.com/stardust-ui/react/pull/1365))
 
 ### Features
 - Add `selected`, `isFromKeyboard` props to `DropdownItem` @mnajdova ([#1299](https://github.com/stardust-ui/react/pull/1299))

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -448,10 +448,9 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     }: PopperChildrenProps,
   ) => {
     const { content: propsContent, renderContent, contentRef, mountDocument, pointing } = this.props
+    const popupPlacementStyles = _.omitBy(popupPlacementStylesRaw, _.isNaN)
     const content = renderContent ? renderContent(scheduleUpdate) : propsContent
     const documentRef = toRefObject(mountDocument)
-
-    const popupPlacementStyles = _.omitBy(popupPlacementStylesRaw, _.isNaN)
 
     const popupWrapperAttributes = {
       ...(rtl && { dir: 'rtl' }),

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -444,12 +444,14 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
       placement,
       ref,
       scheduleUpdate,
-      style: popupPlacementStyles,
+      style: popupPlacementStylesRaw,
     }: PopperChildrenProps,
   ) => {
     const { content: propsContent, renderContent, contentRef, mountDocument, pointing } = this.props
     const content = renderContent ? renderContent(scheduleUpdate) : propsContent
     const documentRef = toRefObject(mountDocument)
+
+    const popupPlacementStyles = _.omitBy(popupPlacementStylesRaw, _.isNaN)
 
     const popupWrapperAttributes = {
       ...(rtl && { dir: 'rtl' }),


### PR DESCRIPTION
## Problem

The problem is Popper's calculation logic outputs NaN values for the cases where height (or width) of reference element is `0`. However, this is pretty common case for test environments, where styles may not be rendered/applied to `Popup`'s `trigger` - and, as a result, it will have height of `0`.

This, in its turn, results in invalid styles being applied to rendered `div` element, as calculated by Popper styles are just passed to slot's `div` component, with NaN values being there:

![image](https://user-images.githubusercontent.com/9024564/58112600-2127bd80-7bf4-11e9-82be-a589716939db.png)

## Resolution strategy

This PR provides fix that will guarantee that simple mount of `Popup` component in client's tests won't result in console errors - by removing style props that has `NaN` as value.