### PR TITLE
chore: tolerate build errors only for 'yarn start'

### DIFF
--- a/build/gulp/plugins/gulp-webpack.ts
+++ b/build/gulp/plugins/gulp-webpack.ts
@@ -1,8 +1,10 @@
 import * as webpack from 'webpack'
 import config from '../../../config'
 
-const { __DEV__ } = config.compiler_globals
+const { __DEV__, __SKIP_ERRORS__ } = config.compiler_globals
 const { log, PluginError } = require('gulp-load-plugins')().util
+
+const DEV_SKIP_ERRORS = __DEV__ && __SKIP_ERRORS__
 
 const webpackPlugin = (webpackConfig, cb, onComplete = (err: any, stats: any) => {}) => {
   webpack(webpackConfig).run((err, stats) => {
@@ -15,11 +17,11 @@ const webpackPlugin = (webpackConfig, cb, onComplete = (err: any, stats: any) =>
       log('Webpack compiler encountered a fatal error.')
       throw new PluginError('webpack', err.toString())
     }
-    if (!__DEV__ && errors.length > 0) {
+    if (!DEV_SKIP_ERRORS && errors.length > 0) {
       log('Webpack compiler encountered errors.')
       throw new PluginError('webpack', errors.toString())
     }
-    if (!__DEV__ && warnings.length > 0) {
+    if (!DEV_SKIP_ERRORS && warnings.length > 0) {
       throw new PluginError('webpack', warnings.toString())
     }
 

--- a/config.ts
+++ b/config.ts
@@ -10,6 +10,8 @@ const __PERF__ = !!process.env.PERF
 const __PROD__ = env === 'production'
 const __BASENAME__ = __PROD__ ? '/react/' : '/'
 
+const __SKIP_ERRORS__ = !!process.env.SKIP_ERRORS
+
 const envConfig = {
   env,
 
@@ -70,6 +72,7 @@ const config = {
     __PERF__,
     __PROD__,
     __BASENAME__: JSON.stringify(__BASENAME__),
+    __SKIP_ERRORS__,
     'process.env': {
       NODE_ENV: JSON.stringify(env),
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release:minor": "yarn prerelease && lerna publish minor && yarn postrelease",
     "release:patch": "yarn prerelease && lerna publish patch && yarn postrelease",
     "prestart": "yarn satisfied --fix yarn",
-    "start": "gulp --series dll docs",
+    "start": "cross-env SKIP_ERRORS=true gulp --series dll docs",
     "stats:build": "gulp stats",
     "stats:save": "gulp stats:save",
     "satisfied": "satisfied --skip-invalid",


### PR DESCRIPTION
These changes are necessary for now, given that Circle CI steps are running with settings of DEV environment. 

This is a separate issue to address (as simple NODE_ENV being set to 'production' leads to another issue - the fact that lint warnings are not tolerated anymore), so for now errors will be tolerated only for single whitelisted `yarn start` scenario.

- [x] check that provided changes detect problems during the build: https://github.com/stardust-ui/react/pull/1381