### PR TITLE
feat(menu): automatic positioning inside viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add strict types for the `colorScheme` props used in the components' `variables` @mnajdova([#1340](https://github.com/stardust-ui/react/pull/1340))
 - Export `message-seen`, `presence-available`, `presence-stroke`, `open-outside` and `eye-friendlier`  icons to Teams theme @joheredi ([#1390](https://github.com/stardust-ui/react/pull/1390))
 - Add 'lightning' icon @notandrew ([#1385](https://github.com/stardust-ui/react/pull/1385))
+- Add automatic positioning inside viewport for `Menu` with submenus @Bugaa92 ([#1384](https://github.com/stardust-ui/react/pull/1384))
 
 ### Documentation
 - Accessibility: improve introduction section @jurokapsiar ([#1368](https://github.com/stardust-ui/react/pull/1368))

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -247,6 +247,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
               align={vertical ? 'top' : 'start'}
               position={vertical ? 'after' : 'below'}
               targetRef={this.itemRef}
+              modifiers={{ flip: { flipVariationsByContent: true } }}
             >
               {Menu.create(menu, {
                 defaultProps: {

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -32,6 +32,7 @@ import {
   withSafeTypeForAs,
 } from '../../types'
 import { focusAsync } from '../../lib/accessibility/FocusZone'
+import { Popper } from '../../lib/positioner'
 
 export interface MenuItemSlotClassNames {
   wrapper: string
@@ -242,18 +243,24 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
       menu && active && menuOpen ? (
         <>
           <Ref innerRef={this.menuRef}>
-            {Menu.create(menu, {
-              defaultProps: {
-                accessibility: submenuBehavior,
-                className: MenuItem.slotClassNames.submenu,
-                vertical: true,
-                primary,
-                secondary,
-                styles: styles.menu,
-                submenu: true,
-                indicator,
-              },
-            })}
+            <Popper
+              align={vertical ? 'top' : 'start'}
+              position={vertical ? 'after' : 'below'}
+              targetRef={this.itemRef}
+            >
+              {Menu.create(menu, {
+                defaultProps: {
+                  accessibility: submenuBehavior,
+                  className: MenuItem.slotClassNames.submenu,
+                  vertical: true,
+                  primary,
+                  secondary,
+                  styles: styles.menu,
+                  submenu: true,
+                  indicator,
+                },
+              })}
+            </Popper>
           </Ref>
           <EventListener listener={this.outsideClickHandler} targetRef={documentRef} type="click" />
         </>

--- a/packages/react/src/lib/getScrollParent.ts
+++ b/packages/react/src/lib/getScrollParent.ts
@@ -1,5 +1,3 @@
-import isBrowser from './isBrowser'
-
 /**
  * Returns the parentNode or the host of the element
  * @argument {Node} node
@@ -34,8 +32,6 @@ const getStyleComputedProperty = (node: Node, property?: string) => {
  * @returns {Node} scroll parent
  */
 const getScrollParent = (node: Node): Node => {
-  if (!isBrowser()) return null
-
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
   if (!node) return document.body
 

--- a/packages/react/src/lib/getScrollParent.ts
+++ b/packages/react/src/lib/getScrollParent.ts
@@ -1,0 +1,21 @@
+import isBrowser from './isBrowser'
+
+const SCROLL_CSS_VALUE_REGEX = /(auto|scroll)/
+
+const isScrollable = (element: Element) => {
+  try {
+    const { overflow, overflowY, overflowX } = window.getComputedStyle(element)
+    return SCROLL_CSS_VALUE_REGEX.test(overflow + overflowX + overflowY)
+  } catch (e) {
+    return false
+  }
+}
+
+const getScrollParent = (element: Element) => {
+  if (!isBrowser()) return null
+  if (!element || element === document.body) return document.body
+  if (isScrollable(element)) return element
+  return getScrollParent(element.parentNode as Element)
+}
+
+export default getScrollParent

--- a/packages/react/src/lib/getScrollParent.ts
+++ b/packages/react/src/lib/getScrollParent.ts
@@ -1,7 +1,7 @@
 /**
- * Returns the parentNode or the host of the element
- * @argument {Node} node
- * @returns {Node} parent
+ * Returns the parent node or the host of the node argument.
+ * @argument {Node} node - DOM node.
+ * @returns {Node} - parent DOM node.
  */
 const getParentNode = (node: Node): Node => {
   if (node.nodeName === 'HTML') {
@@ -12,24 +12,23 @@ const getParentNode = (node: Node): Node => {
 }
 
 /**
- * Get CSS computed property of the given element
- * @argument {Node} node
- * @argument {string} property
+ * Returns CSS styles of the given node.
+ * @argument {Node} node - DOM node.
+ * @returns {Partial<CSSStyleDeclaration>} - CSS styles.
  */
-const getStyleComputedProperty = (node: Node, property?: string) => {
+const getStyleComputedProperty = (node: Node): Partial<CSSStyleDeclaration> => {
   if (node.nodeType !== 1) {
-    return []
+    return {}
   }
 
   const window = node.ownerDocument.defaultView
-  const css = window.getComputedStyle(node as Element, null)
-  return property ? css[property] : css
+  return window.getComputedStyle(node as Element, null)
 }
 
 /**
- * Returns the scrolling parent of the given element
- * @argument {Node} node
- * @returns {Node} scroll parent
+ * Returns the first scrollable parent of the given element.
+ * @argument {Node} node - DOM node.
+ * @returns {Node} - the first scrollable parent.
  */
 const getScrollParent = (node: Node): Node => {
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
@@ -43,7 +42,7 @@ const getScrollParent = (node: Node): Node => {
       return (node as Document).body
   }
 
-  // Firefox wants us to check `-x` and `-y` variations as well
+  // If any of the overflow props is defined for the node then we return it as the parent
   const { overflow, overflowX, overflowY } = getStyleComputedProperty(node)
   if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) return node
 

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -7,11 +7,6 @@ import { getPlacement, applyRtlToOffset } from './positioningHelper'
 import { PopperProps, PopperChildrenFn } from './types'
 import getScrollParent from '../getScrollParent'
 
-const flipForScrollParentModifiers: PopperJS.Modifiers = {
-  preventOverflow: { escapeWithReference: true },
-  flip: { boundariesElement: 'scrollParent' },
-}
-
 /**
  * Popper relies on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.
  */
@@ -54,7 +49,10 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
       const popperHasScrollableParent = getScrollParent(contentRef.current) !== document.body
 
       const modifiers: PopperJS.Modifiers = _.merge(
-        popperHasScrollableParent && flipForScrollParentModifiers,
+        popperHasScrollableParent && {
+          preventOverflow: { escapeWithReference: true },
+          flip: { boundariesElement: 'scrollParent' },
+        },
         computedModifiers,
         userModifiers,
         {

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -5,7 +5,7 @@ import { Ref } from '@stardust-ui/react-component-ref'
 
 import { getPlacement, applyRtlToOffset } from './positioningHelper'
 import { PopperProps, PopperChildrenFn } from './types'
-import getScrollParent from '../getScrollParent'
+import getScrollParent from './getScrollParent'
 
 /**
  * Popper relies on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -49,12 +49,20 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
       const popperHasScrollableParent = getScrollParent(contentRef.current) !== document.body
 
       const modifiers: PopperJS.Modifiers = _.merge(
+        /**
+         * When the popper box is placed in the context of a scrollable element, we need to set
+         * preventOverflow.escapeWithReference to true and flip.boundariesElement to 'scrollParent' (default is 'viewport')
+         * so that the popper box will stick with the targetRef when we scroll targetRef out of the viewport.
+         */
         popperHasScrollableParent && {
           preventOverflow: { escapeWithReference: true },
           flip: { boundariesElement: 'scrollParent' },
         },
         computedModifiers,
         userModifiers,
+        /**
+         * This modifier is necessary in order to render the pointer.
+         */
         {
           arrow: {
             enabled: !!pointerTargetRefElement,

--- a/packages/react/src/lib/positioner/getScrollParent.ts
+++ b/packages/react/src/lib/positioner/getScrollParent.ts
@@ -4,10 +4,7 @@
  * @returns {Node} - parent DOM node.
  */
 const getParentNode = (node: Node): Node => {
-  if (node.nodeName === 'HTML') {
-    return node
-  }
-
+  if (node.nodeName === 'HTML') return node
   return node.parentNode || (node as any).host
 }
 
@@ -17,9 +14,7 @@ const getParentNode = (node: Node): Node => {
  * @returns {Partial<CSSStyleDeclaration>} - CSS styles.
  */
 const getStyleComputedProperty = (node: Node): Partial<CSSStyleDeclaration> => {
-  if (node.nodeType !== 1) {
-    return {}
-  }
+  if (node.nodeType !== 1) return {}
 
   const window = node.ownerDocument.defaultView
   return window.getComputedStyle(node as Element, null)
@@ -32,21 +27,22 @@ const getStyleComputedProperty = (node: Node): Partial<CSSStyleDeclaration> => {
  */
 const getScrollParent = (node: Node): Node => {
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
-  if (!node) return document.body
+  const parentNode = node && getParentNode(node)
+  if (!parentNode) return document.body
 
-  switch (node.nodeName) {
+  switch (parentNode.nodeName) {
     case 'HTML':
     case 'BODY':
-      return node.ownerDocument.body
+      return parentNode.ownerDocument.body
     case '#document':
-      return (node as Document).body
+      return (parentNode as Document).body
   }
 
   // If any of the overflow props is defined for the node then we return it as the parent
-  const { overflow, overflowX, overflowY } = getStyleComputedProperty(node)
-  if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) return node
+  const { overflow, overflowX, overflowY } = getStyleComputedProperty(parentNode)
+  if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) return parentNode
 
-  return getScrollParent(getParentNode(node))
+  return getScrollParent(parentNode)
 }
 
 export default getScrollParent

--- a/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -398,12 +398,7 @@ const menuItemStyles: ComponentSlotStylesInput<MenuItemPropsAndState, MenuVariab
     }
   },
 
-  menu: ({ props: p }) => ({
-    zIndex: '1000',
-    position: 'absolute',
-    top: p.vertical ? '0' : '100%',
-    left: p.vertical ? '100%' : '0',
-  }),
+  menu: () => ({ zIndex: '1000' }),
 
   indicator: () => ({
     position: 'relative',

--- a/packages/react/test/specs/lib/positioner/getScrollParent-test.ts
+++ b/packages/react/test/specs/lib/positioner/getScrollParent-test.ts
@@ -1,0 +1,99 @@
+import getScrollParent from 'src/lib/positioner/getScrollParent'
+
+const overflowStyles: Partial<CSSStyleDeclaration>[] = [
+  { overflow: 'scroll' },
+  { overflowX: 'auto' },
+  { overflowY: 'overlay' },
+  { overflowX: 'scroll', overflowY: 'auto' },
+  { overflowX: 'scroll', overflowY: 'auto', overflow: 'overlay' },
+]
+
+const setStylesForElement = (element: HTMLElement, style: Partial<CSSStyleDeclaration>) => {
+  Object.keys(style).forEach(prop => {
+    element.style[prop] = style[prop]
+  })
+}
+
+const setStylesForElements = (elements: HTMLElement[], style: Partial<CSSStyleDeclaration>) =>
+  elements.forEach(element => setStylesForElement(element, style))
+
+const resetOverflowStyles = (element: HTMLElement) =>
+  ['overflow', 'overflowX', 'overflowY'].map(prop => (element.style[prop] = ''))
+
+const testsSetupFactory = () => {
+  const treeElements = Array(4)
+    .fill(undefined)
+    .map(() => document.createElement('div'))
+  const [element, nonScrollableParent, scrollableParent, scrollableGrandparent] = treeElements
+
+  return {
+    element,
+    scrollableParent,
+    scrollableGrandparent,
+
+    init() {
+      nonScrollableParent.appendChild(element) // first parent is non scrollable
+      scrollableParent.appendChild(nonScrollableParent) // 2nd parent is scrollable; this is the result of the getScrollParent function
+      scrollableGrandparent.appendChild(scrollableParent) // 3nd parent is not scrollable; this is the result of the getScrollParent function
+      document.body.appendChild(scrollableGrandparent)
+    },
+
+    resetStyles() {
+      treeElements.forEach(treeElement => resetOverflowStyles(treeElement))
+    },
+
+    destroy() {
+      document.body.removeChild(scrollableGrandparent)
+    },
+  }
+}
+
+describe('getScrollParent', () => {
+  const testsSetup = testsSetupFactory()
+  beforeAll(() => testsSetup.init())
+  beforeEach(() => testsSetup.resetStyles())
+
+  describe('returns document.body', () => {
+    test('when argument is document.body', () => {
+      expect(getScrollParent(document.body)).toBe(document.body)
+    })
+
+    test('when argument is document.documentElement', () => {
+      expect(getScrollParent(document.documentElement)).toBe(document.body)
+    })
+
+    test('when argument is document', () => {
+      expect(getScrollParent(document)).toBe(document.body)
+    })
+
+    test('when there is no scrollable parent for the node argument', () => {
+      expect(getScrollParent(testsSetup.element)).toBe(document.body)
+    })
+  })
+
+  describe('returns the first parent node when there are scrollable parents for the node argument', () => {
+    test('when there are scrollable parents for the node argument', () => {
+      overflowStyles.forEach(styles => {
+        setStylesForElements(
+          [testsSetup.scrollableParent, testsSetup.scrollableGrandparent],
+          styles,
+        )
+
+        expect(getScrollParent(testsSetup.element)).toBe(testsSetup.scrollableParent)
+      })
+    })
+
+    test('when there are scrollable parents for the node argument and the node argument is scrollable', () => {
+      overflowStyles.forEach(styles => {
+        setStylesForElements(
+          [testsSetup.element, testsSetup.scrollableParent, testsSetup.scrollableGrandparent],
+          styles,
+        )
+
+        expect(getScrollParent(testsSetup.element)).toBe(testsSetup.scrollableParent)
+      })
+    })
+  })
+
+  afterAll(() => testsSetup.destroy())
+})

--- a/packages/react/test/specs/lib/positioner/getScrollParent-test.ts
+++ b/packages/react/test/specs/lib/positioner/getScrollParent-test.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash'
+
 import getScrollParent from 'src/lib/positioner/getScrollParent'
 
 const overflowStyles: Partial<CSSStyleDeclaration>[] = [
@@ -21,9 +23,7 @@ const resetOverflowStyles = (element: HTMLElement) =>
   ['overflow', 'overflowX', 'overflowY'].map(prop => (element.style[prop] = ''))
 
 const testsSetupFactory = () => {
-  const treeElements = Array(4)
-    .fill(undefined)
-    .map(() => document.createElement('div'))
+  const treeElements = _.range(4).map(() => document.createElement('div'))
   const [element, nonScrollableParent, scrollableParent, scrollableGrandparent] = treeElements
 
   return {
@@ -53,32 +53,32 @@ describe('getScrollParent', () => {
   beforeAll(() => testsSetup.init())
   beforeEach(() => testsSetup.resetStyles())
 
-  describe('when argument is document.body', () => {
-    test('returns document.body', () => {
+  describe('when argument is <body />', () => {
+    test('returns <body />', () => {
       expect(getScrollParent(document.body)).toBe(document.body)
     })
   })
 
-  describe('when argument is document.documentElement', () => {
-    test('returns document.body', () => {
+  describe('when argument is <html />', () => {
+    test('returns <body />', () => {
       expect(getScrollParent(document.documentElement)).toBe(document.body)
     })
   })
 
-  describe('when argument is document', () => {
-    test('returns document.body', () => {
+  describe('when argument is <document />', () => {
+    test('returns <body />', () => {
       expect(getScrollParent(document)).toBe(document.body)
     })
   })
 
   describe('when there is no scrollable parent for the node argument', () => {
-    test('returns document.body', () => {
+    test('returns <body />', () => {
       expect(getScrollParent(testsSetup.element)).toBe(document.body)
     })
   })
 
   describe('when there are scrollable parents for the node argument', () => {
-    test('returns the first parent node', () => {
+    test('returns the first scrollable parent node', () => {
       overflowStyles.forEach(styles => {
         setStylesForElements(
           [testsSetup.scrollableParent, testsSetup.scrollableGrandparent],
@@ -91,7 +91,7 @@ describe('getScrollParent', () => {
   })
 
   describe('when there are scrollable parents for the node argument and the node argument is scrollable', () => {
-    test('returns the first parent node', () => {
+    test('returns the first scrollable parent node', () => {
       overflowStyles.forEach(styles => {
         setStylesForElements(
           [testsSetup.element, testsSetup.scrollableParent, testsSetup.scrollableGrandparent],

--- a/packages/react/test/specs/lib/positioner/getScrollParent-test.ts
+++ b/packages/react/test/specs/lib/positioner/getScrollParent-test.ts
@@ -53,26 +53,32 @@ describe('getScrollParent', () => {
   beforeAll(() => testsSetup.init())
   beforeEach(() => testsSetup.resetStyles())
 
-  describe('returns document.body', () => {
-    test('when argument is document.body', () => {
+  describe('when argument is document.body', () => {
+    test('returns document.body', () => {
       expect(getScrollParent(document.body)).toBe(document.body)
     })
+  })
 
-    test('when argument is document.documentElement', () => {
+  describe('when argument is document.documentElement', () => {
+    test('returns document.body', () => {
       expect(getScrollParent(document.documentElement)).toBe(document.body)
     })
+  })
 
-    test('when argument is document', () => {
+  describe('when argument is document', () => {
+    test('returns document.body', () => {
       expect(getScrollParent(document)).toBe(document.body)
     })
+  })
 
-    test('when there is no scrollable parent for the node argument', () => {
+  describe('when there is no scrollable parent for the node argument', () => {
+    test('returns document.body', () => {
       expect(getScrollParent(testsSetup.element)).toBe(document.body)
     })
   })
 
-  describe('returns the first parent node when there are scrollable parents for the node argument', () => {
-    test('when there are scrollable parents for the node argument', () => {
+  describe('when there are scrollable parents for the node argument', () => {
+    test('returns the first parent node', () => {
       overflowStyles.forEach(styles => {
         setStylesForElements(
           [testsSetup.scrollableParent, testsSetup.scrollableGrandparent],
@@ -82,8 +88,10 @@ describe('getScrollParent', () => {
         expect(getScrollParent(testsSetup.element)).toBe(testsSetup.scrollableParent)
       })
     })
+  })
 
-    test('when there are scrollable parents for the node argument and the node argument is scrollable', () => {
+  describe('when there are scrollable parents for the node argument and the node argument is scrollable', () => {
+    test('returns the first parent node', () => {
       overflowStyles.forEach(styles => {
         setStylesForElements(
           [testsSetup.element, testsSetup.scrollableParent, testsSetup.scrollableGrandparent],


### PR DESCRIPTION
# feat(menu): automatic positioning inside viewport

Fixes #1360

## Description
Open Menus and submenus at lower part of screen
![image](https://user-images.githubusercontent.com/5442794/58024444-7be8e880-7b12-11e9-8484-eb5ddfea6510.png)

### Expected Result
menus and submenus are automatically rendered inside viewport (on top)

### Actual Result
menus and submenus are cut off when there is not enough space in the viewport 💣

## DEMO with current behavior
![Screen Recording 2019-05-23 at 19 13 31](https://user-images.githubusercontent.com/5442794/58272730-6df3cb80-7d8f-11e9-8888-574052198918.gif)

