### PR TITLE
fix(menuItemBehavior): Remove redundant aria attributes

### DIFF
--- a/packages/react/src/lib/accessibility/Behaviors/Menu/menuItemBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Menu/menuItemBehavior.ts
@@ -45,8 +45,6 @@ const menuItemBehavior: Accessibility = (props: any) => ({
         ? true
         : undefined,
       [IS_FOCUSABLE_ATTRIBUTE]: !props['disabled'],
-      'aria-posinset': props.itemPosition,
-      'aria-setsize': props.itemsCount,
     },
   },
 


### PR DESCRIPTION
This PR removes 'aria-posinset' and 'aria-setsize' attributes from `menuitemBehavior` as they're no more needed.