### PR TITLE
chore(ts): rearrange configs to disallow use aliases

### DIFF
--- a/build/tsconfig.common.json
+++ b/build/tsconfig.common.json
@@ -5,10 +5,7 @@
     "lib": ["es2015", "dom"],
     "baseUrl": "../",
     "paths": {
-      "@stardust-ui/*": ["packages/*/src"],
-      "docs/*": ["docs/*"],
-      "src/*": ["packages/react/src/*"],
-      "test/*": ["packages/react/test/*"]
+      "@stardust-ui/*": ["packages/*/src"]
     },
     "types": ["node", "jest"],
     "typeRoots": ["../types", "../node_modules/@types"],

--- a/build/tsconfig.docs.json
+++ b/build/tsconfig.docs.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "paths": {
+      "@stardust-ui/*": ["packages/*/src"],
       "docs/*": ["docs/*"],
       "src/*": ["packages/react/src/*"],
       "test/*": ["packages/react/test/*"]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "release:major": "yarn prerelease && lerna publish major && yarn postrelease",
     "release:minor": "yarn prerelease && lerna publish minor && yarn postrelease",
     "release:patch": "yarn prerelease && lerna publish patch && yarn postrelease",
-    "prestart": "yarn satisfied --fix yarn",
+    "prestart": "yarn satisfied",
     "start": "cross-env SKIP_ERRORS=true gulp --series dll docs",
     "stats:build": "gulp stats",
     "stats:save": "gulp stats:save",

--- a/packages/react/src/themes/teams-dark/components/List/listItemVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/List/listItemVariables.ts
@@ -1,4 +1,4 @@
-import { ListItemVariables } from 'src/themes/teams/components/List/listItemVariables'
+import { ListItemVariables } from '../../../teams/components/List/listItemVariables'
 
 export default (siteVars: any): Partial<ListItemVariables> => ({
   selectedFocusOutlineColor: siteVars.colors.brand[600],

--- a/packages/react/src/themes/teams-dark/components/RadioGroup/radioGroupItemVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/RadioGroup/radioGroupItemVariables.ts
@@ -1,4 +1,4 @@
-import { RadioGroupItemVariables } from 'src/themes/teams/components/RadioGroup/radioGroupItemVariables'
+import { RadioGroupItemVariables } from '../../../teams/components/RadioGroup/radioGroupItemVariables'
 
 export default (siteVars: any): Partial<RadioGroupItemVariables> => ({
   colorDisabled: siteVars.colors.grey[450],

--- a/packages/react/src/themes/teams-high-contrast/components/List/listItemVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/List/listItemVariables.ts
@@ -1,4 +1,4 @@
-import { ListItemVariables } from 'src/themes/teams/components/List/listItemVariables'
+import { ListItemVariables } from '../../../teams/components/List/listItemVariables'
 
 export default (siteVars: any): Partial<ListItemVariables> => ({
   selectedColor: siteVars.colors.black,

--- a/packages/react/src/themes/teams-high-contrast/components/RadioGroup/radioGroupItemVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/RadioGroup/radioGroupItemVariables.ts
@@ -1,4 +1,4 @@
-import { RadioGroupItemVariables } from 'src/themes/teams/components/RadioGroup/radioGroupItemVariables'
+import { RadioGroupItemVariables } from '../../../teams/components/RadioGroup/radioGroupItemVariables'
 
 export default (siteVars: any): Partial<RadioGroupItemVariables> => ({
   colorDisabled: siteVars.accessibleGreen,

--- a/packages/react/src/themes/teams/withProcessedIcons.ts
+++ b/packages/react/src/themes/teams/withProcessedIcons.ts
@@ -1,8 +1,7 @@
-import { ThemeInput, ThemeIconSpec, SvgIconSpec } from '../types'
+import { ThemeInput, ThemeIconSpec, SvgIconSpec, ThemeIcons } from '../types'
 
 import { default as svgIconsAndStyles } from './components/Icon/svg/ProcessedIcons'
 import { TeamsProcessedSvgIconSpec } from './components/Icon/svg/types'
-import { ThemeIcons } from 'src/themes/types'
 import { getIcon } from './index'
 
 type ThemeProcessedIconSpec = ThemeIconSpec &

--- a/packages/react/test/tsconfig.json
+++ b/packages/react/test/tsconfig.json
@@ -1,12 +1,11 @@
 {
-  "extends": "./tsconfig.common.json",
+  "extends": "../../../build/tsconfig.common",
   "compilerOptions": {
-    "module": "esnext",
     "paths": {
       "docs/*": ["docs/*"],
       "src/*": ["packages/react/src/*"],
       "test/*": ["packages/react/test/*"]
     }
   },
-  "include": ["../docs/src", "../packages/react/src", "../types"]
+  "include": ["**/*"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../build/tsconfig.common",
+  "include": ["src"]
+}


### PR DESCRIPTION
Picked from #1387.

This PR updates `paths` option in our project structure and disallows to use `src`, `docs` and `test` aliases in package directories.

### Motivation

- creates issues with typings
- one of the most common reasons of failed CI builds
- editors use it for auto import and it is easy to miss them
