### PR TITLE
chore(docs): update `react-source-render`

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-markdown": "^4.0.8",
     "react-router": "^4.1.2",
     "react-router-dom": "^4.1.2",
-    "react-source-render": "3.0.0-3",
+    "react-source-render": "3.0.0-5",
     "react-test-renderer": "^16.8.5",
     "react-vis": "^1.11.6",
     "request-promise-native": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11504,10 +11504,10 @@ react-side-effect@^1.0.2:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-source-render@3.0.0-3:
-  version "3.0.0-3"
-  resolved "https://registry.yarnpkg.com/react-source-render/-/react-source-render-3.0.0-3.tgz#6d624fc8489f2b3bdf6c2234e224edc82c570488"
-  integrity sha512-l/xnrmdwV2VKEWG/dmSB6gaeCgDFdXrPP/glNuMLJDInejwNzv3Gs8wgzwGSAlSp4JPCrQmxiQq/59LC2CdSOQ==
+react-source-render@3.0.0-5:
+  version "3.0.0-5"
+  resolved "https://registry.yarnpkg.com/react-source-render/-/react-source-render-3.0.0-5.tgz#0fa93493b3c2909f7c264bfc41db9957696e599b"
+  integrity sha512-NiyLvNJYQeFgJnyTEAicf5AerAJ8iXGhDQchm/ZxU/fwOLi03meBgPO5wrj2xxnhBbgWiunOeHK5pNBXU1pfpA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     deepmerge "^2.2.1"


### PR DESCRIPTION
Fixes small regression from #1370.

HTML preview was broken before:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/14183168/58410294-324c5080-8072-11e9-8777-4a736b7ec60b.png)
