### PR TITLE
refactor(customPropTypes): remove usage of _.chain

### DIFF
--- a/packages/react-proptypes/src/index.ts
+++ b/packages/react-proptypes/src/index.ts
@@ -5,7 +5,7 @@ import leven from './leven'
 
 type ObjectOf<T> = Record<string, T>
 
-const typeOf = x => Object.prototype.toString.call(x)
+const typeOf = (x: any) => Object.prototype.toString.call(x)
 
 /**
  * Ensure a component can render as a give prop value.
@@ -43,42 +43,43 @@ export const suggest = (suggestions: string[]) => {
   const findBestSuggestions = _.memoize((str: string) => {
     const propValueWords = str.split(' ')
 
-    return _.chain(suggestions)
-      .map((suggestion: string) => {
-        const suggestionWords = suggestion.split(' ')
+    return _.take(
+      _.sortBy(
+        _.map(suggestions, (suggestion: string) => {
+          const suggestionWords = suggestion.split(' ')
 
-        const propValueScore = _.chain(propValueWords)
-          .map(x => _.map(suggestionWords, y => leven(x, y)))
-          .map(_.min)
-          .sum()
-          .value()
+          const propValueScore = _.sum(
+            _.map(_.map(propValueWords, x => _.map(suggestionWords, y => leven(x, y))), _.min),
+          )
 
-        const suggestionScore = _.chain(suggestionWords)
-          .map(x => _.map(propValueWords, y => leven(x, y)))
-          .map(_.min)
-          .sum()
-          .value()
+          const suggestionScore = _.sum(
+            _.map(_.map(suggestionWords, x => _.map(propValueWords, y => leven(x, y))), _.min),
+          )
 
-        return { suggestion, score: propValueScore + suggestionScore }
-      })
-      .sortBy(['score', 'suggestion'])
-      .take(3)
-      .value()
+          return { suggestion, score: propValueScore + suggestionScore }
+        }),
+        ['score', 'suggestion'],
+      ),
+      3,
+    )
   })
 
   // Convert the suggestions list into a hash map for O(n) lookup times. Ensure
   // the words in each key are sorted alphabetically so that we have a consistent
   // way of looking up a value in the map, i.e. we can sort the words in the
   // incoming propValue and look that up without having to check all permutations.
-  const suggestionsLookup = suggestions.reduce((acc, key) => {
-    acc[
-      key
-        .split(' ')
-        .sort()
-        .join(' ')
-    ] = true
-    return acc
-  }, {})
+  const suggestionsLookup: Record<string, boolean> = suggestions.reduce(
+    (acc: Record<string, boolean>, key: string) => {
+      acc[
+        key
+          .split(' ')
+          .sort()
+          .join(' ')
+      ] = true
+      return acc
+    },
+    {},
+  )
 
   return (props: ObjectOf<any>, propName: string, componentName: string) => {
     const propValue = props[propName]
@@ -174,20 +175,18 @@ export const every = (validators: Function[]) => (
     )
   }
 
-  const error = _.chain(validators)
-    .map(validator => {
-      if (typeof validator !== 'function') {
-        throw new Error(
-          `every() argument "validators" should contain functions, found: ${typeOf(validator)}.`,
-        )
-      }
-      return validator(props, propName, componentName, ...args)
-    })
-    .compact()
-    .first() // we can only return one error at a time
-    .value()
-
-  return error
+  return _.first(
+    _.compact(
+      _.map(validators, validator => {
+        if (typeof validator !== 'function') {
+          throw new Error(
+            `every() argument "validators" should contain functions, found: ${typeOf(validator)}.`,
+          )
+        }
+        return validator(props, propName, componentName, ...args)
+      }),
+    ),
+  ) // we can only return one error at a time
 }
 
 /**
@@ -209,17 +208,16 @@ export const some = (validators: Function[]) => (
     )
   }
 
-  const errors = _.chain(validators)
-    .map(validator => {
+  const errors = _.compact(
+    _.map(validators, validator => {
       if (!_.isFunction(validator)) {
         throw new Error(
           `some() argument "validators" should contain functions, found: ${typeOf(validator)}.`,
         )
       }
       return validator(props, propName, componentName, ...args)
-    })
-    .compact()
-    .value()
+    }),
+  )
 
   // fail only if all validators failed
   if (errors.length === validators.length) {
@@ -236,7 +234,7 @@ export const some = (validators: Function[]) => (
  * @param {object} propsShape An object describing the prop shape.
  * @param {function} validator A propType function.
  */
-export const givenProps = (propsShape: object, validator: Function) => (
+export const givenProps = (propsShape: Record<string, any>, validator: Function) => (
   props: ObjectOf<any>,
   propName: string,
   componentName: string,
@@ -260,7 +258,7 @@ export const givenProps = (propsShape: object, validator: Function) => (
     )
   }
 
-  const shouldValidate = _.keys(propsShape).every(key => {
+  const shouldValidate = _.keys(propsShape).every((key: string) => {
     const val = propsShape[key]
     // require propShape validators to pass or prop values to match
     return typeof val === 'function'

--- a/packages/react/test/specs/components/Box/Box-test.ts
+++ b/packages/react/test/specs/components/Box/Box-test.ts
@@ -1,8 +1,0 @@
-import Box from 'src/components/Box/Box'
-import { isConformant } from 'test/specs/commonTests'
-
-describe('Box', () => {
-  xdescribe('is conformant', () => {
-    isConformant(Box)
-  })
-})


### PR DESCRIPTION
Picked from #1169.

This PR removes the usage of Lodash's `_.chain()`:
https://medium.com/making-internets/why-using-chain-is-a-mistake-9bc1f80d51ba

The main problem: with `_.chain()` you will include the whole Lodash and you will not be able to pick single modules. `babel-plugin-lodash` will also stuck in this case.