### PR TITLE
refactor(Ref): use only one type for props

### DIFF
--- a/packages/react-component-ref/src/Ref.tsx
+++ b/packages/react-component-ref/src/Ref.tsx
@@ -5,17 +5,7 @@ import * as ReactIs from 'react-is'
 
 import RefFindNode from './RefFindNode'
 import RefForward from './RefForward'
-
-export interface RefProps {
-  children: React.ReactElement<any>
-
-  /**
-   * Called when a child component will be mounted or updated.
-   *
-   * @param {HTMLElement} node - Referred node.
-   */
-  innerRef: React.Ref<any>
-}
+import { RefProps } from './types'
 
 const Ref: React.FunctionComponent<RefProps> = props => {
   const { children, innerRef } = props

--- a/packages/react-component-ref/src/RefFindNode.tsx
+++ b/packages/react-component-ref/src/RefFindNode.tsx
@@ -4,19 +4,9 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
 import handleRef from './handleRef'
+import { RefProps } from './types'
 
-export interface RefFindNodeProps {
-  children: React.ReactElement<any>
-
-  /**
-   * Called when a child component will be mounted or updated.
-   *
-   * @param {HTMLElement} node - Referred node.
-   */
-  innerRef: React.Ref<any>
-}
-
-export default class RefFindNode extends React.Component<RefFindNodeProps> {
+export default class RefFindNode extends React.Component<RefProps> {
   static displayName = 'RefFindNode'
 
   static propTypes = {
@@ -32,7 +22,7 @@ export default class RefFindNode extends React.Component<RefFindNodeProps> {
     handleRef(this.props.innerRef, this.prevNode)
   }
 
-  componentDidUpdate(prevProps: RefFindNodeProps) {
+  componentDidUpdate(prevProps: RefProps) {
     const currentNode = ReactDOM.findDOMNode(this)
 
     if (this.prevNode !== currentNode) {

--- a/packages/react-component-ref/src/RefForward.tsx
+++ b/packages/react-component-ref/src/RefForward.tsx
@@ -3,19 +3,9 @@ import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import handleRef from './handleRef'
+import { RefProps } from './types'
 
-export interface RefForwardProps {
-  children: React.ReactElement<any>
-
-  /**
-   * Called when a child component will be mounted or updated.
-   *
-   * @param {HTMLElement} node - Referred node.
-   */
-  innerRef: React.Ref<any>
-}
-
-export default class RefForward extends React.Component<RefForwardProps> {
+export default class RefForward extends React.Component<RefProps> {
   static displayName = 'RefForward'
 
   static propTypes = {

--- a/packages/react-component-ref/src/index.ts
+++ b/packages/react-component-ref/src/index.ts
@@ -2,7 +2,8 @@ export { default as handleRef } from './handleRef'
 export { default as isRefObject } from './isRefObject'
 export { default as toRefObject } from './toRefObject'
 
-export * from './Ref'
 export { default as Ref } from './Ref'
 export { default as RefFindNode } from './RefFindNode'
 export { default as RefForward } from './RefForward'
+
+export * from './types'

--- a/packages/react-component-ref/src/types.ts
+++ b/packages/react-component-ref/src/types.ts
@@ -1,0 +1,12 @@
+import * as React from 'react'
+
+export interface RefProps {
+  children: React.ReactElement<any>
+
+  /**
+   * Called when a child component will be mounted or updated.
+   *
+   * @param {HTMLElement} node - Referred node.
+   */
+  innerRef: React.Ref<any>
+}

--- a/packages/react-component-ref/test/toRefObject-test.ts
+++ b/packages/react-component-ref/test/toRefObject-test.ts
@@ -7,7 +7,7 @@ describe('toRefObject', () => {
   })
 
   it('handles "null" as input', () => {
-    expect(toRefObject(null)).toHaveProperty('current', null)
+    expect(toRefObject(null as any)).toHaveProperty('current', null)
   })
 
   it('returned object is memoized', () => {


### PR DESCRIPTION
Picked from #1169.

It's strange that we have separated types for these components, this PR removes `RefFindNodeProps` and `RefForwardProps` because they are useless.