### PR TITLE
fix(eslint): address warnings

### DIFF
--- a/build/.eslintrc.json
+++ b/build/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../packages/internal-tooling/eslint/index.js"],
+  "rules": {
+    "no-console": "off"
+  },
+  "root": true
+}

--- a/docs/.eslintrc.json
+++ b/docs/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../packages/internal-tooling/eslint/index.js"],
+  "rules": {
+    "no-alert": "off"
+  },
+  "root": true
+}

--- a/packages/internal-tooling/eslint/index.js
+++ b/packages/internal-tooling/eslint/index.js
@@ -37,6 +37,7 @@ module.exports = {
     'react/button-has-type': 'off',
     'react/destructuring-assignment': 'off',
     'react/default-props-match-prop-types': 'off',
+    'react/forbid-foreign-prop-types': 'off',
     'react/jsx-curly-brace-presence': 'off',
     'react/jsx-boolean-value': 'off',
     'react/jsx-no-bind': 'off',

--- a/packages/internal-tooling/jest/setupTests.js
+++ b/packages/internal-tooling/jest/setupTests.js
@@ -2,6 +2,9 @@
  * Setup
  * This is the bootstrap code that is run before any tests, utils, mocks.
  */
+
+/* eslint-disable no-console */
+
 const enzyme = require('enzyme')
 const Adapter = require('enzyme-adapter-react-16')
 

--- a/packages/react/src/lib/AutoControlledComponent.tsx
+++ b/packages/react/src/lib/AutoControlledComponent.tsx
@@ -82,6 +82,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
       const { defaultProps, name, propTypes } = this.constructor as any
       // require static autoControlledProps
       if (!autoControlledProps) {
+        /* eslint-disable no-console */
         console.error(`Auto controlled ${name} must specify a static autoControlledProps array.`)
       }
 
@@ -90,12 +91,14 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
         const defaultProp = getDefaultPropName(prop)
         // regular prop
         if (!_.has(propTypes, defaultProp)) {
+          /* eslint-disable no-console */
           console.error(
             `${name} is missing "${defaultProp}" propTypes validation for auto controlled prop "${prop}".`,
           )
         }
         // its default prop
         if (!_.has(propTypes, prop)) {
+          /* eslint-disable no-console */
           console.error(
             `${name} is missing propTypes validation for auto controlled prop "${prop}".`,
           )
@@ -114,6 +117,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
       // https://babeljs.io/blog/2015/06/07/react-on-es6-plus#property-initializers
       const illegalDefaults = _.intersection(autoControlledProps, _.keys(defaultProps))
       if (!_.isEmpty(illegalDefaults)) {
+        /* eslint-disable no-console */
         console.error(
           [
             'Do not set defaultProps for autoControlledProps. You can set defaults by',
@@ -132,6 +136,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
         _.startsWith(prop, 'default'),
       )
       if (!_.isEmpty(illegalAutoControlled)) {
+        /* eslint-disable no-console */
         console.error(
           [
             'Do not add default props to autoControlledProps.',
@@ -154,6 +159,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
         const { name } = this.constructor
         // prevent defaultFoo={} along side foo={}
         if (!_.isUndefined(this.props[defaultPropName]) && !_.isUndefined(this.props[prop])) {
+          /* eslint-disable no-console */
           console.error(
             `${name} prop "${prop}" is auto controlled. Specify either ${defaultPropName} or ${prop}, but not both.`,
           )

--- a/packages/react/src/lib/AutoControlledComponent.tsx
+++ b/packages/react/src/lib/AutoControlledComponent.tsx
@@ -82,7 +82,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
       const { defaultProps, name, propTypes } = this.constructor as any
       // require static autoControlledProps
       if (!autoControlledProps) {
-        /* eslint-disable no-console */
+        /* eslint-disable-next-line no-console */
         console.error(`Auto controlled ${name} must specify a static autoControlledProps array.`)
       }
 
@@ -91,14 +91,14 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
         const defaultProp = getDefaultPropName(prop)
         // regular prop
         if (!_.has(propTypes, defaultProp)) {
-          /* eslint-disable no-console */
+          /* eslint-disable-next-line no-console */
           console.error(
             `${name} is missing "${defaultProp}" propTypes validation for auto controlled prop "${prop}".`,
           )
         }
         // its default prop
         if (!_.has(propTypes, prop)) {
-          /* eslint-disable no-console */
+          /* eslint-disable-next-line no-console */
           console.error(
             `${name} is missing propTypes validation for auto controlled prop "${prop}".`,
           )
@@ -117,7 +117,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
       // https://babeljs.io/blog/2015/06/07/react-on-es6-plus#property-initializers
       const illegalDefaults = _.intersection(autoControlledProps, _.keys(defaultProps))
       if (!_.isEmpty(illegalDefaults)) {
-        /* eslint-disable no-console */
+        /* eslint-disable-next-line no-console */
         console.error(
           [
             'Do not set defaultProps for autoControlledProps. You can set defaults by',
@@ -136,7 +136,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
         _.startsWith(prop, 'default'),
       )
       if (!_.isEmpty(illegalAutoControlled)) {
-        /* eslint-disable no-console */
+        /* eslint-disable-next-line no-console */
         console.error(
           [
             'Do not add default props to autoControlledProps.',
@@ -159,7 +159,7 @@ export default class AutoControlledComponent<P = {}, S = {}> extends UIComponent
         const { name } = this.constructor
         // prevent defaultFoo={} along side foo={}
         if (!_.isUndefined(this.props[defaultPropName]) && !_.isUndefined(this.props[prop])) {
-          /* eslint-disable no-console */
+          /* eslint-disable-next-line no-console */
           console.error(
             `${name} prop "${prop}" is auto controlled. Specify either ${defaultPropName} or ${prop}, but not both.`,
           )

--- a/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -276,7 +276,7 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
 
     if (bodyChildren.length && !document.body.contains(this._root.current)) {
       // In case popup render options will change
-      /* eslint-disable no-console */
+      /* eslint-disable-next-line no-console */
       console.warn(
         'Body element does not contain trap zone element. Please, ensure the trap zone element is placed inside body, so it will work properly.',
       )

--- a/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -276,6 +276,7 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
 
     if (bodyChildren.length && !document.body.contains(this._root.current)) {
       // In case popup render options will change
+      /* eslint-disable no-console */
       console.warn(
         'Body element does not contain trap zone element. Please, ensure the trap zone element is placed inside body, so it will work properly.',
       )

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -161,6 +161,7 @@ function createShorthandFromValue({
     !valIsReactElement &&
     !valIsNoop
   ) {
+    /* eslint-disable no-console */
     console.error(
       [
         'Shorthand value must be a string|number|object|array|ReactElements.',

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -161,7 +161,7 @@ function createShorthandFromValue({
     !valIsReactElement &&
     !valIsNoop
   ) {
-    /* eslint-disable no-console */
+    /* eslint-disable-next-line no-console */
     console.error(
       [
         'Shorthand value must be a string|number|object|array|ReactElements.',

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -16,7 +16,7 @@ try {
 
 if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   if (felaDevMode) {
-    /* eslint-disable no-console */
+    /* eslint-disable-next-line no-console */
     console.warn(
       [
         '@stardust-ui/react:',
@@ -25,7 +25,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
       ].join(' '),
     )
   } else {
-    /* eslint-disable no-console */
+    /* eslint-disable-next-line no-console */
     console.warn(
       [
         '@stardust-ui/react:',

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -16,6 +16,7 @@ try {
 
 if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   if (felaDevMode) {
+    /* eslint-disable no-console */
     console.warn(
       [
         '@stardust-ui/react:',
@@ -24,6 +25,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
       ].join(' '),
     )
   } else {
+    /* eslint-disable no-console */
     console.warn(
       [
         '@stardust-ui/react:',

--- a/packages/react/src/lib/providerMissingHandler.ts
+++ b/packages/react/src/lib/providerMissingHandler.ts
@@ -9,7 +9,7 @@ const warning = {
 
 const logProviderMissingWarning = (): void => {
   if (!warning.wasLogged) {
-    /* eslint-disable no-console */
+    /* eslint-disable-next-line no-console */
     console.error(warning.message)
     warning.wasLogged = true
   }

--- a/packages/react/src/lib/providerMissingHandler.ts
+++ b/packages/react/src/lib/providerMissingHandler.ts
@@ -9,6 +9,7 @@ const warning = {
 
 const logProviderMissingWarning = (): void => {
   if (!warning.wasLogged) {
+    /* eslint-disable no-console */
     console.error(warning.message)
     warning.wasLogged = true
   }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -110,12 +110,13 @@ type PickProps<T, Props extends string | number | symbol> = {
   [K in Intersect<Props, keyof T>]: T[K]
 }
 
-export const withSafeTypeForAs = function<
+export const withSafeTypeForAs = <
   TComponentType extends React.ComponentType,
   TProps,
-  TAs extends keyof JSX.IntrinsicElements = 'div',
-  TAdditionalProps extends keyof TComponentType = undefined
->(componentType: TComponentType) {
+  TAs extends keyof JSX.IntrinsicElements = 'div'
+>(
+  componentType: TComponentType,
+) => {
   /**
    * TODO: introduce overload once TS compiler issue that leads to
    * 'JS Heap Out Of Memory' exception will be fixed

--- a/perf/.eslintrc.json
+++ b/perf/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../packages/internal-tooling/eslint/index.js"],
+  "rules": {
+    "no-console": "off"
+  },
+  "root": true
+}


### PR DESCRIPTION
This PR addresses the problem of eslint warnings for our repo: there were 55 warnings previously reported:

![image](https://user-images.githubusercontent.com/9024564/58441619-b5f25580-80e3-11e9-856d-2d282b1d3a0e.png)

These warnings are turning into errors in production environment (`NODE_ENV` being equal to `production`), and **this has prevented us from running CI scripts agains PROD**. Now the issue is fixed.

![image](https://user-images.githubusercontent.com/9024564/58442125-619da480-80e8-11e9-9e28-54553bcbcb25.png)
