### PR TITLE
fix(popup): revert proptypes for content and trigger fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - ESC key pressed on a trigger element should propagate event if `Popup` is closed @sophieH29 ([#1373](https://github.com/stardust-ui/react/pull/1373))
 - Changing icon behavior as for some cases icon could be visible @kolaps33 ([#1327](https://github.com/stardust-ui/react/pull/1327))
-- `Popup` - fix proptypes for `content` and `trigger` props @miroslavstastny ([#1420](https://github.com/stardust-ui/react/pull/1420))
 - Make `contentRef` prop optional for `Accordion.Title` @Bugaa92 ([#1418](https://github.com/stardust-ui/react/pull/1418))
 - Call `getDerivedStateFromProps()` from `AutoControlledComponent` in `Dropdown` ([#1416](https://github.com/stardust-ui/react/pull/1416))
 

--- a/packages/react-proptypes/src/index.ts
+++ b/packages/react-proptypes/src/index.ts
@@ -376,19 +376,13 @@ export const wrapperShorthand = PropTypes.oneOfType([
 ])
 
 /**
- * A shorthand prop which can be used together with `children`.
- */
-export const shorthandAllowingChildren = PropTypes.oneOfType([
-  PropTypes.node,
-  PropTypes.object,
-  PropTypes.func,
-])
-
-/**
  * Item shorthand is a description of a component that can be a literal,
  * a props object, an element or a render function.
  */
-export const itemShorthand = every([disallow(['children']), shorthandAllowingChildren])
+export const itemShorthand = every([
+  disallow(['children']),
+  PropTypes.oneOfType([PropTypes.node, PropTypes.object, PropTypes.func]),
+])
 export const itemShorthandWithKindProp = (kindPropValues: string[]) => {
   return every([
     disallow(['children']),

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -142,7 +142,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     ...commonPropTypes.createCommon({
       animated: false,
       as: false,
-      content: false,
+      content: 'shorthand',
     }),
     align: PropTypes.oneOf(ALIGNMENTS),
     defaultOpen: PropTypes.bool,
@@ -162,8 +162,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     position: PropTypes.oneOf(POSITIONS),
     renderContent: PropTypes.func,
     target: PropTypes.any,
-    trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.any]),
-    content: customPropTypes.shorthandAllowingChildren,
+    trigger: PropTypes.any,
     contentRef: customPropTypes.ref,
   }
 


### PR DESCRIPTION
Revert "fix(Popup): proptypes for content and trigger (#1420)"

This reverts commit bd714f42da3e8ccbba20f0a53b5d22a02ded88c9.
