### PR TITLE
fix(popper): fix popper.js imports

### DIFF
--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -7,6 +7,8 @@ import { getPlacement, applyRtlToOffset } from './positioningHelper'
 import { PopperProps, PopperChildrenFn } from './types'
 import getScrollParent from './getScrollParent'
 
+// `popper.js` has a UMD build without `.default`, it breaks CJS builds:
+// https://github.com/rollup/rollup/issues/1267#issuecomment-446681320
 const createPopper = (
   reference: Element,
   popper: Element,

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react'
 import * as _ from 'lodash'
-import PopperJS from 'popper.js'
+import PopperJS, * as _PopperJS from 'popper.js'
 import { Ref } from '@stardust-ui/react-component-ref'
 
 import { getPlacement, applyRtlToOffset } from './positioningHelper'
 import { PopperProps, PopperChildrenFn } from './types'
 import getScrollParent from './getScrollParent'
+
+const createPopper = (
+  reference: Element,
+  popper: Element,
+  options?: PopperJS.PopperOptions,
+): PopperJS => new ((_PopperJS as any).default || _PopperJS)(reference, popper, options)
 
 /**
  * Popper relies on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.
@@ -91,7 +97,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
         onUpdate: handleUpdate,
       }
 
-      popperRef.current = new PopperJS(targetRef.current, contentRef.current, options)
+      popperRef.current = createPopper(targetRef.current, contentRef.current, options)
       return () => popperRef.current.destroy()
     },
     [computedModifiers, eventsEnabled, userModifiers, positionFixed, proposedPlacement],


### PR DESCRIPTION
## fix(popper): fix popper.js imports

### Description

This PR fixes the following issue:

The `commonjs` bundle file generated for `packages/react/src/lib/positioner/Popper.tsx` is incorrect; it produces the following error:

`TypeError: popper_js_1.default is not a constructor`

### Fix

`popper.js` has a UMD build without `.default`, it breaks CJS builds. Therefore we need to conditionally check `.default` prop on `PopperJS` object when we create the popper instance:
```typescript
new ((_PopperJS as any).default || _PopperJS)(reference, popper, options)
```