### PR TITLE
fix(popper): flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Call `getDerivedStateFromProps()` from `AutoControlledComponent` in `Dropdown` ([#1416](https://github.com/stardust-ui/react/pull/1416))
 - Fix `backgroundHover1` color in the Teams dark theme `colorScheme` @mnajdova ([1437](https://github.com/stardust-ui/react/pull/1437))
 - Revert changes with different roots in `Icon` component @layershifter ([#1435](https://github.com/stardust-ui/react/pull/1435))
+- Fix flickering issues with `Dropdown` and `Popup` components @Bugaa92 ([#1434](https://github.com/stardust-ui/react/pull/1434))
 
 ### Features
 - Add keyboard navigation and screen reader support for `Accordion` @silviuavram ([#1322](https://github.com/stardust-ui/react/pull/1322))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Make `contentRef` prop optional for `Accordion.Title` @Bugaa92 ([#1418](https://github.com/stardust-ui/react/pull/1418))
 - Call `getDerivedStateFromProps()` from `AutoControlledComponent` in `Dropdown` ([#1416](https://github.com/stardust-ui/react/pull/1416))
 - Fix `backgroundHover1` color in the Teams dark theme `colorScheme` @mnajdova ([1437](https://github.com/stardust-ui/react/pull/1437))
+- Fix flickering issues with `Dropdown` and `Popup` components @Bugaa92 ([#1434](https://github.com/stardust-ui/react/pull/1434))
 
 ### Features
 - Add keyboard navigation and screen reader support for `Accordion` @silviuavram ([#1322](https://github.com/stardust-ui/react/pull/1322))

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -660,7 +660,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           position={position}
           offset={offset}
           rtl={rtl}
-          eventsEnabled={open}
+          enabled={open}
           targetRef={this.containerRef}
           positioningDependencies={[items.length]}
         >

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -247,7 +247,6 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
               align={vertical ? 'top' : 'start'}
               position={vertical ? 'after' : 'below'}
               targetRef={this.itemRef}
-              modifiers={{ flip: { flipVariationsByContent: true } }}
             >
               {Menu.create(menu, {
                 defaultProps: {

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -150,16 +150,17 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
           placement: computedPlacement,
           scheduleUpdate,
         })
-      : React.Children.only(children)
+      : children
 
   return (
     <Ref
       innerRef={contentElement => {
         contentRef.current = contentElement
+        // for correct positioning we need to create the PopperJS instance immediately after we get a ref to the popper box
         createInstance()
       }}
     >
-      {child as React.ReactElement}
+      {React.Children.only(child) as React.ReactElement}
     </Ref>
   )
 }

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -119,6 +119,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
 
       popperRef.current = createPopper(targetRef.current, contentRef.current, options)
     },
+    // TODO review dependencies for popperHasScrollableParent
     [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement],
   )
 

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -89,7 +89,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
 
       const modifiers: PopperJS.Modifiers = _.merge(
         { preventOverflow: { padding: 0 } },
-        { flip: { padding: 0 } },
+        { flip: { padding: 0, flipVariationsByContent: true } },
         /**
          * When the popper box is placed in the context of a scrollable element, we need to set
          * preventOverflow.escapeWithReference to true and flip.boundariesElement to 'scrollParent' (default is 'viewport')

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -37,8 +37,10 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
 
   const popperRef = React.useRef<PopperJS>()
   const contentRef = React.useRef<HTMLElement>(null)
-  const latestPlacement = React.useRef<PopperJS.Placement>()
-  const [computedPlacement, setComputedPlacement] = React.useState<PopperJS.Placement>()
+  const latestPlacement = React.useRef<PopperJS.Placement>(proposedPlacement)
+  const [computedPlacement, setComputedPlacement] = React.useState<PopperJS.Placement>(
+    proposedPlacement,
+  )
 
   const computedModifiers: PopperJS.Modifiers = React.useMemo(
     () =>
@@ -49,32 +51,18 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
     [rtl, offset, position],
   )
 
-  const scheduleUpdate = React.useCallback(
-    () => {
-      if (popperRef.current) {
-        popperRef.current.scheduleUpdate()
-      }
-    },
-    [popperRef.current],
-  )
+  const scheduleUpdate = React.useCallback(() => {
+    if (popperRef.current) {
+      popperRef.current.scheduleUpdate()
+    }
+  }, [])
 
-  const destroyInstance = React.useCallback(
-    () => {
-      if (popperRef.current) {
-        popperRef.current.destroy()
-        popperRef.current = null
-      }
-    },
-    [popperRef.current],
-  )
-
-  const instanceDependencies = [
-    computedModifiers,
-    enabled,
-    userModifiers,
-    positionFixed,
-    proposedPlacement,
-  ]
+  const destroyInstance = React.useCallback(() => {
+    if (popperRef.current) {
+      popperRef.current.destroy()
+      popperRef.current = null
+    }
+  }, [])
 
   const createInstance = React.useCallback(
     () => {
@@ -131,7 +119,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
 
       popperRef.current = createPopper(targetRef.current, contentRef.current, options)
     },
-    [targetRef.current, contentRef.current, ...instanceDependencies],
+    [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement],
   )
 
   React.useEffect(
@@ -139,7 +127,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
       createInstance()
       return destroyInstance
     },
-    [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement],
+    [createInstance],
   )
 
   React.useEffect(scheduleUpdate, [...positioningDependencies, computedPlacement])

--- a/packages/react/src/lib/positioner/types.ts
+++ b/packages/react/src/lib/positioner/types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import PopperJS from 'popper.js'
 
 export type Position = 'above' | 'below' | 'before' | 'after'
@@ -42,9 +43,9 @@ export interface PopperProps extends PositioningProps {
 
   /**
    * Enables events (resize, scroll).
-   * @prop {Boolean} eventsEnabled=true
+   * @prop {Boolean} enabled=true
    */
-  eventsEnabled?: boolean
+  enabled?: boolean
 
   /**
    * List of modifiers used to modify the offsets before they are applied to the Popper box.
@@ -66,7 +67,7 @@ export interface PopperProps extends PositioningProps {
   /**
    * Ref object containing the target node (the element that we're using as reference for Popper box).
    */
-  targetRef?: React.RefObject<Element>
+  targetRef: React.RefObject<Element>
 
   /**
    * Rtl attribute for the component.


### PR DESCRIPTION
## fix(popper): flickering

Fixes #1415
Fixes #1361 

### Description

#### Popup content jumps for a split second when opening.
Perform the following steps to reproduce the problem:
- build master
- go to `Popup` examples page: http://localhost:8080/components/popup#types-popup
- click the button to open the `Popup`

#### Expected Result
Popup opens without jump

#### Actual Result
Popup has a small but noticeable jump when opening (see gif below) 💣

![popup](https://user-images.githubusercontent.com/5442794/58549567-1aa8cf80-820c-11e9-8989-aa550c436368.gif)

### Proposed fix

Create the `PopperJS` instance earlier, aka immediately after we get a `ref` to the `children` prop that the `popper.js` box is going to display:

```jsx
<Ref
  innerRef={contentElement => {
    contentRef.current = contentElement
    createInstance() // create `PopperJS` instance here !! 
  }}
>
  {child as React.ReactElement}
</Ref>
```