### PR TITLE
fix(attachment): action click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `Toolbar` component @miroslavstastny ([#1408](https://github.com/stardust-ui/react/pull/1408))
 - Add `disableAnimations` boolean prop on the `Provider` @mnajdova ([#1377](https://github.com/stardust-ui/react/pull/1377))
 
+### Fixes
+- Fix click handling on focus for `action` slot in `Attachment` component @Bugaa92 ([#1444](https://github.com/stardust-ui/react/pull/1444))
+
 <!--------------------------------[ v0.32.0 ]------------------------------- -->
 ## [v0.32.0](https://github.com/stardust-ui/react/tree/v0.32.0) (2019-06-03)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.31.0...v0.32.0)
@@ -44,7 +47,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `backgroundHover1` color in the Teams dark theme `colorScheme` @mnajdova ([1437](https://github.com/stardust-ui/react/pull/1437))
 - Revert changes with different roots in `Icon` component @layershifter ([#1435](https://github.com/stardust-ui/react/pull/1435))
 - Fix flickering issues with `Dropdown` and `Popup` components @Bugaa92 ([#1434](https://github.com/stardust-ui/react/pull/1434))
-- Fix click handling on focus for `action` slot in `Attachment` component @Bugaa92 ([#1444](https://github.com/stardust-ui/react/pull/1444))
 
 ### Features
 - Add keyboard navigation and screen reader support for `Accordion` @silviuavram ([#1322](https://github.com/stardust-ui/react/pull/1322))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `backgroundHover1` color in the Teams dark theme `colorScheme` @mnajdova ([1437](https://github.com/stardust-ui/react/pull/1437))
 - Revert changes with different roots in `Icon` component @layershifter ([#1435](https://github.com/stardust-ui/react/pull/1435))
 - Fix flickering issues with `Dropdown` and `Popup` components @Bugaa92 ([#1434](https://github.com/stardust-ui/react/pull/1434))
+- Fix click handling on focus for `action` slot in `Attachment` component @Bugaa92 ([#1444](https://github.com/stardust-ui/react/pull/1444))
 
 ### Features
 - Add keyboard navigation and screen reader support for `Accordion` @silviuavram ([#1322](https://github.com/stardust-ui/react/pull/1322))

--- a/packages/react/src/themes/teams/getBorderFocusStyles.ts
+++ b/packages/react/src/themes/teams/getBorderFocusStyles.ts
@@ -22,6 +22,7 @@ const getPseudoElementStyles = (args: BorderPseudoElementStyles): ICSSInJSStyle 
     content: '""',
     position: 'absolute',
     borderStyle: 'solid',
+    pointerEvents: 'none',
     top: borderEdgeValue,
     right: borderEdgeValue,
     bottom: borderEdgeValue,


### PR DESCRIPTION
## fix(attachment): action click

### Description

This PR fixes #1334 

Steps to reproduce issue:

1. Click on the action icon in the attachment and notice that the action's onClick event is fired.
2. Focus the Attachment, then click on the action icon and notice that the attachment's onClick event gets fired.

### Fix

Add `pointerEvents: 'none'` to `getBorderFocusStyles.ts` style helper in order ignore pointer events for the pseudo elements.

### BEFORE
The Attachment onClick event is fired when clicking the action icon when the attachment is focused.

![attachment-onClick-bug](https://user-images.githubusercontent.com/828692/57655822-ad4e3b00-758b-11e9-849e-0c359c9053b9.gif)

### AFTER
![Screen Recording 2019-06-03 at 14 43 59](https://user-images.githubusercontent.com/5442794/58802814-5f6aa700-860e-11e9-813f-0977ca67e663.gif)
