### PR TITLE
fix(ListItem): end media in Teams theme breaks ButtonGroup styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix click handling on focus for `action` slot in `Attachment` component @Bugaa92 ([#1444](https://github.com/stardust-ui/react/pull/1444))
+- Fix Teams' theme list item end media styles @mnajdova ([#1448](https://github.com/stardust-ui/react/pull/1448))
 
 <!--------------------------------[ v0.32.0 ]------------------------------- -->
 ## [v0.32.0](https://github.com/stardust-ui/react/tree/v0.32.0) (2019-06-03)

--- a/docs/src/examples/components/List/Variations/ListExampleTruncate.shorthand.tsx
+++ b/docs/src/examples/components/List/Variations/ListExampleTruncate.shorthand.tsx
@@ -1,6 +1,23 @@
 import { useBooleanKnob, useRangeKnob } from '@stardust-ui/docs-components'
-import { List, Image } from '@stardust-ui/react'
+import { List, Image, ButtonGroup } from '@stardust-ui/react'
 import * as React from 'react'
+
+const actions = (
+  <ButtonGroup
+    buttons={[
+      {
+        icon: 'stardust-checkmark',
+        iconOnly: true,
+        text: true,
+      },
+      {
+        icon: 'stardust-close',
+        iconOnly: true,
+        text: true,
+      },
+    ]}
+  />
+)
 
 const items = [
   {
@@ -10,6 +27,7 @@ const items = [
     headerMedia: '7:26:56 AM',
     content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
     contentMedia: '!!',
+    endMedia: actions,
   },
   {
     key: 'skyler',
@@ -18,6 +36,7 @@ const items = [
     headerMedia: '11:30:17 PM',
     content: 'Use the online FTP application to input the multi-byte application!',
     contentMedia: '!!',
+    endMedia: actions,
   },
   {
     key: 'dante',
@@ -26,6 +45,7 @@ const items = [
     headerMedia: '5:22:40 PM',
     content: 'The GB pixel is down, navigate the virtual interface!',
     contentMedia: '!!',
+    endMedia: actions,
   },
 ]
 

--- a/packages/react/src/themes/teams/components/List/listItemStyles.ts
+++ b/packages/react/src/themes/teams/components/List/listItemStyles.ts
@@ -100,6 +100,7 @@ const listItemStyles: ComponentSlotStylesInput<ListItemPropsAndState, any> = {
   }),
   endMedia: ({ props: p }) => ({
     ...(p.selectable && { display: 'none' }),
+    flexShrink: 0,
   }),
   main: () => ({
     minWidth: 0, // needed for the truncate styles to work


### PR DESCRIPTION
Fix https://github.com/stardust-ui/react/issues/1287

ButtonGroup style were broken when inside endMedia of ListItem.

**Before:**
![image](https://user-images.githubusercontent.com/4512430/58872754-0873d900-86c5-11e9-98fe-d289c7c2bccf.png)


**After:**
![image](https://user-images.githubusercontent.com/4512430/58872715-f2feaf00-86c4-11e9-9edd-d10d2de22d40.png)


