### PR TITLE
fix(felaPluginFallbackValue): broken because of order of plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix click handling on focus for `action` slot in `Attachment` component @Bugaa92 ([#1444](https://github.com/stardust-ui/react/pull/1444))
 - Fix Teams' theme list item end media styles @mnajdova ([#1448](https://github.com/stardust-ui/react/pull/1448))
+- Fix the order of the fela plugin @mnajdova ([#1461](https://github.com/stardust-ui/react/pull/1461))
 
 <!--------------------------------[ v0.32.0 ]------------------------------- -->
 ## [v0.32.0](https://github.com/stardust-ui/react/tree/v0.32.0) (2019-06-03)

--- a/docs/src/examples/components/Provider/Types/ProviderExampleRendererFelaPluginFallbackValue.shorthand.tsx
+++ b/docs/src/examples/components/Provider/Types/ProviderExampleRendererFelaPluginFallbackValue.shorthand.tsx
@@ -2,10 +2,16 @@ import * as React from 'react'
 import { Segment } from '@stardust-ui/react'
 
 const ProviderExampleShorthand = () => (
-  <Segment
-    content="Segment with blue border"
-    styles={{ border: ['1px solid red', '1px solid blue'] as any }}
-  />
+  <>
+    <Segment
+      content="Segment with red border"
+      styles={{ border: ['1px solid red', '1px solid invalid'] as any }}
+    />
+    <Segment
+      content="Segment with blue border"
+      styles={{ border: ['1px solid red', '1px solid blue'] as any }}
+    />
+  </>
 )
 
 export default ProviderExampleShorthand

--- a/docs/src/examples/components/Provider/Types/ProviderExampleRendererFelaPluginFallbackValue.shorthand.tsx
+++ b/docs/src/examples/components/Provider/Types/ProviderExampleRendererFelaPluginFallbackValue.shorthand.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { Segment } from '@stardust-ui/react'
+
+const ProviderExampleShorthand = () => (
+  <Segment
+    content="Segment with blue border"
+    styles={{ border: ['1px solid red', '1px solid blue'] as any }}
+  />
+)
+
+export default ProviderExampleShorthand

--- a/docs/src/examples/components/Provider/Types/index.tsx
+++ b/docs/src/examples/components/Provider/Types/index.tsx
@@ -26,6 +26,9 @@ const Types = () => (
     <NonPublicSection title="Types for visual tests">
       <ComponentExample examplePath="components/Provider/Types/ProviderExampleScrollbar" />
     </NonPublicSection>
+    <NonPublicSection title="Types for visual tests">
+      <ComponentExample examplePath="components/Provider/Types/ProviderExampleRendererFelaPluginFallbackValue" />
+    </NonPublicSection>
   </>
 )
 

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -55,13 +55,13 @@ const createRendererConfig = (options: any = {}) => ({
       skip: ['content', 'keyframe'],
     }),
 
-    felaExpandCssShorthandsPlugin(),
     felaPluginPlaceholderPrefixer(),
     felaPluginPrefixer(),
 
     // Heads up!
     // This is required after fela-plugin-prefixer to resolve the array of fallback values prefixer produces.
     felaPluginFallbackValue(),
+    felaExpandCssShorthandsPlugin(),
     felaDisableAnimationsPlugin(),
     felaRenderKeyframesPlugin(),
     ...(options.isRtl ? [rtl()] : []),


### PR DESCRIPTION
Fix https://github.com/stardust-ui/react/issues/1460 After introducing the `felaExpandCssShorthandsPlugin` the `felaPluginFallbackValue` was broken, because of the wrong order of the plugins. The `felaExpandCssShorthandsPlugin` should run after the `felaPluginFallbackValue`. As part of the PR there is a screenshot test added that will ensure the fallback value plugin is working as expected.