### PR TITLE
fix: yarn test:watch

### DIFF
--- a/build/gulp/plugins/gulp-jest.ts
+++ b/build/gulp/plugins/gulp-jest.ts
@@ -1,7 +1,7 @@
 import sh from '../sh'
 
 export type JestPluginConfig = {
-  config?: string
+  config: string
   coverage?: boolean
   detectLeaks?: boolean
   maxWorkers?: number
@@ -13,7 +13,7 @@ export type JestPluginConfig = {
   watchAll?: boolean
 }
 
-const jest = (config: JestPluginConfig = {}) => cb => {
+const jest = (config: JestPluginConfig) => cb => {
   process.env.NODE_ENV = 'test'
 
   // in watch mode jest never exits

--- a/build/gulp/tasks/test-unit.ts
+++ b/build/gulp/tasks/test-unit.ts
@@ -2,7 +2,7 @@ import { parallel, series, task } from 'gulp'
 import yargs from 'yargs'
 
 import sh from '../sh'
-import jest from '../plugins/gulp-jest'
+import jest, { JestPluginConfig } from '../plugins/gulp-jest'
 
 const argv = yargs
   .option('runInBand', {})
@@ -10,6 +10,14 @@ const argv = yargs
   .option('detectLeaks', {})
   .option('testNamePattern', { alias: 't' })
   .option('testFilePattern', { alias: 'F' }).argv
+
+const jestConfigFromArgv: Partial<JestPluginConfig> = {
+  runInBand: argv.runInBand as boolean,
+  maxWorkers: argv.maxWorkers as number,
+  detectLeaks: argv.detectLeaks as boolean,
+  testNamePattern: argv.testNamePattern as string,
+  testFilePattern: argv.testFilePattern as string,
+}
 
 task('test:jest:pre', () => sh('yarn satisfied'))
 
@@ -26,15 +34,18 @@ task(
   jest({
     config: './jest.config.js',
     coverage: true,
-    runInBand: argv.runInBand as boolean,
-    maxWorkers: argv.maxWorkers as number,
-    detectLeaks: argv.detectLeaks as boolean,
-    testNamePattern: argv.testNamePattern as string,
-    testFilePattern: argv.testFilePattern as string,
+    ...jestConfigFromArgv,
   }),
 )
 
-task('test:jest:watch', jest({ watchAll: true }))
+task(
+  'test:jest:watch',
+  jest({
+    config: './jest.config.js',
+    watchAll: true,
+    ...jestConfigFromArgv,
+  }),
+)
 
 // ----------------------------------------
 // Tests


### PR DESCRIPTION
This PR addresses regression for `yarn test:watch` script that had resulted in error after PR with E2E tests was merged: #1438 

The cause of the problem is missing `config` parameter for our `gulp-jest` plugin - this was not provided when `yarn test:watch` script was executed. 

Problem is resolved, as well as typings for `gulp-jest` plugin were reworked to prevent this problem in future.