### PR TITLE
feat(popup): unstable_pinned prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Expand all `Tree` siblings on `asterisk` key @silviuavram ([#1457](https://github.com/stardust-ui/react/pull/1457))
 - Add 'data-is-focusable' attribute to `attachmentBehavior` @sophieH29 ([#1445](https://github.com/stardust-ui/react/pull/1445))
 - Improve accessibility for `Checkbox` @jurokapsiar ([1479](https://github.com/stardust-ui/react/pull/1479))
+- Add `unstable_pinned` prop to `Popup` and `Dropdown` components @Bugaa92 ([#1471](https://github.com/stardust-ui/react/pull/1471))
 
 ### Fixes
 - Fix click handling on focus for `action` slot in `Attachment` component @Bugaa92 ([#1444](https://github.com/stardust-ui/react/pull/1444))

--- a/docs/src/examples/components/Dropdown/Variations/DropdownExamplePosition.shorthand.tsx
+++ b/docs/src/examples/components/Dropdown/Variations/DropdownExamplePosition.shorthand.tsx
@@ -7,6 +7,7 @@ const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange']
 
 const DropdownExamplePosition = () => {
   const [open] = useBooleanKnob({ name: 'open', initialValue: true })
+  const [unstable_pinned] = useBooleanKnob({ name: 'unstable_pinned', initialValue: false })
 
   const [positionAndAlign] = useSelectKnob({
     name: 'position-align',
@@ -24,6 +25,7 @@ const DropdownExamplePosition = () => {
         placeholder={`Opens ${position} trigger${align ? ` aligned to ${align}` : ''}.`}
         align={align}
         position={position}
+        unstable_pinned={unstable_pinned}
       />
     </Grid>
   )

--- a/docs/src/examples/components/Popup/Variations/PopupExamplePosition.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Variations/PopupExamplePosition.shorthand.tsx
@@ -5,6 +5,7 @@ import { useBooleanKnob, useSelectKnob } from '@stardust-ui/docs-components'
 
 const PopupExamplePosition = () => {
   const [open] = useBooleanKnob({ name: 'open-s', initialValue: true })
+  const [unstable_pinned] = useBooleanKnob({ name: 'unstable_pinned-s', initialValue: false })
 
   const [positionAndAlign] = useSelectKnob({
     name: 'position-align-s',
@@ -21,6 +22,7 @@ const PopupExamplePosition = () => {
         open={open || undefined}
         align={align}
         position={position}
+        unstable_pinned={unstable_pinned}
         trigger={<Button icon={icons[position]} styles={buttonStyles} />}
         content={{
           content: (

--- a/docs/src/examples/components/Popup/Variations/PopupExamplePosition.tsx
+++ b/docs/src/examples/components/Popup/Variations/PopupExamplePosition.tsx
@@ -5,6 +5,7 @@ import { useBooleanKnob, useSelectKnob } from '@stardust-ui/docs-components'
 
 const PopupExamplePosition = () => {
   const [open] = useBooleanKnob({ name: 'open-c', initialValue: true })
+  const [unstable_pinned] = useBooleanKnob({ name: 'unstable_pinned-c', initialValue: false })
 
   const [positionAndAlign] = useSelectKnob({
     name: 'position-align-c',
@@ -21,6 +22,7 @@ const PopupExamplePosition = () => {
         open={open || undefined}
         align={align}
         position={position}
+        unstable_pinned={unstable_pinned}
         content={{
           content: (
             <p>

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -280,6 +280,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     searchInput: customPropTypes.itemShorthand,
     toggleIndicator: customPropTypes.itemShorthand,
     triggerButton: customPropTypes.itemShorthand,
+    unstable_pinned: PropTypes.bool,
     value: PropTypes.oneOfType([
       customPropTypes.itemShorthand,
       customPropTypes.collectionShorthand,

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -617,7 +617,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     value: ShorthandValue | ShorthandCollection,
     rtl: boolean,
   ) {
-    const { align, offset, position, search } = this.props
+    const { align, offset, position, search, unstable_pinned } = this.props
     const { open } = this.state
     const items = open
       ? this.renderItems(styles, variables, getItemProps, highlightedIndex, value)
@@ -658,6 +658,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           rtl={rtl}
           enabled={open}
           targetRef={this.containerRef}
+          unstable_pinned={unstable_pinned}
           positioningDependencies={[items.length]}
         >
           <List

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -386,7 +386,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     rtl: boolean,
     accessibility: ReactAccessibilityBehavior,
   ): JSX.Element {
-    const { align, position, offset, target } = this.props
+    const { align, position, offset, target, unstable_pinned } = this.props
 
     return (
       <Popper
@@ -395,6 +395,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
         position={position}
         offset={offset}
         rtl={rtl}
+        unstable_pinned={unstable_pinned}
         targetRef={target ? toRefObject(target) : this.triggerRef}
         children={this.renderPopperChildren.bind(this, popupPositionClasses, rtl, accessibility)}
       />

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -160,6 +160,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     renderContent: PropTypes.func,
     target: PropTypes.any,
     trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.any]),
+    unstable_pinned: PropTypes.bool,
     content: customPropTypes.shorthandAllowingChildren,
     contentRef: customPropTypes.ref,
   }

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -130,7 +130,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
     [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement, unstable_pinned],
   )
 
-  React.useEffect(
+  React.useLayoutEffect(
     () => {
       createInstance()
       return destroyInstance
@@ -148,17 +148,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
         })
       : children
 
-  return (
-    <Ref
-      innerRef={contentElement => {
-        contentRef.current = contentElement
-        // for correct positioning we need to create the PopperJS instance immediately after we get a ref to the popper box
-        createInstance()
-      }}
-    >
-      {React.Children.only(child) as React.ReactElement}
-    </Ref>
-  )
+  return <Ref innerRef={contentRef}>{React.Children.only(child) as React.ReactElement}</Ref>
 }
 
 Popper.defaultProps = {

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -31,6 +31,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
     positioningDependencies = [],
     rtl,
     targetRef,
+    unstable_pinned,
   } = props
 
   const proposedPlacement = getPlacement({ align, position, rtl })
@@ -87,6 +88,12 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
           preventOverflow: { escapeWithReference: true },
           flip: { boundariesElement: 'scrollParent' },
         },
+        /**
+         * unstable_pinned disables the flip modifier by setting flip.enabled to false; this disables automatic
+         * repositioning of the popper box; it will always be placed according to the values of `align` and
+         * `position` props, regardless of the size of the component, the reference element or the viewport.
+         */
+        unstable_pinned && { flip: { enabled: false } },
         computedModifiers,
         userModifiers,
         /**
@@ -120,7 +127,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
       popperRef.current = createPopper(targetRef.current, contentRef.current, options)
     },
     // TODO review dependencies for popperHasScrollableParent
-    [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement],
+    [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement, unstable_pinned],
   )
 
   React.useEffect(

--- a/packages/react/src/lib/positioner/types.ts
+++ b/packages/react/src/lib/positioner/types.ts
@@ -23,6 +23,12 @@ export interface PositioningProps {
   offset?: string
 
   /**
+   * Disables automatic repositioning of the component; it will always be placed according to the values of `align` and
+   * `position` props, regardless of the size of the component, the reference element or the viewport.
+   */
+  unstable_pinned?: boolean
+
+  /**
    * Position for the component. Position has higher priority than align. If position is vertical ('above' | 'below')
    * and align is also vertical ('top' | 'bottom') or if both position and align are horizontal ('before' | 'after'
    * and 'start' | 'end' respectively), then provided value for 'align' will be ignored and 'center' will be used instead.


### PR DESCRIPTION
## feat(popup): unstable_pinned prop

### Description

There are certain use cases where our users need to position `Popup` content or `Dropdown` items using a specific alignment and position (via `align` and `position` props).

By default, `Popup` content or `Dropdown` items reposition themselves automatically on both axis if the content / items do not fit in the viewport. However, the algorithm has a few issues, outlined in #1391 so this PR addresses that with a short term fix presented [here](https://github.com/stardust-ui/react/issues/1391#issuecomment-498592986):

The short term fix is to add the `unstable_pinned` prop that **disables automatic repositioning of the component**; it will always be placed according to the values of `align` and `position` props, regardless of the size of the component, the reference element or the viewport.

e.g.
```jsx
<Popup align="start" position="above" pinned ... />
```

will create a `Popup` that will always be placed on top of the trigger aligned to the start (auto positioning will be turned off). Same applies for `Dropdown`.

### Screenshot outlining the difference in `Popup`:
![Screen Recording 2019-06-07 at 14 23 45](https://user-images.githubusercontent.com/5442794/59103748-fea1de00-892f-11e9-9651-63e0925c7eb0.gif)
