### PR TITLE
docs: Remove Base and FontAwesome themes from themes dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix Teams' theme list item end media styles @mnajdova ([#1448](https://github.com/stardust-ui/react/pull/1448))
 - Fix the order of the fela plugin @mnajdova ([#1461](https://github.com/stardust-ui/react/pull/1461))
 
+### Documentation
+- Remove unfinished themes from the docs themes dropdown on components examples pages @alinais ([#1473](https://github.com/stardust-ui/react/pull/1473)
+
 <!--------------------------------[ v0.32.0 ]------------------------------- -->
 ## [v0.32.0](https://github.com/stardust-ui/react/tree/v0.32.0) (2019-06-03)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.31.0...v0.32.0)

--- a/docs/src/context/ThemeContext.tsx
+++ b/docs/src/context/ThemeContext.tsx
@@ -5,10 +5,12 @@ import { themes } from '@stardust-ui/react'
 type ThemeName = keyof typeof themes
 type ThemeOption = { text: string; value: ThemeName }
 
-const themeOptions: ThemeOption[] = Object.keys(themes).map(key => ({
-  text: _.startCase(key),
-  value: key as ThemeName,
-}))
+const themeOptions: ThemeOption[] = Object.keys(themes)
+  .filter(key => !_.includes(['base', 'fontAwesome'], key))
+  .map(key => ({
+    text: _.startCase(key),
+    value: key as ThemeName,
+  }))
 
 export type ThemeContextData = {
   themeName: ThemeName


### PR DESCRIPTION
Remove Base and FontAwesome themes from themes dropdown in the components examples because they are not complete and choosing any of it breaks the docs experience.

![image](https://user-images.githubusercontent.com/1826985/59110268-074de080-893f-11e9-9dd5-9e57deeecec0.png)


