### PR TITLE
fix(Popper): use useLayoutEffect

### DIFF
--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -123,7 +123,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
     [computedModifiers, enabled, userModifiers, positionFixed, proposedPlacement],
   )
 
-  React.useEffect(
+  React.useLayoutEffect(
     () => {
       createInstance()
       return destroyInstance
@@ -141,17 +141,7 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
         })
       : children
 
-  return (
-    <Ref
-      innerRef={contentElement => {
-        contentRef.current = contentElement
-        // for correct positioning we need to create the PopperJS instance immediately after we get a ref to the popper box
-        createInstance()
-      }}
-    >
-      {React.Children.only(child) as React.ReactElement}
-    </Ref>
-  )
+  return <Ref innerRef={contentRef}>{React.Children.only(child) as React.ReactElement}</Ref>
 }
 
 Popper.defaultProps = {


### PR DESCRIPTION
This PR fixes issue with crazy scrolling when `Popup` is used with `popupFocusTrapBehavior`.
https://stardust-ui.github.io/react/components/popup#usage-on-with-focus-trap

![popup-trap](https://user-images.githubusercontent.com/14183168/59115944-a4624680-894a-11e9-8628-dd6cc93ccc6a.gif)
