### PR TITLE
fix(styles): update definition of `FontFace` and rename `FontFaceStyle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add 'poll' and 'to-do-list' icons to Teams theme @natashamayurshah ([#1498](https://github.com/stardust-ui/react/pull/1498))
 - Add `toolbarBehavior` for `Toolbar` component and apply `buttonBehavior` for `ToolbarItem` component @sophieH29 ([#1468](https://github.com/stardust-ui/react/pull/1468))
 - Integrate ARIA HTML design pattern in the `Tree` component @silviuavram ([#1488](https://github.com/stardust-ui/react/pull/1488))
+- Allow to pass `local()` to font definition @layershifter ([1487](https://github.com/stardust-ui/react/pull/1487))
 
 ### Performance
 - Use single Fela renderer for LTR & RTL @layershifter ([#1459](https://github.com/stardust-ui/react/pull/1459))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Type `FontFaceStyle` was renamed to `FontFaceProps` @layershifter ([1487](https://github.com/stardust-ui/react/pull/1487))
+- Type `style` was renamed to `props` on `FontFace` @layershifter ([1487](https://github.com/stardust-ui/react/pull/1487))
+
 ### Fixes
 - Fix prop types of `Tooltip` component @kuzhelov ([#1499](https://github.com/stardust-ui/react/pull/1499))
 - Fix `Popup` styling with `pointer` when it is wrapped by `FocusZones` @layershifter ([#1492](https://github.com/stardust-ui/react/pull/1492))
@@ -26,7 +30,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add 'poll' and 'to-do-list' icons to Teams theme @natashamayurshah ([#1498](https://github.com/stardust-ui/react/pull/1498))
 - Add `toolbarBehavior` for `Toolbar` component and apply `buttonBehavior` for `ToolbarItem` component @sophieH29 ([#1468](https://github.com/stardust-ui/react/pull/1468))
 - Integrate ARIA HTML design pattern in the `Tree` component @silviuavram ([#1488](https://github.com/stardust-ui/react/pull/1488))
-- Allow to pass `local()` to font definition @layershifter ([1487](https://github.com/stardust-ui/react/pull/1487))
 
 ### Performance
 - Use single Fela renderer for LTR & RTL @layershifter ([#1459](https://github.com/stardust-ui/react/pull/1459))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### BREAKING CHANGES
-- Type `FontFaceStyle` was renamed to `FontFaceProps` @layershifter ([1487](https://github.com/stardust-ui/react/pull/1487))
-- Type `style` was renamed to `props` on `FontFace` @layershifter ([1487](https://github.com/stardust-ui/react/pull/1487))
+- Type `FontFaceStyle` was renamed to `FontFaceProps` @layershifter ([#1487](https://github.com/stardust-ui/react/pull/1487))
+- Type `style` was renamed to `props` on `FontFace` @layershifter ([#1487](https://github.com/stardust-ui/react/pull/1487))
 
 ### Fixes
 - Fix prop types of `Tooltip` component @kuzhelov ([#1499](https://github.com/stardust-ui/react/pull/1499))

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -119,7 +119,7 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
         throw new Error(`fontFaces must be objects, got: ${typeof font}`)
       }
       const properties = { ...font.style, localAlias: font.localAliases }
-      console.log(properties)
+
       felaRenderer.renderFont(font.name, font.paths, properties)
     }
 

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -119,7 +119,7 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
         throw new Error(`fontFaces must be objects, got: ${typeof font}`)
       }
       const properties = { ...font.style, localAlias: font.localAliases }
-
+      console.log(properties)
       felaRenderer.renderFont(font.name, font.paths, properties)
     }
 

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -118,9 +118,8 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
       if (!_.isPlainObject(font)) {
         throw new Error(`fontFaces must be objects, got: ${typeof font}`)
       }
-      const properties = { ...font.style, localAlias: font.localAliases }
 
-      felaRenderer.renderFont(font.name, font.paths, properties)
+      felaRenderer.renderFont(font.name, font.paths, font.props)
     }
 
     fontFaces.forEach((font: FontFace) => {

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -118,7 +118,9 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
       if (!_.isPlainObject(font)) {
         throw new Error(`fontFaces must be objects, got: ${typeof font}`)
       }
-      felaRenderer.renderFont(font.name, font.paths, font.style)
+      const properties = { ...font.style, localAlias: font.localAliases }
+
+      felaRenderer.renderFont(font.name, font.paths, properties)
     }
 
     fontFaces.forEach((font: FontFace) => {

--- a/packages/react/src/themes/teams/fontFaces.ts
+++ b/packages/react/src/themes/teams/fontFaces.ts
@@ -6,21 +6,21 @@ const fontFaces: FontFaces = [
     paths: [
       'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-regular.woff2',
     ],
-    style: { fontWeight: 400 },
+    props: { fontWeight: 400 },
   },
   {
     name: 'Segoe UI',
     paths: [
       'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-semibold.woff2',
     ],
-    style: { fontWeight: 600 },
+    props: { fontWeight: 600 },
   },
   {
     name: 'Segoe UI',
     paths: [
       'https://static2.sharepointonline.com/files/fabric/assets/fonts/segoeui-westeuropean/segoeui-bold.woff2',
     ],
-    style: { fontWeight: 700 },
+    props: { fontWeight: 700 },
   },
 ]
 

--- a/packages/react/src/themes/types.ts
+++ b/packages/react/src/themes/types.ts
@@ -547,19 +547,19 @@ export interface Renderer extends FelaRenderer {}
 // Fonts
 // ========================================================
 
-export interface FontFaceStyle {
+export interface FontFaceProps {
   fontStretch?: string
   fontStyle?: string
   fontVariant?: string
   fontWeight?: number
+  localAlias?: string | string[]
   unicodeRange?: string
 }
 
 export interface FontFace {
   name: string
-  localAliases?: string | string[]
   paths: string[]
-  style: FontFaceStyle
+  props: FontFaceProps
 }
 
 export type FontFaces = FontFace[]

--- a/packages/react/src/themes/types.ts
+++ b/packages/react/src/themes/types.ts
@@ -552,13 +552,13 @@ export interface FontFaceStyle {
   fontStyle?: string
   fontVariant?: string
   fontWeight?: number
-  localAlias?: string
+  localAlias?: string | string[]
   unicodeRange?: string
 }
 
 export interface FontFace {
   name: string
-  localAliases?: []
+  localAliases?: string[]
   paths: string[]
   style: FontFaceStyle
 }

--- a/packages/react/src/themes/types.ts
+++ b/packages/react/src/themes/types.ts
@@ -552,13 +552,12 @@ export interface FontFaceStyle {
   fontStyle?: string
   fontVariant?: string
   fontWeight?: number
-  localAlias?: string | string[]
   unicodeRange?: string
 }
 
 export interface FontFace {
   name: string
-  localAliases?: string[]
+  localAliases?: string | string[]
   paths: string[]
   style: FontFaceStyle
 }

--- a/packages/react/src/themes/types.ts
+++ b/packages/react/src/themes/types.ts
@@ -558,6 +558,7 @@ export interface FontFaceStyle {
 
 export interface FontFace {
   name: string
+  localAliases?: []
   paths: string[]
   style: FontFaceStyle
 }


### PR DESCRIPTION
Fixes #1454.

# BREAKING CHANGES

Our `FontFace` definition haven't matched Fela [`renderFont()`](http://fela.js.org/docs/api/fela/Renderer.html#renderfont):

```js
{ name: "Segoe UI Local", style: {} },
// vs
{ name: "Segoe UI Local", props: {} },
```

So when are passing `localAlias` it looks that we are passing it to `style` what it is completely weird:

```js
{ name: "Segoe UI Local", style: { localAlias: 'Segoe UI' } },
```

## Migration

This PR contains:
- rename of `FontFaceStyle` to `FontFaceProps`
- rename of `style` to `props` on `FontFace` type

```diff
-import { FontFaceStyle } from '@stardust-ui/react'
+import { FontFaceProps } from '@stardust-ui/react'
```

```diff
const fontFaces: FontFaces = [
  {
    name: 'Segoe UI',
    paths: [],
-   style: { fontWeight: 400 },
+   props: { fontWeight: 400 },
  },
]
```