### PR TITLE
chore(dangerjs): Check changelog entries' format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### BREAKING CHANGES
-- Rename `toolbarBehavior` to `menuAsToolbarBehavior` and `toolbarButtonBehavior` to `menuItemAsToolbarButtonBehavior` ([#1393](https://github.com/stardust-ui/react/pull/1393))
-- Rename types related to accessibility ([#1421](https://github.com/stardust-ui/react/pull/1421))
+- Rename `toolbarBehavior` to `menuAsToolbarBehavior` and `toolbarButtonBehavior` to `menuItemAsToolbarButtonBehavior` @miroslavstastny ([#1393](https://github.com/stardust-ui/react/pull/1393))
+- Rename types related to accessibility @layershifter ([#1421](https://github.com/stardust-ui/react/pull/1421))
 - Moved the `rtl` and `renderer` props from the `theme` prop object to the `Provider`'s props API @mnajdova ([#1377](https://github.com/stardust-ui/react/pull/1377))
 
 ### Features
@@ -43,7 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix merging of item variables in `Menu` and `Toolbar` @miroslavstastny ([#1447](https://github.com/stardust-ui/react/pull/1447)) 
 
 ### Documentation
-- Remove unfinished themes from the docs themes dropdown on components examples pages @alinais ([#1473](https://github.com/stardust-ui/react/pull/1473)
+- Remove unfinished themes from the docs themes dropdown on components examples pages @alinais ([#1473](https://github.com/stardust-ui/react/pull/1473))
 
 ### Performance
 - Use minified version of `normalize.css` and update it to `8.0.1` @layershifter ([#1476](https://github.com/stardust-ui/react/pull/1476))

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -5,6 +5,15 @@ import * as _ from 'lodash'
 
 const CHANGELOG_FILE = 'CHANGELOG.md'
 
+function getAddedLinesFromChangelog(): Promise<any> {
+  return danger.git.structuredDiffForFile(CHANGELOG_FILE).then(changelogDiff => {
+    return changelogDiff.chunks.reduce((acc, chunk) => {
+      const filteredLines = chunk.changes.filter(change => change.type === 'add')
+      return acc.concat(filteredLines)
+    }, [])
+  })
+}
+
 /**
  * This function asserts that added entries into the changelog file are placed in the right section.
  */
@@ -14,33 +23,20 @@ const hasAddedLinesAfterVersionInChangelog = async (): Promise<boolean> => {
     .split('\n')
     .findIndex(line => line.startsWith('<!--') && line.endsWith('-->'))
 
-  const changelogDiff = await danger.git.structuredDiffForFile(CHANGELOG_FILE)
-  const addedLines = changelogDiff.chunks.reduce((acc, chunk) => {
-    const filteredLines = chunk.changes.filter(change => change.type === 'add')
-
-    return acc.concat(filteredLines)
-  }, [])
+  const addedLines = await getAddedLinesFromChangelog()
 
   return addedLines.some(line => line.ln > versionLineNumber)
 }
 
-const checkChangelogFormat = async () => {
-  const changelogDiff = await danger.git.structuredDiffForFile(CHANGELOG_FILE)
-  const addedLines = changelogDiff.chunks.reduce((acc, chunk) => {
-    const filteredLines = chunk.changes.filter(change => change.type === 'add')
-    return acc.concat(filteredLines)
-  }, [])
-
+const getMalformedChangelogEntries = async (): Promise<string[]> => {
   // +- description @githubname ([#DDDD](https://github.com/stardust-ui/react/pull/DDDD))
   const validEntry = /^\+- .*@\S+ \(\[#\d+]\(https:\/\/github\.com\/stardust-ui\/react\/pull\/\d+\)\)$/
 
-  addedLines
-    .filter(line => line.content.startsWith('+-'))
-    .forEach(line => {
-      if (!validEntry.test(line.content)) {
-        fail(`Invalid entry format in ${CHANGELOG_FILE}: >${line.content}<`)
-      }
-    })
+  const addedLines = await getAddedLinesFromChangelog()
+
+  return addedLines
+    .map(line => line.content)
+    .filter(content => content.startsWith('+-') && !validEntry.test(content))
 }
 
 async function getChangedDependencies(filepath, dependenciesKey = 'dependencies') {
@@ -112,7 +108,12 @@ export default async () => {
       'There are no updates provided to CHANGELOG. Ensure there are no publicly visible changes introduced by this PR.',
     )
   } else {
-    await checkChangelogFormat()
+    getMalformedChangelogEntries().then(malformedChangelogEntries => {
+      malformedChangelogEntries.forEach(entry => {
+        fail(`Invalid entry format in ${CHANGELOG_FILE}: >${entry}<`)
+      })
+    })
+
     hasAddedLinesAfterVersionInChangelog().then(hasLine => {
       if (hasLine) {
         fail(`All of your entries in ${CHANGELOG_FILE} should be in the **Unreleased** section!`)


### PR DESCRIPTION
Some entries in CHANGELOG break the format.

This PR prevents that by adding a check to danger.js, which checks all added/modified lines which start with '-' to be of the following format:
```
- description @githubname ([#DDDD](https://github.com/stardust-ui/react/pull/DDDD))
```