### PR TITLE
fix(Popup): fix styling with `pointer` when it is wrapped by FocusZones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix prop types of `Tooltip` component @kuzhelov ([#1499](https://github.com/stardust-ui/react/pull/1499))
+- Fix `Popup` styling with `pointer` when it is wrapped by FocusZones @layershifter ([#1492](https://github.com/stardust-ui/react/pull/1492))
 
 <!--------------------------------[ v0.33.0 ]------------------------------- -->
 ## [v0.33.0](https://github.com/stardust-ui/react/tree/v0.33.0) (2019-06-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix prop types of `Tooltip` component @kuzhelov ([#1499](https://github.com/stardust-ui/react/pull/1499))
-- Fix `Popup` styling with `pointer` when it is wrapped by FocusZones @layershifter ([#1492](https://github.com/stardust-ui/react/pull/1492))
+- Fix `Popup` styling with `pointer` when it is wrapped by `FocusZones` @layershifter ([#1492](https://github.com/stardust-ui/react/pull/1492))
 
 <!--------------------------------[ v0.33.0 ]------------------------------- -->
 ## [v0.33.0](https://github.com/stardust-ui/react/tree/v0.33.0) (2019-06-13)

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -447,6 +447,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
         placement,
         pointing,
         pointerRef: this.pointerTargetRef,
+        unstable_wrapped: accessibility.focusTrap || accessibility.autoFocus,
       },
       overrideProps: this.getContentProps,
     })

--- a/packages/react/src/components/Popup/PopupContent.tsx
+++ b/packages/react/src/components/Popup/PopupContent.tsx
@@ -55,6 +55,7 @@ export interface PopupContentProps
   pointerRef?: React.Ref<Element>
 
   /**
+   * @deprecated
    * Indicates that PopupContent is wrapped with FocusZone. Do not use it, it used only for internal implementation and
    * will be removed in future releases.
    */

--- a/packages/react/src/components/Popup/PopupContent.tsx
+++ b/packages/react/src/components/Popup/PopupContent.tsx
@@ -53,6 +53,12 @@ export interface PopupContentProps
 
   /** A ref to a pointer element. */
   pointerRef?: React.Ref<Element>
+
+  /**
+   * Indicates that PopupContent is wrapped with FocusZone. Do not use it, it used only for internal implementation and
+   * will be removed in future releases.
+   */
+  unstable_wrapped?: boolean
 }
 
 class PopupContent extends UIComponent<WithAsProp<PopupContentProps>> {
@@ -68,6 +74,7 @@ class PopupContent extends UIComponent<WithAsProp<PopupContentProps>> {
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     pointerRef: customPropTypes.ref,
+    unstable_wrapped: PropTypes.bool,
   }
 
   static defaultProps = {

--- a/packages/react/src/themes/teams/components/Popup/popupContentStyles.ts
+++ b/packages/react/src/themes/teams/components/Popup/popupContentStyles.ts
@@ -8,6 +8,10 @@ const popupContentStyles: ComponentSlotStylesInput<PopupContentProps, PopupConte
     borderRadius: v.borderRadius,
     display: 'block',
 
+    ...(p.unstable_wrapped && {
+      backgroundColor: 'inherit',
+      position: 'relative',
+    }),
     ...(p.pointing && getPointerStyles(v.pointerOffset, v.pointerMargin, rtl, p.placement).root),
   }),
   pointer: ({ props: p, variables: v, rtl }): ICSSInJSStyle => ({


### PR DESCRIPTION
Fixes #1433.

---

## Problem

When we use behaviors for `Popup` that have FocusZones, it results in new `div` and changed DOM structure, which causes broken styles.

## Solution

Provide `wrapped` prop to `PopupContent`, so we will know if it is wrapped by FocusZones and provide correct styles. This solution is short-term and aims only to fix bug - as any refactoring that will make it simpler and will allow to avoid `wrapped` prop will contain breaking changes, which we want to allow for now.

I decided to prefer prop instead of passing down the `variables` because we don't have a proper merging of them.