### PR TITLE
docs(ComponentExample): allow to disable html preview

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -45,6 +45,7 @@ export interface ComponentExampleProps
   title: React.ReactNode
   description?: React.ReactNode
   examplePath: string
+  previewHtml?: boolean
   themeName?: string
 }
 
@@ -69,6 +70,10 @@ const childrenStyle: React.CSSProperties = {
 class ComponentExample extends React.Component<ComponentExampleProps, ComponentExampleState> {
   anchorName: string
   kebabExamplePath: string
+
+  static defaultProps = {
+    previewHtml: true,
+  }
 
   constructor(props) {
     super(props)
@@ -467,6 +472,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       currentCodeLanguage,
       currentCodePath,
       description,
+      previewHtml,
       title,
     } = this.props
     const { showCode, showRtl, showTransparent, themeName } = this.state
@@ -508,7 +514,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
             <SourceRender
               babelConfig={babelConfig}
               source={currentCode}
-              renderHtml={showCode}
+              renderHtml={previewHtml && showCode}
               resolver={importResolver}
               themeName={themeName}
               wrap={this.renderElement}
@@ -547,12 +553,17 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
                     {showCode && (
                       <div>
                         <Divider fitted />
-                        <CodeSnippet fitted label="Rendered HTML" mode="html" value={markup} />
+                        {previewHtml ? (
+                          <CodeSnippet fitted label="Rendered HTML" mode="html" value={markup} />
+                        ) : (
+                          <Segment color="red" styles={{ fontSize: '0.8rem' }}>
+                            HTML preview is disabled for this example.
+                          </Segment>
+                        )}
                       </div>
                     )}
                     {this.renderVariables()}
                   </Segment>
-                  <div style={{ paddingBottom: '10px' }} />
                 </>
               )}
             </SourceRender>

--- a/docs/src/examples/components/Dropdown/Types/index.tsx
+++ b/docs/src/examples/components/Dropdown/Types/index.tsx
@@ -8,21 +8,25 @@ const Types = () => (
       title="Selection"
       description="A dropdown can be used to select between choices in a form."
       examplePath="components/Dropdown/Types/DropdownExample"
+      previewHtml={false}
     />
     <ComponentExample
       title="Multiple Selection"
       description="A dropdown can be used to select multiple items from a form."
       examplePath="components/Dropdown/Types/DropdownExampleMultiple"
+      previewHtml={false}
     />
     <ComponentExample
       title="Search Selection"
       description="A dropdown can be searchable."
       examplePath="components/Dropdown/Types/DropdownExampleSearch"
+      previewHtml={false}
     />
     <ComponentExample
       title="Search Multiple Selection"
       description="A dropdown can be searchable and allow a multiple selection."
       examplePath="components/Dropdown/Types/DropdownExampleSearchMultiple"
+      previewHtml={false}
     />
     <ComponentExample
       title="Clearable"

--- a/docs/src/examples/components/Dropdown/Variations/index.tsx
+++ b/docs/src/examples/components/Dropdown/Variations/index.tsx
@@ -8,16 +8,19 @@ const Variations = () => (
       title="Multiple Search with Image and Content"
       description="A multiple search dropdown which items have header, content and image."
       examplePath="components/Dropdown/Variations/DropdownExampleSearchMultipleImageAndContent"
+      previewHtml={false}
     />
     <ComponentExample
       title="Multiple Search Fluid"
       description="A multiple search dropdown that fits the width of the container."
       examplePath="components/Dropdown/Variations/DropdownExampleSearchMultipleFluid"
+      previewHtml={false}
     />
     <ComponentExample
       title="Multiple Search Using French Language"
       description="A multiple search dropdown that overrides visual and accessibility texts with French equivalents."
       examplePath="components/Dropdown/Variations/DropdownExampleSearchMultipleFrenchLanguage"
+      previewHtml={false}
     />
     <ComponentExample
       title="Alignment and Position"

--- a/docs/src/examples/components/Popup/Variations/index.tsx
+++ b/docs/src/examples/components/Popup/Variations/index.tsx
@@ -9,6 +9,7 @@ const Variations = () => (
       title="Alignment and Position"
       description="A popup can be positioned around its trigger and aligned relative to the trigger's margins. Click on a button to open a popup on a specific position and alignment."
       examplePath="components/Popup/Variations/PopupExamplePosition"
+      previewHtml={false}
     />
     <ComponentExample
       title="Offset"


### PR DESCRIPTION
### Problem

![image](https://user-images.githubusercontent.com/14183168/59442687-00214980-8dfb-11e9-8d86-e0bd0a51643e.png)

Some examples are broken.

### Why it happens?

HTML preview is generated using `react-dom` which doesn't support `createPortal()` from `react` 💣 

### Solution

Disable preview for examples that uses `React.createPortal()` in initial state.