### PR TITLE
fix(Doc): sort components menu

### DIFF
--- a/build/gulp/plugins/gulp-component-menu-behaviors.ts
+++ b/build/gulp/plugins/gulp-component-menu-behaviors.ts
@@ -77,7 +77,7 @@ export default () => {
   }
 
   function getParsedResults() {
-    return _(result)
+    return _.chain(result)
       .groupBy('displayName')
       .map((behaviors, displayName) => ({
         displayName,

--- a/build/gulp/plugins/gulp-component-menu.ts
+++ b/build/gulp/plugins/gulp-component-menu.ts
@@ -1,4 +1,5 @@
 import gutil from 'gulp-util'
+import _ from 'lodash'
 import fs from 'fs'
 import path from 'path'
 import through2 from 'through2'
@@ -64,7 +65,7 @@ export default () => {
   function endStream(cb) {
     const file = new Vinyl({
       path: './componentMenu.json',
-      contents: Buffer.from(JSON.stringify(result, null, 2)),
+      contents: Buffer.from(JSON.stringify(_.sortBy(result, 'displayName'), null, 2)),
     })
 
     this.push(file)


### PR DESCRIPTION
List of components was not sorted:
![image](https://user-images.githubusercontent.com/9615899/59449151-db32d380-8e06-11e9-9ab2-17a31e55849e.png)

This PR sorts `componentMenu.json` by `displayName` to fix that.