### PR TITLE
fix(Tooltip): prop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix prop types of `Tooltip` component @kuzhelov ([#1499](https://github.com/stardust-ui/react/pull/1499))
+
 <!--------------------------------[ v0.33.0 ]------------------------------- -->
 ## [v0.33.0](https://github.com/stardust-ui/react/tree/v0.33.0) (2019-06-13)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.32.0...v0.33.0)

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -51,11 +51,17 @@ export interface TooltipProps
   /** Additional CSS class name(s) to apply.  */
   className?: string
 
+  /** Initial value for 'open'. */
+  defaultOpen?: boolean
+
   /** Existing element the tooltip should be bound to. */
   mountNode?: HTMLElement
 
   /** Delay in ms for the mouse leave event, before the tooltip will be closed. */
   mouseLeaveDelay?: number
+
+  /** Defines whether tooltip is displayed. */
+  open?: boolean
 
   /** A tooltip can show a pointer to trigger. */
   pointing?: boolean


### PR DESCRIPTION
Adds `open` and `defaultOpen` props that were originally missed from Tooltip's prop types.