### PR TITLE
fix(Tree): apply custom focus style on TreeTitle and TreeItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix prop types of `Tooltip` component @kuzhelov ([#1499](https://github.com/stardust-ui/react/pull/1499))
 - Fix `Popup` styling with `pointer` when it is wrapped by `FocusZones` @layershifter ([#1492](https://github.com/stardust-ui/react/pull/1492))
+- Apply custom focus style on `TreeItem` and `TreeTitle` @silviuavram ([#1506](https://github.com/stardust-ui/react/pull/1506))
 
 ### Features
 - Integrate ARIA HTML design pattern in the `Tree` component @silviuavram ([#1488](https://github.com/stardust-ui/react/pull/1488))

--- a/packages/react/src/themes/teams/components/Tree/treeItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Tree/treeItemStyles.ts
@@ -1,7 +1,7 @@
 import { ICSSInJSStyle } from '../../../types'
 import { pxToRem } from '../../../../lib'
 import getBorderFocusStyles from '../../getBorderFocusStyles'
-import TreeTitle from 'src/components/Tree/TreeTitle'
+import TreeTitle from '../../../../components/Tree/TreeTitle'
 
 const treeItemStyles = {
   root: ({ theme: { siteVariables } }): ICSSInJSStyle => ({

--- a/packages/react/src/themes/teams/components/Tree/treeItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Tree/treeItemStyles.ts
@@ -1,10 +1,22 @@
 import { ICSSInJSStyle } from '../../../types'
 import { pxToRem } from '../../../../lib'
+import getBorderFocusStyles from '../../getBorderFocusStyles'
+import TreeTitle from 'src/components/Tree/TreeTitle'
 
 const treeItemStyles = {
-  root: (): ICSSInJSStyle => ({
+  root: ({ theme: { siteVariables } }): ICSSInJSStyle => ({
     listStyleType: 'none',
     padding: `0 0 0 ${pxToRem(1)}`,
+    ':focus': {
+      outline: 0,
+      [`> .${TreeTitle.className}`]: {
+        position: 'relative',
+        ...getBorderFocusStyles({
+          siteVariables,
+          isFromKeyboard: true,
+        })[':focus'],
+      },
+    },
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Tree/treeTitleStyles.ts
+++ b/packages/react/src/themes/teams/components/Tree/treeTitleStyles.ts
@@ -1,11 +1,18 @@
 import { ICSSInJSStyle } from '../../../types'
 import { pxToRem } from '../../../../lib'
+import getBorderFocusStyles from '../../getBorderFocusStyles'
 
 const treeTitleStyles = {
-  root: ({ variables }): ICSSInJSStyle => ({
+  root: ({ variables, theme: { siteVariables } }): ICSSInJSStyle => ({
     padding: `${pxToRem(1)} 0`,
     cursor: 'pointer',
     color: variables.defaultColor,
+    border: `${pxToRem(2)} transparent solid`,
+    position: 'relative',
+    ...getBorderFocusStyles({
+      siteVariables,
+      isFromKeyboard: true,
+    }),
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Tree/treeTitleStyles.ts
+++ b/packages/react/src/themes/teams/components/Tree/treeTitleStyles.ts
@@ -7,7 +7,6 @@ const treeTitleStyles = {
     padding: `${pxToRem(1)} 0`,
     cursor: 'pointer',
     color: variables.defaultColor,
-    border: `${pxToRem(2)} transparent solid`,
     position: 'relative',
     ...getBorderFocusStyles({
       siteVariables,


### PR DESCRIPTION
If focus is on `TreeItem` (`<li>`), style its `TreeTitle` instead.
Focus style is now the one from `getBorderFocusStyles`.