### PR TITLE
docs(Accessibility): Improve layout of behaviors pages

### DIFF
--- a/docs/src/components/ComponentDoc/BehaviorDescription.tsx
+++ b/docs/src/components/ComponentDoc/BehaviorDescription.tsx
@@ -6,12 +6,14 @@ const AccessibilityDescription = React.lazy(() => import('./AccessibilityDescrip
 const item = '- '
 
 const BehaviorDescription: React.FunctionComponent<{ value: string }> = ({ value }) => {
+  // doctrine has a bug where it ignores list item indicator (-) if it is in the beginning of the comment
+  // because of that, add the list item indicators after parsing
   const markdown =
     item +
     value
       .split('\n')
       .join(`\n${item}`)
-      .replace(/'(?!s )/g, '\u0060')
+      .replace(/'(?!s )/g, '\u0060') // replace ' with backtick as regexp rules with backtick would not be understandablein unit tests
   return (
     <React.Suspense fallback={<Loader />}>
       <AccessibilityDescription value={markdown} />

--- a/docs/src/components/ComponentDoc/BehaviorDescription.tsx
+++ b/docs/src/components/ComponentDoc/BehaviorDescription.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { Loader } from '@stardust-ui/react/src'
+
+const AccessibilityDescription = React.lazy(() => import('./AccessibilityDescription'))
+
+const item = '- '
+
+const BehaviorDescription: React.FunctionComponent<{ value: string }> = ({ value }) => {
+  const markdown =
+    item +
+    value
+      .split('\n')
+      .join(`\n${item}`)
+      .replace(/'(?!s )/g, '\u0060')
+  return (
+    <React.Suspense fallback={<Loader />}>
+      <AccessibilityDescription value={markdown} />
+    </React.Suspense>
+  )
+}
+
+export default BehaviorDescription

--- a/docs/src/components/DocsBehaviorRoot.tsx
+++ b/docs/src/components/DocsBehaviorRoot.tsx
@@ -38,9 +38,8 @@ class DocsBehaviorRoot extends React.Component<any, any> {
           {behaviorMenuItems
             .find(behavior => behavior.displayName === _.capitalize(match.params.name))
             .variations.map((variation, keyValue) => (
-              <>
+              <React.Fragment key={keyValue}>
                 <Segment
-                  key={keyValue}
                   className="docs-example"
                   id={_.kebabCase(variation.name)}
                   styles={exampleStyle}
@@ -71,7 +70,7 @@ class DocsBehaviorRoot extends React.Component<any, any> {
                   </div>
                 </Segment>
                 <br />
-              </>
+              </React.Fragment>
             ))}
         </Segment>
       </DocumentTitle>

--- a/docs/src/components/DocsBehaviorRoot.tsx
+++ b/docs/src/components/DocsBehaviorRoot.tsx
@@ -1,9 +1,10 @@
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
-import { Header, Segment } from '@stardust-ui/react'
+import { Header, Segment, Divider } from '@stardust-ui/react'
 import DocumentTitle from 'react-document-title'
 import ComponentExampleTitle from './ComponentDoc/ComponentExample/ComponentExampleTitle'
+import BehaviorDescription from './ComponentDoc/BehaviorDescription'
 
 const behaviorMenuItems = require('docs/src/behaviorMenu')
 
@@ -18,72 +19,59 @@ class DocsBehaviorRoot extends React.Component<any, any> {
   }
 
   baseName(fileName: string) {
-    const divided = _.startCase(fileName.replace(/\.ts$/, ''))
+    const divided = _.startCase(fileName.replace(/Behavior\.ts$/, ''))
     return _.upperFirst(_.lowerCase(divided))
   }
 
   render() {
     const exampleStyle: React.CSSProperties = {
-      position: 'relative',
-      transition: 'box-shadow 200ms, background 200ms',
-      boxShadow: '0 1px 2px #ccc',
-      margin: '1em 1em 1em 2em',
+      boxShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
     }
 
     const { match } = this.props
-    const pageTitle = `${_.capitalize(match.params.name)} behaviors`
+    const pageTitle = `${_.capitalize(match.params.name)} accessibility behaviors`
     return (
       <DocumentTitle title={pageTitle}>
-        <Segment>
-          <Header
-            as="h1"
-            aria-level={2}
-            content={pageTitle}
-            description={`Keyboard and Screenreader options for ${match.params.name} component.`}
-          />
+        <Segment styles={{ backgroundColor: 'transparent' }}>
+          <Header as="h1" aria-level={2} content={pageTitle} />
 
           {behaviorMenuItems
             .find(behavior => behavior.displayName === _.capitalize(match.params.name))
             .variations.map((variation, keyValue) => (
-              <Segment
-                key={keyValue}
-                className="docs-example"
-                id={_.kebabCase(variation.name)}
-                styles={exampleStyle}
-              >
-                <ComponentExampleTitle
-                  title={this.baseName(variation.name)}
-                  description={`Name: ${variation.name.replace('.ts', '')}`}
-                />
+              <>
+                <Segment
+                  key={keyValue}
+                  className="docs-example"
+                  id={_.kebabCase(variation.name)}
+                  styles={exampleStyle}
+                >
+                  <ComponentExampleTitle
+                    title={this.baseName(variation.name)}
+                    description={`Name: ${variation.name.replace('.ts', '')}`}
+                  />
 
-                <div style={{ padding: '1em' }}>
-                  {variation.description && (
-                    <>
-                      <strong>Description:</strong>
-                      <br />
-                      {variation.description.split('\n').map((splittedText, key) => (
-                        <span key={key}>
-                          {splittedText}
-                          <br />
-                        </span>
-                      ))}
-                    </>
-                  )}
-                  {variation.specification && (
-                    <>
-                      {variation.description && <br />}
-                      <strong>Specification:</strong>
-                      <br />
-                      {variation.specification.split('\n').map((splittedText, key) => (
-                        <span key={key}>
-                          {splittedText}
-                          <br />
-                        </span>
-                      ))}
-                    </>
-                  )}
-                </div>
-              </Segment>
+                  <Divider />
+
+                  <div style={{ paddingTop: '1em' }}>
+                    {variation.description && (
+                      <>
+                        <strong>Description:</strong>
+                        <br />
+                        <BehaviorDescription value={variation.description} />
+                      </>
+                    )}
+                    {variation.specification && (
+                      <>
+                        {variation.description && <br />}
+                        <strong>Specification:</strong>
+                        <br />
+                        <BehaviorDescription value={variation.specification} />
+                      </>
+                    )}
+                  </div>
+                </Segment>
+                <br />
+              </>
             ))}
         </Segment>
       </DocumentTitle>

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -186,5 +186,7 @@ Tree.create = createShorthandFactory({ Component: Tree, mappedArrayProp: 'items'
 
 /**
  * Allows users to display data organised in tree-hierarchy.
+ * @accessibility
+ * Implements [ARIA TreeView](https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView) design pattern.
  */
 export default withSafeTypeForAs<typeof Tree, TreeProps, 'ul'>(Tree)

--- a/packages/react/src/lib/accessibility/Behaviors/Accordion/accordionBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Accordion/accordionBehavior.ts
@@ -3,7 +3,7 @@ import * as keyboardKey from 'keyboard-key'
 
 /**
  * @specification
- * Adds attribute 'role=presentation' to 'root' component's part.
+ * Adds attribute 'role=presentation' to 'root' slot.
  * Triggers 'moveNext' action with 'ArrowDown' on 'root'.
  * Triggers 'movePrevious' action with 'ArrowUp' on 'root'.
  * Triggers 'moveFirst' action with 'Home' on 'root'.

--- a/packages/react/src/lib/accessibility/Behaviors/Accordion/accordionContentBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Accordion/accordionContentBehavior.ts
@@ -5,7 +5,7 @@ import { Accessibility } from '../../types'
  * Optionally, an accordion content can have the 'role=region'. It is not applied by default.
  *
  * @specification
- * Adds attribute 'aria-labelledby' based on the property 'accordionTitleId' to 'root' component's part.
+ * Adds attribute 'aria-labelledby' based on the property 'accordionTitleId' to 'root' slot.
  */
 const accordionContentBehavior: Accessibility<AccordionContentBehaviorProps> = props => {
   return {

--- a/packages/react/src/lib/accessibility/Behaviors/Accordion/accordionTitleBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Accordion/accordionTitleBehavior.ts
@@ -4,14 +4,14 @@ import * as keyboardKey from 'keyboard-key'
 /**
  * @description
  * Adds accessibility attributed to implement the Accordion design pattern.
- * Adds 'aria-disabled' to the 'content' component's part with a value based on active and canBeCollapsed props.
+ * Adds 'aria-disabled' to the 'content' slot with a value based on active and canBeCollapsed props.
  * Adds role='heading' and aria-level='3' if the element type is not a header.
  *
  * @specification
- * Adds attribute 'role=button' to 'content' component's part.
- * Adds attribute 'tabIndex=0' to 'content' component's part.
- * Adds attribute 'aria-expanded=true' based on the property 'active' to 'content' component's part.
- * Adds attribute 'aria-controls=content-id' based on the property 'accordionContentId' to 'content' component's part.
+ * Adds attribute 'role=button' to 'content' slot.
+ * Adds attribute 'tabIndex=0' to 'content' slot.
+ * Adds attribute 'aria-expanded=true' based on the property 'active' to 'content' slot.
+ * Adds attribute 'aria-controls=content-id' based on the property 'accordionContentId' to 'content' slot.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'content'.
  */
 const accordionTitleBehavior: Accessibility<AccordionTitleBehaviorProps> = props => {

--- a/packages/react/src/lib/accessibility/Behaviors/Alert/alertWarningBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Alert/alertWarningBehavior.ts
@@ -2,8 +2,8 @@ import { Accessibility } from '../../types'
 
 /**
  * @specification
- * Adds role 'alert' to 'content' component's part.
- * Adds attribute 'aria-live=polite' to 'content' component's part.
+ * Adds role 'alert' to 'content' slot.
+ * Adds attribute 'aria-live=polite' to 'content' slot.
  */
 
 const alertWarningBehavior: Accessibility = () => ({

--- a/packages/react/src/lib/accessibility/Behaviors/Attachment/attachmentBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Attachment/attachmentBehavior.ts
@@ -4,7 +4,7 @@ import { IS_FOCUSABLE_ATTRIBUTE } from '../../FocusZone/focusUtilities'
 
 /**
  * @specification
- * Adds attribute 'tabIndex=0' to 'root' component's part.
+ * Adds attribute 'tabIndex=0' to 'root' slot.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  */
 const attachmentBehavior: Accessibility = () => ({

--- a/packages/react/src/lib/accessibility/Behaviors/Checkbox/checkboxBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Checkbox/checkboxBehavior.ts
@@ -6,7 +6,7 @@ import { Accessibility } from '../../types'
  * Adds role='checkbox'. This allows screen readers to handle the component as a checkbox button.
  * Adds attribute 'aria-checked=true' based on the property 'checked'.
  * Adds attribute 'aria-disabled=true' based on the property 'disabled'.
- * Adds attribute 'tabIndex=0' to 'root' component's part.
+ * Adds attribute 'tabIndex=0' to 'root' slot.
  */
 const checkboxBehavior: Accessibility<CheckboxBehaviorProps> = props => ({
   attributes: {

--- a/packages/react/src/lib/accessibility/Behaviors/Dialog/dialogBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Dialog/dialogBehavior.ts
@@ -5,14 +5,14 @@ import { PopupBehaviorProps } from '../Popup/popupBehavior'
 /**
  * @description
  * Implements ARIA Dialog (Modal) design pattern.
- * Adds tabIndex='0' to 'trigger' component's part, if it is not tabbable element and no tabIndex attribute provided.
+ * Adds tabIndex='0' to 'trigger' slot, if it is not tabbable element and no tabIndex attribute provided.
  *
  * @specification
- * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
- * Adds attribute 'aria-modal=true' to 'popup' component's part.
- * Adds attribute 'role=dialog' to 'popup' component's part.
- * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'popup' component's part.
- * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'popup' component's part.
+ * Adds attribute 'aria-disabled=true' to 'trigger' slot if 'disabled' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'aria-modal=true' to 'popup' slot.
+ * Adds attribute 'role=dialog' to 'popup' slot.
+ * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'popup' slot.
+ * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'popup' slot.
  * Traps focus inside component.
  */
 const dialogBehavior: Accessibility<DialogBehaviorProps> = props => {

--- a/packages/react/src/lib/accessibility/Behaviors/Embed/embedBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Embed/embedBehavior.ts
@@ -4,13 +4,12 @@ import { Accessibility } from '../../types'
 /**
  * @description
  * GIFs are visual representation only so hidden unless alt or title applied.
- *
  * Enter/space keys play and pause the gif respectively
  *
  * @specification
- * Adds role 'presentation' to 'root' component's part.
+ * Adds role 'presentation' to 'root' slot.
  * Adds attribute 'aria-hidden=true', if there is no 'alt' property provided.
- * Adds attribute 'tabIndex=0' to 'root' component's part.
+ * Adds attribute 'tabIndex=0' to 'root' slot.
  */
 const embedBehavior: Accessibility<EmbedBehaviorProps> = props => ({
   attributes: {

--- a/packages/react/src/lib/accessibility/Behaviors/Loader/loaderBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Loader/loaderBehavior.ts
@@ -5,7 +5,7 @@ import { Accessibility } from '../../types'
  * Loader is usually an element that displays the progress status for a task that take a long time or consists of several steps.
  *
  * @specification
- * Adds role 'progressbar' to 'root' component's part.
+ * Adds role 'progressbar' to 'root' slot.
  */
 
 const loaderBehavior: Accessibility = () => ({

--- a/packages/react/src/lib/accessibility/Behaviors/Menu/menuDividerBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Menu/menuDividerBehavior.ts
@@ -5,7 +5,7 @@ import { Accessibility } from '../../types'
  * Behavior for menu divider
  *
  * @specification
- * Adds role 'presentation' to 'root' component's part.
+ * Adds role 'presentation' to 'root' slot.
  */
 
 const menuDividerBehavior: Accessibility = () => ({

--- a/packages/react/src/lib/accessibility/Behaviors/Menu/menuItemBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Menu/menuItemBehavior.ts
@@ -7,16 +7,16 @@ import * as keyboardKey from 'keyboard-key'
  * The behavior is designed for particular structure of menu item. The item consists of root element and anchor inside the root element.
  *
  * @specification
- * Adds role 'presentation' to 'wrapper' component's part.
- * Adds role 'menuitem' to 'root' component's part.
- * Adds attribute 'tabIndex=0' to 'root' component's part.
- * Adds attribute 'data-is-focusable=false' to 'root' component's part if 'disabled' property is true. Sets the attribute to 'true' otherwise.
- * Adds attribute 'aria-label' based on the property 'aria-label' to 'root' component's part.
- * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' component's part.
- * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'root' component's part.
- * Adds attribute 'aria-expanded=true' based on the property 'menuOpen' if the component has 'menu' property to 'root' component's part.
- * Adds attribute 'aria-haspopup=true' to 'root' component's part if 'menu' property is set.
- * Adds attribute 'aria-disabled=true' to 'root' component's part based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
+ * Adds role 'presentation' to 'wrapper' slot.
+ * Adds role 'menuitem' to 'root' slot.
+ * Adds attribute 'tabIndex=0' to 'root' slot.
+ * Adds attribute 'data-is-focusable=false' to 'root' slot if 'disabled' property is true. Sets the attribute to 'true' otherwise.
+ * Adds attribute 'aria-label' based on the property 'aria-label' to 'root' slot.
+ * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' slot.
+ * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'root' slot.
+ * Adds attribute 'aria-expanded=true' based on the property 'menuOpen' if the component has 'menu' property to 'root' slot.
+ * Adds attribute 'aria-haspopup=true' to 'root' slot if 'menu' property is set.
+ * Adds attribute 'aria-disabled=true' to 'root' slot based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'wrapper'.
  * Triggers 'closeMenuAndFocusTrigger' action with 'Escape' on 'wrapper'.
  * Triggers 'closeAllMenusAndFocusNextParentItem' action with 'ArrowRight' on 'wrapper'.

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupAutoFocusBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupAutoFocusBehavior.ts
@@ -3,10 +3,10 @@ import popupBehavior, { PopupBehaviorProps } from './popupBehavior'
 
 /**
  * @description
- * Adds tabIndex='0' to 'trigger' component's part, if it is not tabbable element and no tabIndex attribute provided.
+ * Adds tabIndex='0' to 'trigger' slot, if it is not tabbable element and no tabIndex attribute provided.
  *
  * @specification
- * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'aria-disabled=true' to 'trigger' slot if 'disabled' property is true. Does not set the attribute otherwise.
  * Automatically focus the first focusable element inside component.
  */
 const popupAutoFocusBehavior: Accessibility<PopupBehaviorProps> = props => ({

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupBehavior.ts
@@ -5,11 +5,11 @@ import { PopupEvents, PopupEventsArray } from '../../../../components/Popup/Popu
 
 /**
  * @description
- * Adds tabIndex='0' to 'trigger' component's part, if it is not tabbable element and no tabIndex attribute provided.
+ * Adds tabIndex='0' to 'trigger' slot, if it is not tabbable element and no tabIndex attribute provided.
  *
  * @specification
- * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
- * Adds attribute 'role=complementary' to 'popup' component's part.
+ * Adds attribute 'aria-disabled=true' to 'trigger' slot if 'disabled' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'role=complementary' to 'popup' slot.
  */
 const popupBehavior: Accessibility<PopupBehaviorProps> = props => {
   const onAsArray = _.isArray(props.on) ? props.on : [props.on]

--- a/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Popup/popupFocusTrapBehavior.ts
@@ -3,12 +3,12 @@ import popupBehavior, { PopupBehaviorProps } from './popupBehavior'
 
 /**
  * @description
- * Adds tabIndex='0' to 'trigger' component's part, if it is not tabbable element and no tabIndex attribute provided.
+ * Adds tabIndex='0' to 'trigger' slot, if it is not tabbable element and no tabIndex attribute provided.
  *
  * @specification
- * Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
- * Adds attribute 'aria-modal=true' to 'popup' component's part.
- * Adds attribute 'role=dialog' to 'popup' component's part.
+ * Adds attribute 'aria-disabled=true' to 'trigger' slot if 'disabled' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'aria-modal=true' to 'popup' slot.
+ * Adds attribute 'role=dialog' to 'popup' slot.
  * Traps focus inside component.
  */
 const popupFocusTrapBehavior: Accessibility<PopupBehaviorProps> = props => {

--- a/packages/react/src/lib/accessibility/Behaviors/Tab/tabBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Tab/tabBehavior.ts
@@ -4,16 +4,16 @@ import { IS_FOCUSABLE_ATTRIBUTE } from '../../FocusZone/focusUtilities'
 
 /**
  * @specification
- * Adds role 'presentation' to 'wrapper' component's part.
- * Adds role 'tab' to 'root' component's part.
- * Adds attribute 'tabIndex=0' to 'root' component's part.
- * Adds attribute 'data-is-focusable=false' to 'root' component's part if 'disabled' property is true. Sets the attribute to 'true' otherwise.
- * Adds attribute 'aria-selected=true' to 'root' component's part based on the property 'active'. This can be overriden by providing 'aria-selected' property directly to the component.
- * Adds attribute 'aria-label' based on the property 'aria-label' to 'root' component's part.
- * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' component's part.
- * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'root' component's part.
- * Adds attribute 'aria-controls' based on the property 'aria-controls' to 'root' component's part.
- * Adds attribute 'aria-disabled=true' to 'root' component's part based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
+ * Adds role 'presentation' to 'wrapper' slot.
+ * Adds role 'tab' to 'root' slot.
+ * Adds attribute 'tabIndex=0' to 'root' slot.
+ * Adds attribute 'data-is-focusable=false' to 'root' slot if 'disabled' property is true. Sets the attribute to 'true' otherwise.
+ * Adds attribute 'aria-selected=true' to 'root' slot based on the property 'active'. This can be overriden by providing 'aria-selected' property directly to the component.
+ * Adds attribute 'aria-label' based on the property 'aria-label' to 'root' slot.
+ * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' slot.
+ * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'root' slot.
+ * Adds attribute 'aria-controls' based on the property 'aria-controls' to 'root' slot.
+ * Adds attribute 'aria-disabled=true' to 'root' slot based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'wrapper'.
  */
 const tabBehavior: Accessibility<TabBehaviorProps> = props => ({

--- a/packages/react/src/lib/accessibility/Behaviors/Tab/tabListBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Tab/tabListBehavior.ts
@@ -7,7 +7,7 @@ import tabBehavior from './tabBehavior'
  * Implements ARIA Tabs design pattern.
  * Child item components need to have tabBehavior assigned.
  * @specification
- * Adds role 'tablist' to 'root' component's part.
+ * Adds role 'tablist' to 'root' slot.
  * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectional direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.

--- a/packages/react/src/lib/accessibility/Behaviors/Toolbar/menuAsToolbarBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Toolbar/menuAsToolbarBehavior.ts
@@ -7,7 +7,7 @@ import menuItemAsToolbarButtonBehavior from './menuItemAsToolbarButtonBehavior'
  * Implements ARIA Toolbar design pattern.
  * Child item components need to have menuItemAsToolbarButtonBehavior assigned.
  * @specification
- * Adds role 'toolbar' to 'root' component's part.
+ * Adds role 'toolbar' to 'root' slot.
  * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectional direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.

--- a/packages/react/src/lib/accessibility/Behaviors/Toolbar/menuItemAsToolbarButtonBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Toolbar/menuItemAsToolbarButtonBehavior.ts
@@ -8,15 +8,15 @@ import { MenuItemBehaviorProps } from '../Menu/menuItemBehavior'
  * The behavior is designed for particular structure of menu item. The item consists of root element and anchor inside the root element.
  *
  * @specification
- * Adds role 'presentation' to 'wrapper' component's part.
- * Adds role 'button' to 'root' component's part.
- * Adds attribute 'tabIndex=0' to 'root' component's part.
- * Adds attribute 'data-is-focusable=false' to 'root' component's part if 'disabled' property is true. Sets the attribute to 'true' otherwise.
- * Adds attribute 'aria-label' based on the property 'aria-label' to 'root' component's part.
- * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' component's part.
- * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'root' component's part.
- * Adds attribute 'aria-disabled=true' to 'root' component's part based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
- * Adds attribute 'aria-haspopup=true' to 'root' component's part if 'menu' property is set.
+ * Adds role 'presentation' to 'wrapper' slot.
+ * Adds role 'button' to 'root' slot.
+ * Adds attribute 'tabIndex=0' to 'root' slot.
+ * Adds attribute 'data-is-focusable=false' to 'root' slot if 'disabled' property is true. Sets the attribute to 'true' otherwise.
+ * Adds attribute 'aria-label' based on the property 'aria-label' to 'root' slot.
+ * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' slot.
+ * Adds attribute 'aria-describedby' based on the property 'aria-describedby' to 'root' slot.
+ * Adds attribute 'aria-disabled=true' to 'root' slot based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
+ * Adds attribute 'aria-haspopup=true' to 'root' slot if 'menu' property is set.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'wrapper'.
  * Triggers 'closeMenuAndFocusTrigger' action with 'Escape' on 'wrapper'.
  * Triggers 'openMenu' action with 'ArrowDown' on 'wrapper', when orientation is horizontal.

--- a/packages/react/src/lib/accessibility/Behaviors/Toolbar/toolbarBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Toolbar/toolbarBehavior.ts
@@ -6,7 +6,7 @@ import { FocusZoneDirection } from '../../FocusZone'
  * Implements ARIA Toolbar design pattern.
  * Child item components need to have toolbarItemBehavior assigned.
  * @specification
- * Adds role 'toolbar' to 'root' component's part.
+ * Adds role 'toolbar' to 'root' slot.
  * Embeds component into FocusZone.
  * Provides arrow key navigation in horizontal direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.

--- a/packages/react/src/lib/accessibility/Behaviors/Tree/subtreeBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Tree/subtreeBehavior.ts
@@ -4,7 +4,7 @@ import * as keyboardKey from 'keyboard-key'
 /**
  * @specification
  * Triggers 'expandSiblings' action with '*' on 'root'.
- * Adds role 'group' to 'root' component's part.
+ * Adds role 'group' to 'root' slot.
  */
 const subtreeBehavior: Accessibility = () => ({
   attributes: {

--- a/packages/react/src/lib/accessibility/Behaviors/Tree/treeBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/Tree/treeBehavior.ts
@@ -4,8 +4,8 @@ import subtreeBehavior from './subtreeBehavior'
 
 /**
  * @specification
- * Adds role 'tree' to 'root' component's part.
- * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' component's part.
+ * Adds role 'tree' to 'root' slot.
+ * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' slot.
  * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Triggers 'expandSiblings' action with '*' on 'root'.

--- a/packages/react/src/lib/getKeyDownHandlers.ts
+++ b/packages/react/src/lib/getKeyDownHandlers.ts
@@ -11,7 +11,7 @@ const rtlKeyMap = {
 }
 
 /**
- * Assigns onKeyDown handler to the Component's part element, based on Component's actions
+ * Assigns onKeyDown handler to the slot element, based on Component's actions
  * and keys mappings defined in Accessibility behavior
  * @param {AccessibilityActionHandlers} componentActionHandlers Actions handlers defined in a component.
  * @param {KeyActions} behaviorKeyActions Mappings of actions and keys defined in Accessibility behavior.

--- a/packages/react/test/specs/behaviors/testDefinitions.ts
+++ b/packages/react/test/specs/behaviors/testDefinitions.ts
@@ -36,9 +36,9 @@ definitions.push({
   },
 })
 
-// Example:  Adds role 'menuitem' to 'anchor' component's part
+// Example:  Adds role 'menuitem' to 'anchor' slot
 definitions.push({
-  regexp: /Adds role '(\w+)' to '([\w-]+)' component's part/g,
+  regexp: /Adds role '(\w+)' to '([\w-]+)' slot/g,
   testMethod: (parameters: TestMethod) => {
     const [roleToBeAdded, elementWhereToBeAdded] = parameters.props
     const property = {}
@@ -47,10 +47,10 @@ definitions.push({
   },
 })
 
-// Example: Adds attribute 'tabIndex=0' to 'anchor' component's part.
-//          Adds attribute 'data-is-focusable=true' to 'anchor' component's part.
+// Example: Adds attribute 'tabIndex=0' to 'anchor' slot.
+//          Adds attribute 'data-is-focusable=true' to 'anchor' slot.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' component's part\./g,
+  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' slot\./g,
   testMethod: (parameters: TestMethod) => {
     const [attributeToBeAdded, attributeExpectedValue, elementWhereToBeAdded] = parameters.props
     const property = {}
@@ -63,9 +63,9 @@ definitions.push({
   },
 })
 
-// Example: Adds attribute 'aria-expanded=true' based on the property 'menuOpen' if the component has 'menu' property to 'anchor' component's part.
+// Example: Adds attribute 'aria-expanded=true' based on the property 'menuOpen' if the component has 'menu' property to 'anchor' slot.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' based on the property '([\w-]+)' if the component has '([\w-]+)' property to '([\w-]+)' component's part\./g,
+  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' based on the property '([\w-]+)' if the component has '([\w-]+)' property to '([\w-]+)' slot\./g,
   testMethod: (parameters: TestMethod) => {
     const [
       attributeToBeAdded,
@@ -102,10 +102,10 @@ definitions.push({
   },
 })
 
-// Example: Adds attribute 'aria-expanded=true' based on the property 'active' to 'button' component's part.
-//          Adds attribute 'aria-label' based on the property 'aria-label' to 'anchor' component's part.
+// Example: Adds attribute 'aria-expanded=true' based on the property 'active' to 'button' slot.
+//          Adds attribute 'aria-label' based on the property 'aria-label' to 'anchor' slot.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=*([\w-]*)' based on the property '([\w-]+)' to '([\w-]+)' component's part\./g,
+  regexp: /Adds attribute '([\w-]+)=*([\w-]*)' based on the property '([\w-]+)' to '([\w-]+)' slot\./g,
   testMethod: (parameters: TestMethod) => {
     const [
       attributeToBeAdded,
@@ -125,9 +125,9 @@ definitions.push({
   },
 })
 
-// Example: Adds attribute 'aria-selected=true' to 'anchor' component's part based on the property 'active'. This can be overriden by directly providing 'aria-selected' property to the component.
+// Example: Adds attribute 'aria-selected=true' to 'anchor' slot based on the property 'active'. This can be overriden by directly providing 'aria-selected' property to the component.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' component's part based on the property '([\w-]+)'\. This can be overriden by providing '[\w-]+' property directly to the component\./g,
+  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' slot based on the property '([\w-]+)'\. This can be overriden by providing '[\w-]+' property directly to the component\./g,
   testMethod: (parameters: TestMethod) => {
     const [
       attributeToBeAdded,
@@ -187,9 +187,9 @@ function testMethodConditionallyAddAttribute(
   )
 }
 
-// Example: Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Does not set the attribute otherwise.
+// Example: Adds attribute 'aria-disabled=true' to 'trigger' slot if 'disabled' property is true. Does not set the attribute otherwise.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' component's part if '([\w-]+)' property is true\. Does not set the attribute otherwise\./g,
+  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' slot if '([\w-]+)' property is true\. Does not set the attribute otherwise\./g,
   testMethod: (parameters: TestMethod) => {
     const [
       attributeToBeAdded,
@@ -210,9 +210,9 @@ definitions.push({
   },
 })
 
-// Example: Adds attribute 'aria-disabled=true' to 'trigger' component's part if 'disabled' property is true. Sets the attribute to 'false' otherwise.
+// Example: Adds attribute 'aria-disabled=true' to 'trigger' slot if 'disabled' property is true. Sets the attribute to 'false' otherwise.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' component's part if '([\w-]+)' property is true\. Sets the attribute to '([\w\d]+)' otherwise\./g,
+  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' slot if '([\w-]+)' property is true\. Sets the attribute to '([\w\d]+)' otherwise\./g,
   testMethod: (parameters: TestMethod) => {
     const [
       attributeToBeAdded,
@@ -234,9 +234,9 @@ definitions.push({
   },
 })
 
-// Adds attribute 'aria-haspopup=true' to 'root' component's part if 'menu' menu property is set.
+// Adds attribute 'aria-haspopup=true' to 'root' slot if 'menu' menu property is set.
 definitions.push({
-  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' component's part if '([\w-]+)' property is set\./g,
+  regexp: /Adds attribute '([\w-]+)=([\w\d]+)' to '([\w-]+)' slot if '([\w-]+)' property is set\./g,
   testMethod: (parameters: TestMethod) => {
     const [
       attributeToBeAdded,


### PR DESCRIPTION
- improve layout of behaviors pages by fixing styles and introducing markdown
- descriptions and specifications form transformed into bullet list (only in render, not for unit tests)
- replace "component's part" with "slot"