### PR TITLE
docs(Menu): Improve Menu accessibility information

### DIFF
--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -245,8 +245,9 @@ Menu.create = createShorthandFactory({ Component: Menu, mappedArrayProp: 'items'
  * A menu displays grouped navigation actions.
  * @accessibility
  * Implements ARIA [Menu](https://www.w3.org/TR/wai-aria-practices-1.1/#menu), [Toolbar](https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar) or [Tabs](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel) design pattern, depending on the behavior used.
- * Do not use Children API, use Shorthand API with `items` prop instead. For render tree customization, use [render callback argument](https://stardust-ui.github.io/react/shorthand-props#render-callback-argument).
- * Do not render focusable or clickable elements inside of the `MenuItem`.
+ * Do not use Children API (`<MenuItem>` component directly), use [Shorthand API](https://stardust-ui.github.io/react/shorthand-props) with `items` prop instead.
+ * For render tree customization, use [render callback argument](https://stardust-ui.github.io/react/shorthand-props#render-callback-argument).
+ * Do not render focusable or clickable elements inside of the menu item.
  * Do choose desired accessibility behavior depending on the use case.
  * Do provide label to the Menu component using `aria-label` or `aria-labelledby` prop.
  */

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -245,7 +245,8 @@ Menu.create = createShorthandFactory({ Component: Menu, mappedArrayProp: 'items'
  * A menu displays grouped navigation actions.
  * @accessibility
  * Implements ARIA [Menu](https://www.w3.org/TR/wai-aria-practices-1.1/#menu), [Toolbar](https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar) or [Tabs](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel) design pattern, depending on the behavior used.
+ * Do not use Children API, use Shorthand API with `items` prop instead. For render tree customization, use [render callback argument](https://stardust-ui.github.io/react/shorthand-props#render-callback-argument).
  * Do choose desired accessibility behavior depending on the use case.
- * Do provide label to the Menu component using aria-label or aria-labelledby prop.
+ * Do provide label to the Menu component using `aria-label` or `aria-labelledby` prop.
  */
 export default withSafeTypeForAs<typeof Menu, MenuProps, 'ul'>(Menu)

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -246,6 +246,7 @@ Menu.create = createShorthandFactory({ Component: Menu, mappedArrayProp: 'items'
  * @accessibility
  * Implements ARIA [Menu](https://www.w3.org/TR/wai-aria-practices-1.1/#menu), [Toolbar](https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar) or [Tabs](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel) design pattern, depending on the behavior used.
  * Do not use Children API, use Shorthand API with `items` prop instead. For render tree customization, use [render callback argument](https://stardust-ui.github.io/react/shorthand-props#render-callback-argument).
+ * Do not render focusable or clickable elements inside of the `MenuItem`.
  * Do choose desired accessibility behavior depending on the use case.
  * Do provide label to the Menu component using `aria-label` or `aria-labelledby` prop.
  */


### PR DESCRIPTION
Add DOs and DONT'S to Menu accessibility section about the children api usage and focusable elements inside of the menu item.