### PR TITLE
WIP: feat(MenuButton): menu button prototype using popups

### DIFF
--- a/docs/src/prototypes/MenuButton/focusUtils.ts
+++ b/docs/src/prototypes/MenuButton/focusUtils.ts
@@ -1,13 +1,13 @@
 import { FocusZoneUtilities, Menu } from '@stardust-ui/react'
 
-export const focusMenuItem = (menuRef: HTMLUListElement, order: 'first' | 'last') => {
+export const focusMenuItem = (menuRef: HTMLElement, order: 'first' | 'last') => {
   const selector = `.${Menu.Item.slotClassNames.wrapper}:${order}-child .${Menu.Item.className}`
-  const element = menuRef.querySelector<HTMLUListElement>(selector)
+  const element = menuRef.querySelector<HTMLElement>(selector)
 
   element.focus()
 }
 
-export const focusNearest = (buttonNode: HTMLButtonElement, order: 'next' | 'previous') => {
+export const focusNearest = (buttonNode: HTMLElement, order: 'next' | 'previous') => {
   const getter =
     order === 'next' ? FocusZoneUtilities.getNextElement : FocusZoneUtilities.getPreviousElement
   const element = getter(document.body, buttonNode)

--- a/docs/src/prototypes/MenuButton/index.tsx
+++ b/docs/src/prototypes/MenuButton/index.tsx
@@ -1,23 +1,47 @@
-import { Button, Divider, Header, Dropdown, DropdownProps } from '@stardust-ui/react'
-import * as PopperJS from 'popper.js'
+import {
+  Button,
+  Divider,
+  Header,
+  Toolbar,
+  Dropdown,
+  DropdownProps,
+  Alignment,
+  Position,
+  PopupEvents,
+  RestrictedClickEvents,
+} from '@stardust-ui/react'
 import * as React from 'react'
 
 import { ComponentPrototype, PrototypeSection } from 'docs/src/prototypes/Prototypes'
 import MenuButton from './MenuButton'
 
 interface MenuButtonPrototypeState {
-  placement: PopperJS.Placement
+  position: Position
+  align: Alignment
+  on: string[]
 }
 
 class MenuButtonPrototype extends React.Component<{}, MenuButtonPrototypeState> {
-  state: MenuButtonPrototypeState = { placement: 'bottom-start' }
+  state: MenuButtonPrototypeState = { position: 'below', align: 'start', on: ['click'] }
 
-  handleChange = (e, data: DropdownProps) => {
-    this.setState({ placement: data.value as PopperJS.Placement })
+  handlePositionChange = (e, data: DropdownProps) => {
+    this.setState({ position: data.value as Position })
   }
 
+  handleAlignChange = (e, data: DropdownProps) => {
+    this.setState({ align: data.value as Alignment })
+  }
+
+  handleOnChange = (e, data: DropdownProps) => {
+    this.setState({ on: data.value as PopupEvents[] })
+  }
+
+  renderToolbarMenu = (ComponentType, props) => (
+    <MenuButton trigger={<ComponentType {...props} />} menu={{ items: ['Red', 'Green', 'Blue'] }} />
+  )
+
   render() {
-    const { placement } = this.state
+    const { position, align, on } = this.state
 
     return (
       <PrototypeSection title="MenuButton">
@@ -29,48 +53,100 @@ class MenuButtonPrototype extends React.Component<{}, MenuButtonPrototypeState> 
               <a href="https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html">
                 ARIA Navigation Menu example
               </a>
-              , you also can choose placement.
+              , you also can choose placement and trigger event.
             </>
           }
         >
-          <Header as="h4" content="Choose placement:" />
+          <Header as="h4" content="Choose position:" />
           <Dropdown
+            items={['above', 'below', 'before', 'after']}
+            onSelectedChange={this.handlePositionChange}
+            value={position}
+          />
+          <Header as="h4" content="Choose position:" />
+          <Dropdown
+            items={['start', 'center', 'end']}
+            onSelectedChange={this.handleAlignChange}
+            value={align}
+          />
+          <Header as="h4" content="Choose trigger event (on):" />
+          <Dropdown
+            multiple
             items={[
-              'above-start',
-              'above-center',
-              'above-end',
-              'below-start',
-              'below-center',
-              'below-end',
-              'before-top',
-              'before-center',
-              'before-bottom',
-              'after-top',
-              'after-center',
-              'after-bottom',
+              'click',
+              'focus',
+              'hover',
+              // 'context',
             ]}
-            onSelectedChange={this.handleChange}
-            value={placement}
+            onSelectedChange={this.handleOnChange}
+            value={on}
           />
           <Divider />
           <Button.Group>
             <Button content="A usual button" primary />
             <MenuButton
-              button="WAI-ARIA Quick Links"
-              buttonId="button-example1"
+              trigger={<Button content="WAI-ARIA Quick Links" onClick={() => alert('Clicks!')} />}
+              position={position}
+              align={align}
+              on={(on as any) as RestrictedClickEvents}
               menu={{
                 items: [
                   'W3C Home Page',
                   'W3C Web Accessibility Initiative',
                   'Accessible Rich Internet Application Specification',
                   'WAI-ARIA Authoring Practices',
+                  { content: 'Submenu', key: 'submenu', menu: ['1', '2', '3'] },
                 ],
               }}
-              menuId="menu-example1"
-              placement={placement}
             />
             <Button content="Another button" />
           </Button.Group>
+        </ComponentPrototype>
+
+        <ComponentPrototype
+          title="Context menu"
+          description="Right click context menu (will work once popup contextmenu PR is merged"
+        >
+          <MenuButton
+            trigger={
+              <div style={{ padding: '10rem' }}>
+                In this area you can try the awesome context menu.{' '}
+                <a href="#">This is just for focus</a>
+              </div>
+            }
+            position="below"
+            align="start"
+            // on="context"
+            // triggerHandlesFocus={true}
+            menu={{
+              items: [
+                'Random action',
+                { content: 'Submenu', key: 'submenu', menu: ['1', '2', '3'] },
+              ],
+            }}
+          />
+        </ComponentPrototype>
+
+        <ComponentPrototype
+          title="Toolbar"
+          description="Shows the usage of menu button inside of toolbar"
+        >
+          <Toolbar
+            items={[
+              {
+                key: 'highlight',
+                icon: { name: 'highlight', outline: true },
+              },
+              render =>
+                render(
+                  {
+                    key: 'font-color',
+                    icon: { name: 'font-color', outline: true },
+                  },
+                  this.renderToolbarMenu,
+                ),
+            ]}
+          />
         </ComponentPrototype>
       </PrototypeSection>
     )

--- a/docs/src/prototypes/MenuButton/menuButtonBehavior.ts
+++ b/docs/src/prototypes/MenuButton/menuButtonBehavior.ts
@@ -1,17 +1,14 @@
 import { Accessibility } from '@stardust-ui/react'
-import * as _ from 'lodash'
 
 import { MenuButtonProps, MenuButtonState } from './MenuButton'
 
 const menuButtonBehavior: Accessibility = (props: MenuButtonProps & MenuButtonState) => ({
   attributes: {
     button: {
-      'aria-disabled': !_.isNil(props['aria-disabled']) ? props['aria-disabled'] : !!props.disabled,
-      'aria-controls': props.menuId,
+      'aria-controls': props.menuId, // TODO: consder using aria-owns
       'aria-expanded': props.menuOpen || undefined,
       'aria-haspopup': 'true',
       id: props.buttonId,
-      role: _.get(props, 'button.as') === 'button' ? undefined : 'button',
       tabIndex: props.menuOpen ? -1 : undefined,
     },
     menu: {


### PR DESCRIPTION
Use Popup in MenuButton, this will allow it to become a component for:
- dropdown menus
- toolbar menus
- potentially submenus
- context (right click) menus once Popup allows it

TODOs:
```
// TODO: spread unhandled props to root
// TODO: id generation - should we respect <Button id="" />?
// TODO: test with aria-owns
// TODO: rename to ContextMenu?
// TODO: should enter move focus back to trigger? should click move focus back to trigger?
// TODO: for contextmenu - if focus was inside of the trigger (not on trigger), should it return there?
// TODO: allow passing onOpenChange
// TODO: for toolbar menu, left+right arrow keys need to be handled (stopPropagation)
```