### PR TITLE
fix(plugins): use compiled dependency instead of `css-expand-shorthand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `theme` types, remove duplication @kuzhelov ([#1508](https://github.com/stardust-ui/react/pull/1508))
 - Fix `RadioGroup` first item should be tabbable by default when none of the items selected @sophieH29 ([#1515](https://github.com/stardust-ui/react/pull/1515))
 - Export all accessibility behaviors @jurokapsiar ([#1538](https://github.com/stardust-ui/react/pull/1538))
+- Replace `css-shorthand-expand` with bundled version to make it work in IE11 @layershifter ([#1542](https://github.com/stardust-ui/react/pull/1542))
 
 ### Features
 - Add 'poll' and 'to-do-list' icons to Teams theme @natashamayurshah ([#1498](https://github.com/stardust-ui/react/pull/1498))

--- a/docs/src/index.ejs
+++ b/docs/src/index.ejs
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/brands.css" integrity="sha384-1KLgFVb/gHrlDGLFPgMbeedi6tQBLcWvyNUN+YKXbD7ZFbjX6BLpMDf0PJ32XJfX" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://unpkg.com/react-vis@<%= htmlWebpackPlugin.options.versions.reactVis %>/dist/style.css" />
   <link rel="shortcut icon" type="image/x-icon" href='<%= __BASENAME__ + 'logo.png' %>'/>
   <title>Stardust</title>
   <script>
@@ -32,24 +31,14 @@
   </style>
 </head>
 <body>
-  <script src="https://cdn.jsdelivr.net/npm/@babel/polyfill@7/dist/polyfill.min.js"></script>
+  <script src='https://cdn.jsdelivr.net/npm/core-js-bundle/minified.js'></script>
+  <script src='https://cdn.jsdelivr.net/npm/whatwg-fetch/dist/fetch.umd.min.js'></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.1/anchor.min.js"></script>
   <script
     crossOrigin="anonymous"
-    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/standalone.js"
+    src="https://cdn.jsdelivr.net/combine/npm/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/standalone.min.js,npm/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-babylon.min.js,npm/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-html.min.js,npm/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-typescript.min.js"
   ></script>
-  <script
-    crossOrigin="anonymous"
-    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-babylon.js"
-  ></script>
-  <script
-    crossOrigin="anonymous"
-    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-html.js"
-  ></script>
-  <script
-    crossOrigin="anonymous"
-    src="https://unpkg.com/prettier@<%= htmlWebpackPlugin.options.versions.prettier %>/parser-typescript.js"
-  ></script>
+
   <!-- Use unminified React when not in production so we get errors and warnings -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/<%= htmlWebpackPlugin.options.versions.propTypes %>/prop-types<%= __PROD__ ? '.min' : '' %>.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.react %>/umd/react<%= __PROD__ ? '.production.min' : '.development' %>.js"></script>
@@ -62,7 +51,8 @@
 
   <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@<%= htmlWebpackPlugin.options.versions.babelStandalone %>/babel.min.js"></script>
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.16.0/themes/prism-tomorrow.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.16.0/themes/prism-tomorrow.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-vis@<%= htmlWebpackPlugin.options.versions.reactVis %>/dist/style.min.css" />
 
   <style>
     html, body {

--- a/packages/docs-components/src/CodeSnippet/CodeSnippetLabel.tsx
+++ b/packages/docs-components/src/CodeSnippet/CodeSnippetLabel.tsx
@@ -7,6 +7,21 @@ type CopySnippetLabelProps = Pick<CodeSnippetProps, 'copyable' | 'label' | 'mode
   value: string
 }
 
+const checkIcon = (
+  <svg height="0.7rem" viewBox="0 0 512 512">
+    <path
+      fill="currentColor"
+      d="M461.6,109.6l-54.9-43.3c-1.7-1.4-3.8-2.4-6.2-2.4c-2.4,0-4.6,1-6.3,2.5L194.5,323c0,0-78.5-75.5-80.7-77.7  c-2.2-2.2-5.1-5.9-9.5-5.9c-4.4,0-6.4,3.1-8.7,5.4c-1.7,1.8-29.7,31.2-43.5,45.8c-0.8,0.9-1.3,1.4-2,2.1c-1.2,1.7-2,3.6-2,5.7  c0,2.2,0.8,4,2,5.7l2.8,2.6c0,0,139.3,133.8,141.6,136.1c2.3,2.3,5.1,5.2,9.2,5.2c4,0,7.3-4.3,9.2-6.2L462,121.8  c1.2-1.7,2-3.6,2-5.8C464,113.5,463,111.4,461.6,109.6z"
+    />
+  </svg>
+)
+
+const copyIcon = (
+  <svg height="0.7rem" viewBox="0 0 16 16">
+    <path d="M2,0v1v2H0v13h13v-2h2h1V1V0H3H2z M15,1v12h-2V3H3V1H15z" fill="currentColor " />
+  </svg>
+)
+
 const CodeSnippetLabel: React.FunctionComponent<CopySnippetLabelProps> = props => {
   const { copyable, label, mode, value } = props
   const hasLabel = label !== false
@@ -18,8 +33,8 @@ const CodeSnippetLabel: React.FunctionComponent<CopySnippetLabelProps> = props =
       <div
         onClick={copyable ? onCopy : undefined}
         style={{
-          border: '1px solid #566',
-          color: '#899',
+          border: '1px solid #ccc',
+          color: '#ccc',
           cursor: copyable ? 'pointer' : 'default',
           display: 'grid',
           gridTemplateColumns: 'auto auto',
@@ -28,14 +43,14 @@ const CodeSnippetLabel: React.FunctionComponent<CopySnippetLabelProps> = props =
           lineHeight: 1,
           padding: '0.2rem 0.35rem',
           position: 'absolute',
-          right: '1rem',
-          top: '1rem',
+          right: '0.8rem',
+          top: '0.8rem',
           zIndex: 100,
         }}
         title={copyable ? 'Copy' : undefined}
       >
         <div>{label || mode}</div>
-        {copyable && <div style={{ marginLeft: '5px' }}>{active ? '✔ ' : '📋'}</div>}
+        {copyable && <div style={{ marginLeft: '5px' }}>{active ? checkIcon : copyIcon}</div>}
       </div>
     )
   )

--- a/packages/docs-components/src/CodeSnippet/CodeSnippetLabel.tsx
+++ b/packages/docs-components/src/CodeSnippet/CodeSnippetLabel.tsx
@@ -35,7 +35,7 @@ const CodeSnippetLabel: React.FunctionComponent<CopySnippetLabelProps> = props =
         title={copyable ? 'Copy' : undefined}
       >
         <div>{label || mode}</div>
-        {copyable && <div style={{ marginLeft: '5px' }}>{active ? '✔ ' : '⎘'}</div>}
+        {copyable && <div style={{ marginLeft: '5px' }}>{active ? '✔ ' : '📋'}</div>}
       </div>
     )
   )

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,6 @@
     "@stardust-ui/react-component-ref": "^0.33.0",
     "@stardust-ui/react-proptypes": "^0.33.0",
     "classnames": "^2.2.5",
-    "css-shorthand-expand": "^1.2.0",
     "downshift": "^3.2.10",
     "fast-memoize": "^2.5.1",
     "fela": "^10.5.0",

--- a/packages/react/src/lib/cssExpandShorthand.ts
+++ b/packages/react/src/lib/cssExpandShorthand.ts
@@ -1,0 +1,914 @@
+/* eslint-disable */
+/* tslint:disable */
+
+let mapObj = function(obj, cb) {
+  let ret = {}
+  let keys = Object.keys(obj)
+
+  for (let i = 0; i < keys.length; i++) {
+    let key = keys[i]
+    let res = cb(key, obj[key], obj)
+    ret[res[0]] = res[1]
+  }
+
+  return ret
+}
+
+let immutable = extend
+
+let hasOwnProperty = Object.prototype.hasOwnProperty
+
+function extend() {
+  let target = {}
+
+  for (let i = 0; i < arguments.length; i++) {
+    let source = arguments[i]
+
+    for (let key in source) {
+      if (hasOwnProperty.call(source, key)) {
+        target[key] = source[key]
+      }
+    }
+  }
+
+  return target
+}
+
+let hexColorRegex = function hexColorRegex(opts) {
+  opts = opts && typeof opts === 'object' ? opts : {}
+
+  return opts.strict
+    ? /^#([a-f0-9]{3,4}|[a-f0-9]{4}(?:[a-f0-9]{2}){1,2})\b$/i
+    : /#([a-f0-9]{3}|[a-f0-9]{4}(?:[a-f0-9]{2}){0,2})\b/gi
+}
+
+let hslaRegex = function hslaRegex(options) {
+  options = options || {}
+
+  return options.exact
+    ? /^hsla\((\d+),\s*([\d.]+)%,\s*([\d.]+)%,\s*(\d*(?:\.\d+)?)\)$/
+    : /hsla\((\d+),\s*([\d.]+)%,\s*([\d.]+)%,\s*(\d*(?:\.\d+)?)\)/gi
+}
+
+let hslRegex = function hslRegex(options) {
+  options = options || {}
+
+  return options.exact
+    ? /^hsl\(\s*(\d+)\s*,\s*(\d*(?:\.\d+)?%)\s*,\s*(\d*(?:\.\d+)?%)\)$/
+    : /hsl\(\s*(\d+)\s*,\s*(\d*(?:\.\d+)?%)\s*,\s*(\d*(?:\.\d+)?%)\)/gi
+}
+
+let rgbRegex = function rgbRegex(options) {
+  options = options || {}
+
+  return options.exact
+    ? /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/
+    : /rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)/gi
+}
+
+let rgbaRegex = function rgbaRegex(options) {
+  options = options || {}
+
+  return options.exact
+    ? /^rgba\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),\s*(\d*(?:\.\d+)?)\)$/
+    : /rgba\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),\s*(\d*(?:\.\d+)?)\)/gi
+}
+
+let aqua = '#00ffff'
+let aliceblue = '#f0f8ff'
+let antiquewhite = '#faebd7'
+let black = '#000000'
+let blue = '#0000ff'
+let cyan = '#00ffff'
+let darkblue = '#00008b'
+let darkcyan = '#008b8b'
+let darkgreen = '#006400'
+let darkturquoise = '#00ced1'
+let deepskyblue = '#00bfff'
+let green = '#008000'
+let lime = '#00ff00'
+let mediumblue = '#0000cd'
+let mediumspringgreen = '#00fa9a'
+let navy = '#000080'
+let springgreen = '#00ff7f'
+let teal = '#008080'
+let midnightblue = '#191970'
+let dodgerblue = '#1e90ff'
+let lightseagreen = '#20b2aa'
+let forestgreen = '#228b22'
+let seagreen = '#2e8b57'
+let darkslategray = '#2f4f4f'
+let darkslategrey = '#2f4f4f'
+let limegreen = '#32cd32'
+let mediumseagreen = '#3cb371'
+let turquoise = '#40e0d0'
+let royalblue = '#4169e1'
+let steelblue = '#4682b4'
+let darkslateblue = '#483d8b'
+let mediumturquoise = '#48d1cc'
+let indigo = '#4b0082'
+let darkolivegreen = '#556b2f'
+let cadetblue = '#5f9ea0'
+let cornflowerblue = '#6495ed'
+let mediumaquamarine = '#66cdaa'
+let dimgray = '#696969'
+let dimgrey = '#696969'
+let slateblue = '#6a5acd'
+let olivedrab = '#6b8e23'
+let slategray = '#708090'
+let slategrey = '#708090'
+let lightslategray = '#778899'
+let lightslategrey = '#778899'
+let mediumslateblue = '#7b68ee'
+let lawngreen = '#7cfc00'
+let aquamarine = '#7fffd4'
+let chartreuse = '#7fff00'
+let gray = '#808080'
+let grey = '#808080'
+let maroon = '#800000'
+let olive = '#808000'
+let purple = '#800080'
+let lightskyblue = '#87cefa'
+let skyblue = '#87ceeb'
+let blueviolet = '#8a2be2'
+let darkmagenta = '#8b008b'
+let darkred = '#8b0000'
+let saddlebrown = '#8b4513'
+let darkseagreen = '#8fbc8f'
+let lightgreen = '#90ee90'
+let mediumpurple = '#9370db'
+let darkviolet = '#9400d3'
+let palegreen = '#98fb98'
+let darkorchid = '#9932cc'
+let yellowgreen = '#9acd32'
+let sienna = '#a0522d'
+let brown = '#a52a2a'
+let darkgray = '#a9a9a9'
+let darkgrey = '#a9a9a9'
+let greenyellow = '#adff2f'
+let lightblue = '#add8e6'
+let paleturquoise = '#afeeee'
+let lightsteelblue = '#b0c4de'
+let powderblue = '#b0e0e6'
+let firebrick = '#b22222'
+let darkgoldenrod = '#b8860b'
+let mediumorchid = '#ba55d3'
+let rosybrown = '#bc8f8f'
+let darkkhaki = '#bdb76b'
+let silver = '#c0c0c0'
+let mediumvioletred = '#c71585'
+let indianred = '#cd5c5c'
+let peru = '#cd853f'
+let chocolate = '#d2691e'
+let tan = '#d2b48c'
+let lightgray = '#d3d3d3'
+let lightgrey = '#d3d3d3'
+let thistle = '#d8bfd8'
+let goldenrod = '#daa520'
+let orchid = '#da70d6'
+let palevioletred = '#db7093'
+let crimson = '#dc143c'
+let gainsboro = '#dcdcdc'
+let plum = '#dda0dd'
+let burlywood = '#deb887'
+let lightcyan = '#e0ffff'
+let lavender = '#e6e6fa'
+let darksalmon = '#e9967a'
+let palegoldenrod = '#eee8aa'
+let violet = '#ee82ee'
+let azure = '#f0ffff'
+let honeydew = '#f0fff0'
+let khaki = '#f0e68c'
+let lightcoral = '#f08080'
+let sandybrown = '#f4a460'
+let beige = '#f5f5dc'
+let mintcream = '#f5fffa'
+let wheat = '#f5deb3'
+let whitesmoke = '#f5f5f5'
+let ghostwhite = '#f8f8ff'
+let lightgoldenrodyellow = '#fafad2'
+let linen = '#faf0e6'
+let salmon = '#fa8072'
+let oldlace = '#fdf5e6'
+let bisque = '#ffe4c4'
+let blanchedalmond = '#ffebcd'
+let coral = '#ff7f50'
+let cornsilk = '#fff8dc'
+let darkorange = '#ff8c00'
+let deeppink = '#ff1493'
+let floralwhite = '#fffaf0'
+let fuchsia = '#ff00ff'
+let gold = '#ffd700'
+let hotpink = '#ff69b4'
+let ivory = '#fffff0'
+let lavenderblush = '#fff0f5'
+let lemonchiffon = '#fffacd'
+let lightpink = '#ffb6c1'
+let lightsalmon = '#ffa07a'
+let lightyellow = '#ffffe0'
+let magenta = '#ff00ff'
+let mistyrose = '#ffe4e1'
+let moccasin = '#ffe4b5'
+let navajowhite = '#ffdead'
+let orange = '#ffa500'
+let orangered = '#ff4500'
+let papayawhip = '#ffefd5'
+let peachpuff = '#ffdab9'
+let pink = '#ffc0cb'
+let red = '#ff0000'
+let seashell = '#fff5ee'
+let snow = '#fffafa'
+let tomato = '#ff6347'
+let white = '#ffffff'
+let yellow = '#ffff00'
+let rebeccapurple = '#663399'
+let keywords = {
+  aqua,
+  aliceblue,
+  antiquewhite,
+  black,
+  blue,
+  cyan,
+  darkblue,
+  darkcyan,
+  darkgreen,
+  darkturquoise,
+  deepskyblue,
+  green,
+  lime,
+  mediumblue,
+  mediumspringgreen,
+  navy,
+  springgreen,
+  teal,
+  midnightblue,
+  dodgerblue,
+  lightseagreen,
+  forestgreen,
+  seagreen,
+  darkslategray,
+  darkslategrey,
+  limegreen,
+  mediumseagreen,
+  turquoise,
+  royalblue,
+  steelblue,
+  darkslateblue,
+  mediumturquoise,
+  indigo,
+  darkolivegreen,
+  cadetblue,
+  cornflowerblue,
+  mediumaquamarine,
+  dimgray,
+  dimgrey,
+  slateblue,
+  olivedrab,
+  slategray,
+  slategrey,
+  lightslategray,
+  lightslategrey,
+  mediumslateblue,
+  lawngreen,
+  aquamarine,
+  chartreuse,
+  gray,
+  grey,
+  maroon,
+  olive,
+  purple,
+  lightskyblue,
+  skyblue,
+  blueviolet,
+  darkmagenta,
+  darkred,
+  saddlebrown,
+  darkseagreen,
+  lightgreen,
+  mediumpurple,
+  darkviolet,
+  palegreen,
+  darkorchid,
+  yellowgreen,
+  sienna,
+  brown,
+  darkgray,
+  darkgrey,
+  greenyellow,
+  lightblue,
+  paleturquoise,
+  lightsteelblue,
+  powderblue,
+  firebrick,
+  darkgoldenrod,
+  mediumorchid,
+  rosybrown,
+  darkkhaki,
+  silver,
+  mediumvioletred,
+  indianred,
+  peru,
+  chocolate,
+  tan,
+  lightgray,
+  lightgrey,
+  thistle,
+  goldenrod,
+  orchid,
+  palevioletred,
+  crimson,
+  gainsboro,
+  plum,
+  burlywood,
+  lightcyan,
+  lavender,
+  darksalmon,
+  palegoldenrod,
+  violet,
+  azure,
+  honeydew,
+  khaki,
+  lightcoral,
+  sandybrown,
+  beige,
+  mintcream,
+  wheat,
+  whitesmoke,
+  ghostwhite,
+  lightgoldenrodyellow,
+  linen,
+  salmon,
+  oldlace,
+  bisque,
+  blanchedalmond,
+  coral,
+  cornsilk,
+  darkorange,
+  deeppink,
+  floralwhite,
+  fuchsia,
+  gold,
+  hotpink,
+  ivory,
+  lavenderblush,
+  lemonchiffon,
+  lightpink,
+  lightsalmon,
+  lightyellow,
+  magenta,
+  mistyrose,
+  moccasin,
+  navajowhite,
+  orange,
+  orangered,
+  papayawhip,
+  peachpuff,
+  pink,
+  red,
+  seashell,
+  snow,
+  tomato,
+  white,
+  yellow,
+  rebeccapurple,
+}
+
+let repeatElement = function repeat(ele, num) {
+  let arr = new Array(num)
+
+  for (let i = 0; i < num; i++) {
+    arr[i] = ele
+  }
+
+  return arr
+}
+
+let cssUrlRegex = function() {
+  return /url\(.*?\)/gi
+}
+
+/**
+ * @enum {number}
+ */
+let states = {
+  VARIATION: 1,
+  LINE_HEIGHT: 2,
+  FONT_FAMILY: 3,
+}
+/**
+ * @param {string} input
+ * @return {Object}
+ */
+
+function parse(input) {
+  let state = states.VARIATION,
+    buffer = '',
+    result = {
+      'font-family': [],
+    }
+
+  for (let c, i = 0; (c = input.charAt(i)); i += 1) {
+    if (state === states.FONT_FAMILY && (c === '"' || c === "'")) {
+      let index = i + 1 // consume the entire string
+
+      do {
+        index = input.indexOf(c, index) + 1
+
+        if (!index) {
+          // If a string is not closed by a ' or " return null.
+          // TODO: Check to see if this is correct.
+          return null
+        }
+      } while (input.charAt(index - 2) === '\\')
+
+      result['font-family'].push(input.slice(i + 1, index - 1).replace(/\\('|")/g, '$1'))
+      i = index - 1
+      buffer = ''
+    } else if (state === states.FONT_FAMILY && c === ',') {
+      if (!/^\s*$/.test(buffer)) {
+        result['font-family'].push(buffer.replace(/^\s+|\s+$/, '').replace(/\s+/g, ' '))
+        buffer = ''
+      }
+    } else if (state === states.VARIATION && (c === ' ' || c === '/')) {
+      if (
+        /^((xx|x)-large|(xx|s)-small|small|large|medium)$/.test(buffer) ||
+        /^(larg|small)er$/.test(buffer) ||
+        /^(\+|-)?([0-9]*\.)?[0-9]+(em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)$/.test(buffer)
+      ) {
+        state = c === '/' ? states.LINE_HEIGHT : states.FONT_FAMILY
+        result['font-size'] = buffer
+      } else if (/^(italic|oblique)$/.test(buffer)) {
+        result['font-style'] = buffer
+      } else if (/^small-caps$/.test(buffer)) {
+        result['font-variant'] = buffer
+      } else if (/^(bold(er)?|lighter|normal|[1-9]00)$/.test(buffer)) {
+        result['font-weight'] = buffer
+      } else if (/^((ultra|extra|semi)-)?(condensed|expanded)$/.test(buffer)) {
+        result['font-stretch'] = buffer
+      }
+
+      buffer = ''
+    } else if (state === states.LINE_HEIGHT && c === ' ') {
+      if (
+        /^(\+|-)?([0-9]*\.)?[0-9]+(em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)?$/.test(buffer)
+      ) {
+        result['line-height'] = buffer
+      }
+
+      state = states.FONT_FAMILY
+      buffer = ''
+    } else {
+      buffer += c
+    }
+  }
+
+  if (state === states.FONT_FAMILY && !/^\s*$/.test(buffer)) {
+    result['font-family'].push(buffer.replace(/^\s+|\s+$/, '').replace(/\s+/g, ' '))
+  }
+
+  if (result['font-size'] && result['font-family'].length) {
+    return result
+  }
+  return null
+}
+
+function font(input) {
+  if (/^(inherit|initial)$/.test(input)) {
+    return {
+      'font-size': input,
+      'line-height': input,
+      'font-style': input,
+      'font-weight': input,
+      'font-variant': input,
+      'font-stretch': input,
+      'font-family': input,
+    }
+  }
+
+  input = input.replace(/\s*\/\s*/, '/')
+  let result = parse(input)
+
+  if (result) {
+    // @ts-ignore
+    result['font-family'] = result['font-family']
+      .map(function(family) {
+        return /^(serif|sans-serif|monospace|cursive|fantasy)$/.test(family)
+          ? family
+          : '"' + family + '"'
+      })
+      .join(', ')
+  }
+
+  return result
+}
+
+function repeat(ele, num) {
+  let arr = new Array(num)
+
+  for (let i = 0; i < num; i++) {
+    arr[i] = ele
+  }
+
+  return arr
+}
+
+function directional(value) {
+  let values = value.split(/\s+/)
+  if (values.length === 1) values = repeat(values[0], 4)
+  else if (values.length === 2) values = values.concat(values)
+  else if (values.length === 3) values.push(values[1])
+  // @ts-ignore
+  else if (values.length > 4) return
+  return ['top', 'right', 'bottom', 'left'].reduce(function(acc, direction, i) {
+    acc[direction] = values[i]
+    return acc
+  }, {})
+}
+
+// @ts-ignore
+let HEX = new RegExp('^' + hexColorRegex().source + '$', 'i')
+let HSLA = hslaRegex({
+  exact: true,
+})
+let HSL = hslRegex({
+  exact: true,
+})
+let RGB = rgbRegex({
+  exact: true,
+})
+let RGBA = rgbaRegex({
+  exact: true,
+})
+function isColor(value) {
+  value = value.toLowerCase()
+  return (
+    !!keywords[value] ||
+    value === 'currentcolor' ||
+    value === 'transparent' ||
+    HEX.test(value) ||
+    HSLA.test(value) ||
+    HSL.test(value) ||
+    RGB.test(value) ||
+    RGBA.test(value)
+  )
+}
+
+let LENGTH = /^(\+|-)?([0-9]*\.)?[0-9]+(em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)$/i
+let ZERO = /^(\+|-)?(0*\.)?0+$/
+function isLength(value) {
+  return LENGTH.test(value) || ZERO.test(value)
+}
+
+// @ts-ignore
+let FUNCTIONS = [hslaRegex(), hslRegex(), rgbRegex(), rgbaRegex()]
+function normalize(value) {
+  return FUNCTIONS.reduce(function(acc, func) {
+    return acc.replace(func, function(match) {
+      return match.replace(/\s+/g, '')
+    })
+  }, value)
+}
+
+let WIDTH = /^(thin|medium|thick)$/
+let STYLE = /^(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset)$/i
+let KEYWORD = /^(inherit|initial)$/i
+
+let suffix = function suffix(_suffix) {
+  return function(value) {
+    let longhand = directional(value)
+    return (
+      longhand &&
+      mapObj(longhand, function(key, value) {
+        return ['border-' + key + '-' + _suffix, value]
+      })
+    )
+  }
+}
+
+let direction = function direction(_direction) {
+  return function(value) {
+    let longhand = all(value)
+    return (
+      longhand &&
+      mapObj(longhand, function(key, value) {
+        return ['border-' + _direction + '-' + key, value]
+      })
+    )
+  }
+}
+
+let all = function all(value) {
+  let values = normalize(value).split(/\s+/)
+  let first = values[0]
+  // @ts-ignore
+  if (values.length > 3) return
+
+  if (values.length === 1 && KEYWORD.test(first)) {
+    return {
+      width: first,
+      style: first,
+      color: first,
+    }
+  }
+
+  let result = {}
+
+  for (let i = 0; i < values.length; i++) {
+    let v = values[i]
+
+    if (WIDTH.test(v) || isLength(v)) {
+      // @ts-ignore
+      if (result.width) return
+      // @ts-ignore
+      result.width = v
+    } else if (STYLE.test(v)) {
+      // @ts-ignore
+      if (result.style) return
+      // @ts-ignore
+      result.style = v
+    } else if (isColor(v)) {
+      // @ts-ignore
+      if (result.color) return
+      // @ts-ignore
+      result.color = v
+    } else {
+      // @ts-ignore
+      return
+    }
+  }
+
+  return result
+}
+
+let border = function border(value) {
+  let longhand = all(value)
+  return (
+    longhand &&
+    Object.keys(longhand).reduce(function(acc, key) {
+      let props = border[key](longhand[key])
+      // @ts-ignore
+      return immutable(acc, props)
+    }, {})
+  )
+}
+
+// @ts-ignore
+border.width = suffix('width')
+// @ts-ignore
+border.style = suffix('style')
+// @ts-ignore
+border.color = suffix('color')
+// @ts-ignore
+border.top = direction('top')
+// @ts-ignore
+border.right = direction('right')
+// @ts-ignore
+border.bottom = direction('bottom')
+// @ts-ignore
+border.left = direction('left')
+
+let directional$1 = function directional(value) {
+  let values = value.split(/\s+/)
+  if (values.length === 1) values = repeatElement(values[0], 4)
+  else if (values.length === 2) values = values.concat(values)
+  else if (values.length === 3) values.push(values[1])
+  // @ts-ignore
+  else if (values.length > 4) return
+  return ['top-left', 'top-right', 'bottom-right', 'bottom-left'].reduce(function(
+    acc,
+    direction,
+    i,
+  ) {
+    acc[direction] = values[i]
+    return acc
+  },
+  {})
+}
+
+let borderRadius = function borderRadius(value) {
+  let longhand = directional$1(value)
+  return (
+    longhand &&
+    mapObj(longhand, function(key, value) {
+      return ['border-' + key + '-radius', value]
+    })
+  )
+}
+
+let ATTACHMENT = /^(fixed|local|scroll)$/
+let BOX = /^(border-box|padding-box|content-box)$/
+let IMAGE = new RegExp('^(none|' + cssUrlRegex().source + ')$', 'i')
+let REPEAT_SINGLE = /^(repeat-x|repeat-y)$/i
+let REPEAT_DOUBLE = /^(repeat|space|round|no-repeat)$/i
+let POSITION_HORIZONTAL = /^(left|center|right)$/
+let POSITION_VERTICAL = /^(top|center|bottom)$/
+let SIZE_SINGLE = /^(cover|contain)$/
+let KEYWORD$1 = /^(inherit|initial)$/i
+
+let normalizeUrl = function normalizeUrl(value) {
+  return value.replace(cssUrlRegex(), function(match) {
+    return match.replace(/^url\(\s+/, 'url(').replace(/\s+\)$/, ')')
+  })
+}
+
+function background(value) {
+  let result = {}
+  let values = normalizeUrl(normalize(value))
+    .replace(/\(.*\/.*\)|(\/)+/g, (match, group1) => (!group1 ? match : ' / '))
+    .split(/\s+/)
+  let first = values[0]
+
+  if (values.length === 1 && KEYWORD$1.test(first)) {
+    return {
+      'background-attachment': first,
+      'background-clip': first,
+      'background-image': first,
+      'background-repeat': first,
+      'background-color': first,
+      'background-position': first,
+      'background-size': first,
+    }
+  }
+
+  for (let i = 0; i < values.length; i++) {
+    let v = values[i]
+
+    if (ATTACHMENT.test(v)) {
+      // @ts-ignore
+      if (result.attachment) return
+      // @ts-ignore
+      result.attachment = v
+    } else if (BOX.test(v)) {
+      // @ts-ignore
+      if (result.clip) return
+      // @ts-ignore
+      result.clip = v
+    } else if (IMAGE.test(v)) {
+      // @ts-ignore
+      if (result.image) return
+      // @ts-ignore
+      result.image = v
+    } else if (REPEAT_SINGLE.test(v)) {
+      // @ts-ignore
+      if (result.repeat) return
+      // @ts-ignore
+      result.repeat = v
+    } else if (REPEAT_DOUBLE.test(v)) {
+      // @ts-ignore
+      if (result.repeat) return
+      let n = values[i + 1]
+
+      if (n && REPEAT_DOUBLE.test(n)) {
+        v += ' ' + n
+        i++
+      }
+
+      // @ts-ignore
+      result.repeat = v
+    } else if (isColor(v)) {
+      // @ts-ignore
+      if (result.color) return
+      // @ts-ignore
+      result.color = v
+    } else if (POSITION_HORIZONTAL.test(v) || POSITION_VERTICAL.test(v) || isLength(v)) {
+      // @ts-ignore
+      if (result.position) return
+      let n = values[i + 1]
+      let isHorizontal = POSITION_HORIZONTAL.test(v) || isLength(v)
+      let isVertical = POSITION_VERTICAL.test(n) || isLength(n)
+
+      if (isHorizontal && isVertical) {
+        // @ts-ignore
+        result.position = v + ' ' + n
+        i++
+      } else {
+        // @ts-ignore
+        result.position = v
+      }
+
+      v = values[i + 1]
+
+      if (v === '/') {
+        i += 2
+        v = values[i]
+
+        if (SIZE_SINGLE.test(v)) {
+          // @ts-ignore
+          result.size = v
+        } else if (v === 'auto' || isLength(v)) {
+          n = values[i + 1]
+
+          if (n === 'auto' || isLength(n)) {
+            v += ' ' + n
+            i++
+          }
+
+          // @ts-ignore
+          result.size = v
+        } else {
+          // @ts-ignore
+          return
+        }
+      }
+    } else {
+      // @ts-ignore
+      return
+    }
+  }
+
+  return mapObj(result, function(key, value) {
+    return ['background-' + key, value]
+  })
+}
+
+let WIDTH$1 = /^(thin|medium|thick)$/
+let STYLE$1 = /^(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset)$/i
+let KEYWORD$2 = /^(inherit|initial)$/i
+
+let outline = function outline(value) {
+  let values = normalize(value).split(/\s+/)
+  // @ts-ignore
+  if (values.length > 3) return
+
+  if (values.length === 1 && KEYWORD$2.test(values[0])) {
+    return {
+      'outline-width': values[0],
+      'outline-style': values[0],
+      'outline-color': values[0],
+    }
+  }
+
+  let result = {}
+
+  for (let i = 0; i < values.length; i++) {
+    let v = values[i]
+
+    if (isLength(v) || WIDTH$1.test(v)) {
+      // @ts-ignore
+      if (result['outline-width']) return
+      result['outline-width'] = v
+    } else if (STYLE$1.test(v)) {
+      // @ts-ignore
+      if (result['outline-style']) return
+      result['outline-style'] = v
+    } else if (isColor(v)) {
+      // @ts-ignore
+      if (result['outline-color']) return
+      result['outline-color'] = v
+    } else {
+      // @ts-ignore
+      return
+    }
+  }
+  return result
+}
+
+let prefix = function prefix(_prefix) {
+  return function(value) {
+    let longhand = directional(value)
+    return (
+      longhand &&
+      mapObj(longhand, function(key, value) {
+        return [_prefix + '-' + key, value]
+      })
+    )
+  }
+}
+
+let shorthand = {
+  font,
+  padding: prefix('padding'),
+  margin: prefix('margin'),
+  border,
+  // @ts-ignore
+  'border-width': border.width,
+  // @ts-ignore
+  'border-style': border.style,
+  // @ts-ignore
+  'border-color': border.color,
+  // @ts-ignore
+  'border-top': border.top,
+  // @ts-ignore
+  'border-right': border.right,
+  // @ts-ignore
+  'border-bottom': border.bottom,
+  // @ts-ignore
+  'border-left': border.left,
+  'border-radius': borderRadius,
+  background,
+  outline,
+}
+function index(property, value) {
+  let normalized = value.trim()
+  let important = /\s+!important$/.test(normalized)
+  normalized = normalized.replace(/\s+!important$/, '')
+  let parse = shorthand[property]
+  let longhand = parse && parse(normalized)
+  if (!longhand) return
+  if (!important) return longhand
+  return mapObj(longhand, function(key, value) {
+    return [key, value + ' !important']
+  })
+}
+
+export default index

--- a/packages/react/src/lib/felaExpandCssShorthandsPlugin.ts
+++ b/packages/react/src/lib/felaExpandCssShorthandsPlugin.ts
@@ -1,14 +1,10 @@
 import * as _ from 'lodash'
-import * as _expand from 'css-shorthand-expand'
+import expand from './cssExpandShorthand'
 import * as _memoize from 'fast-memoize'
 
 // `fast-memoize` is a CJS library, there are known issues with them:
 // https://github.com/rollup/rollup/issues/1267#issuecomment-446681320
 const memoize = (_memoize as any).default || _memoize
-
-// `css-shorthand-expand` is a CJS library, there are known issues with them:
-// https://github.com/rollup/rollup/issues/1267#issuecomment-446681320
-const expand = memoize((_expand as any).default || _expand)
 
 // _.camelCase is quite fast, but we are running it for the same values many times
 const camelCase = memoize(_.camelCase)

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
       [
         '@stardust-ui/react:',
         'You are running Fela in development mode and this can cause performance degrades.',
-        'To disable it please paste `window.localStorage.felaDevMode = false` to your browsers console and reload current page.',
+        'To disable it please paste `delete window.localStorage.felaDevMode` to your browsers console and reload current page.',
       ].join(' '),
     )
   } else {


### PR DESCRIPTION
Fixes #1534.

### Problem

IE11 does not have support of arrow functions while our dependency [`css-shorthand-expand`](https://github.com/kapetan/css-shorthand-expand) has its [usage](https://github.com/kapetan/css-shorthand-expand/blob/master/source/background.js#L28). And for client there is only one option to fix - compile these dependency with `babel-loader` or any other thing 👎 

### Solution

I used [`@pika/pack`](https://github.com/pikapkg/pack) to quicky get bundled library, so our `cssExpandShorthand.ts` contains `css-shorthand-expand` and all its dependencies in the single and tree-shaken file. As we compile all our files with Babel: arrow functions and any other unsupported things will be compiled properly 🚀 