### PR TITLE
docs: fix content overlap with sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add ARIA attributes and keyboard navigation for `Menu` in `Toolbar` @sophieH29 ([#1553](https://github.com/stardust-ui/react/pull/1553))
 - Add `alert`, `info`, `share-alt` and `microsoft-stream` icons to Teams theme @marst89 ([#1544](https://github.com/stardust-ui/react/pull/1544))
 
+### Documentation
+- Ensure docs content doesn't overlap with sidebar @kuzhelov ([#1568](https://github.com/stardust-ui/react/pull/1568))
+
 <!--------------------------------[ v0.34.0 ]------------------------------- -->
 ## [v0.34.0](https://github.com/stardust-ui/react/tree/v0.34.0) (2019-06-26)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.33.0...v0.34.0)

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -133,6 +133,7 @@ class Sidebar extends React.Component<any, any> {
       left: 0,
       padding: 0,
       maxHeight: '100vh',
+      zIndex: 1000,
     }
 
     const menuSectionStyles: ICSSInJSStyle = {


### PR DESCRIPTION
This PR fixes the following problem - on narrow screens the following problem was experienced by docs clients (v0.34):

### Originally, Menu's page scrolled to the right

![image](https://user-images.githubusercontent.com/9024564/60501195-ea959600-9cbb-11e9-9f44-d829503c2e2f.png)

### Now

![image](https://user-images.githubusercontent.com/9024564/60501325-1fa1e880-9cbc-11e9-81c5-26ccdb0db199.png)



