### PR TITLE
fix(Provider): add ProviderBoxProps and div attributes to ProviderProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Dropdown` highlightedIndex on arrow keydown open @silviuavram ([#1570](https://github.com/stardust-ui/react/pull/1570))
 - Fix `Dropdown` ArrowLeft keydown behavior for multiple variants @silviuavram ([#1564](https://github.com/stardust-ui/react/pull/1564))
 - Fix styles for shadows in `Popup` in Teams theme [redlines] @codepretty ([#1561](https://github.com/stardust-ui/react/pull/1561))
+- Fix typings for `Provider` props @miroslavstastny ([#1601](https://github.com/stardust-ui/react/pull/1601))
 
 ### Features
 - Add ARIA attributes and focus handling for `RadioGroup` in `Toolbar` @sophieH29 ([#1526](https://github.com/stardust-ui/react/pull/1526))

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -21,15 +21,20 @@ import {
 
 import ProviderConsumer from './ProviderConsumer'
 import { mergeSiteVariables } from '../../lib/mergeThemes'
-import ProviderBox from './ProviderBox'
-import { WithAsProp, ProviderContextInput, ProviderContextPrepared } from '../../types'
+import ProviderBox, { ProviderBoxProps } from './ProviderBox'
+import {
+  WithAsProp,
+  ProviderContextInput,
+  ProviderContextPrepared,
+  withSafeTypeForAs,
+} from '../../types'
 import mergeContexts from '../../lib/mergeProviderContexts'
 
 export interface ProviderProps extends ChildrenComponentProps {
   renderer?: Renderer
   rtl?: boolean
   disableAnimations?: boolean
-  theme: ThemeInput
+  theme?: ThemeInput
   variables?: ComponentVariablesInput
 }
 
@@ -183,4 +188,4 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
   }
 }
 
-export default Provider
+export default withSafeTypeForAs<typeof Provider, ProviderProps & ProviderBoxProps>(Provider)


### PR DESCRIPTION
`Provider` by default renders `ProviderBox` which by default renders a `div`.

### child props
`Provider` only accepted `ProviderProps`. It was not possible to pass any `ProviderBox` props (like `styles`) or `div` attributes (like `id`).

Now it accepts all of these.

### `theme` prop
Previously, `theme` was required prop. But as new props were added to the `Provider`, it now makes sense to instantiate the `Provider` without the `theme` just changing other params (`rtl`).

This PR makes `theme` optional.

This still does not make sense for top level provider but there already is a runtime check for that.

Fixes #1424.