### PR TITLE
docs(ExampleSnippet): fix error when children are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add prototype for Custom Styled Toolbar @miroslavstastny ([#1541](https://github.com/stardust-ui/react/pull/1541))
 - Add Best Practices section for each component @alinais ([#1550](https://github.com/stardust-ui/react/pull/1550))
 - Update `Layout` guide @layershifter ([#1595](https://github.com/stardust-ui/react/pull/1595))
+- Fix error when children are missing in `ExampleSnippet` @layershifter ([#1619](https://github.com/stardust-ui/react/pull/1619))
 
 <!--------------------------------[ v0.34.0 ]------------------------------- -->
 ## [v0.34.0](https://github.com/stardust-ui/react/tree/v0.34.0) (2019-06-26)

--- a/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
+++ b/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
@@ -4,7 +4,8 @@ import * as React from 'react'
 import renderElementToJSX from './renderElementToJSX'
 
 export type ExampleSnippetProps = {
-  render?: () => React.ReactNode
+  children?: React.ReactElement
+  render?: () => React.ReactElement
   value?: string
 }
 
@@ -21,7 +22,9 @@ const renderedStyle = {
 const ExampleSnippet: React.FunctionComponent<ExampleSnippetProps> = props => {
   const { children, render = () => null, value } = props
 
-  const element: React.ReactNode = render() || React.Children.only(children)
+  const child: React.ReactElement | null = render() || children
+  const element: React.ReactElement = child ? React.Children.only(child) : null
+
   const isFunctionWithoutValue = render && !value
   const string = value || renderElementToJSX(element, !isFunctionWithoutValue)
 


### PR DESCRIPTION
Fixes #1618.

It happened when `render()` function and `children` were missing in the same time.