### PR TITLE
chore: ignore report json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ docs/src/exampleMenus
 docs/src/exampleSources
 docs/dist/
 node_modules/
+report.*.json
 stats/
 .vscode/


### PR DESCRIPTION
I had a typescript build failure which dumped a JSON report file to the root of the project.  I committed and pushed this file without knowing.  This file also dumps _all_ of your environment variables to the report 😕 Needless to say, all my tokens were pushed to GitHub and I had to reset them.

Let's not allow these report files to be committed! 👍 