### PR TITLE
fix(docs): broken fragments on CodeSandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Refine component descriptions @kuzhelov ([#1629](https://github.com/stardust-ui/react/pull/1629))
 - Add best practices and form usage example for `Slider` component @Bugaa92 ([#1641](https://github.com/stardust-ui/react/pull/1641))
 - Add examples with `Tooltip` for the actionable components @mnajdova ([#1636](https://github.com/stardust-ui/react/pull/1636))
+- Fix broken fragments on CodeSandbox @lucivpav ([#1655](https://github.com/stardust-ui/react/pull/1655))
 
 <!--------------------------------[ v0.34.1 ]------------------------------- -->
 ## [v0.34.1](https://github.com/stardust-ui/react/tree/v0.34.1) (2019-07-11)

--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
@@ -6,7 +6,12 @@ import { ComponentSourceManagerLanguage } from 'docs/src/components/ComponentDoc
 const name = 'stardust-ui-example'
 const description =
   'An exported example from Stardust UI React, https://stardust-ui.github.io/react/'
-const dependencies = _.mapValues(imports, () => 'latest')
+const dependencies = {
+  ..._.mapValues(imports, () => 'latest'),
+  // required to enable all features due old templates in https://github.com/codesandbox/codesandbox-importers
+  // https://github.com/stardust-ui/react/issues/1519
+  'react-scripts': 'latest',
+}
 const devDependencies = {
   '@types/lodash': 'latest',
   '@types/react': 'latest',

--- a/docs/src/components/Playground/renderConfig.ts
+++ b/docs/src/components/Playground/renderConfig.ts
@@ -24,7 +24,6 @@ export const imports = {
   react: React,
   'react-dom': ReactDOM,
   'react-fela': ReactFela,
-  'react-scripts': 'latest',
 }
 
 export const importResolver = importName => imports[importName]

--- a/docs/src/components/Playground/renderConfig.ts
+++ b/docs/src/components/Playground/renderConfig.ts
@@ -24,6 +24,7 @@ export const imports = {
   react: React,
   'react-dom': ReactDOM,
   'react-fela': ReactFela,
+  'react-scripts': 'latest',
 }
 
 export const importResolver = importName => imports[importName]


### PR DESCRIPTION
This PR resolves issue #1519. The code examples with `<>...</>` fragments resulted in an error on CodeSandbox if JavaScript language was chosen.