### PR TITLE
fix(Popup): fix broken background with pointing and FocusTrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix a gap in `Checkbox` in RTL mode @layershifter ([#1683](https://github.com/stardust-ui/react/pull/1683))
+- Fix broken background in `Popup` with `pointing` and `FocusTrap` @layershifter ([#1689](https://github.com/stardust-ui/react/pull/1689))
 
 <!--------------------------------[ v0.34.1 ]------------------------------- -->
 ## [v0.34.1](https://github.com/stardust-ui/react/tree/v0.34.1) (2019-07-11)

--- a/packages/react/src/themes/teams/components/Popup/popupStyles.ts
+++ b/packages/react/src/themes/teams/components/Popup/popupStyles.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash'
 import * as React from 'react'
 import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { PopupProps } from '../../../../components/Popup/Popup'
@@ -14,7 +15,7 @@ const popupStyles: ComponentSlotStylesInput<PopupProps, PopupVariables> = {
     /*
      * This fix handles all cases with wrapped focus trap.
      */
-    ...(React.isValidElement(p.content) && {
+    ...((React.isValidElement(p.content) || _.isFunction(p.content)) && {
       // when FocusTrap exists and `context` is JSX element
       color: v.contentColor,
       background: v.contentBackgroundColor,

--- a/packages/react/src/themes/teams/components/Popup/popupStyles.ts
+++ b/packages/react/src/themes/teams/components/Popup/popupStyles.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { ComponentSlotStylesInput, ICSSInJSStyle } from '../../../types'
 import { PopupProps } from '../../../../components/Popup/Popup'
 import { PopupVariables } from './popupVariables'
@@ -5,12 +6,29 @@ import { PopupVariables } from './popupVariables'
 const popupStyles: ComponentSlotStylesInput<PopupProps, PopupVariables> = {
   root: (): ICSSInJSStyle => ({}),
 
-  popup: ({ variables: v }): ICSSInJSStyle => ({
+  popup: ({ props: p, variables: v }): ICSSInJSStyle => ({
     zIndex: v.zIndex,
     position: 'absolute',
     textAlign: 'left',
-    color: v.contentColor,
-    background: v.contentBackgroundColor,
+
+    /*
+     * This fix handles all cases with wrapped focus trap.
+     */
+    ...(React.isValidElement(p.content) && {
+      // when FocusTrap exists and `context` is JSX element
+      color: v.contentColor,
+      background: v.contentBackgroundColor,
+    }),
+    '&.ui-popup__content': {
+      // when there is no FocusTrap
+      color: v.contentColor,
+      background: v.contentBackgroundColor,
+    },
+    '& .ui-popup__content': {
+      // when FocusTrap exists
+      color: v.contentColor,
+      background: v.contentBackgroundColor,
+    },
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Popup/popupStyles.ts
+++ b/packages/react/src/themes/teams/components/Popup/popupStyles.ts
@@ -16,7 +16,7 @@ const popupStyles: ComponentSlotStylesInput<PopupProps, PopupVariables> = {
      * This fix handles all cases with wrapped focus trap.
      */
     ...((React.isValidElement(p.content) || _.isFunction(p.content)) && {
-      // when FocusTrap exists and `context` is JSX element
+      // when FocusTrap exists and `context` is JSX element or render() callback
       color: v.contentColor,
       background: v.contentBackgroundColor,
     }),


### PR DESCRIPTION
Fixes #1679.

## Problem

In `master` we have already resolved this issue by #1565, however we need to provide a fix without breaking changes for now.

### Before

![image](https://user-images.githubusercontent.com/14183168/61530818-7120d600-aa25-11e9-9fcc-72f7fd33d305.png)


### After

![image](https://user-images.githubusercontent.com/14183168/61530783-53ec0780-aa25-11e9-8891-a4d8d5137c19.png)

#### Test snippet

```tsx
import * as React from 'react'
import { Button, Flex, Popup, popupFocusTrapBehavior } from '@stardust-ui/react'

const plainContentStyle = {
  zIndex: 1000,
  padding: 5,
}

const PopupExample = () => (
  <Flex vAlign='center' space='between' styles={{ padding: '50px', height: '500px', backgroundColor: 'orange' }}>
    <Popup content="Hello from popup!" pointing open accessibility={popupFocusTrapBehavior}>
      <Button icon="expand"/>
    </Popup>

    <Popup open content={<p style={plainContentStyle}>Plain popup content rendered 'as is'.</p>}>
      <Button icon="expand" content="Popup with plain content"/>
    </Popup>
    <Popup open accessibility={popupFocusTrapBehavior}
           content={<p style={plainContentStyle}>Plain popup content rendered 'as is'.</p>}>
      <Button icon="expand" content="Popup with plain content"/>
    </Popup>

    <Popup
      open
      content={{ content: <p style={plainContentStyle}>Popup content rendered in wrapper.</p> }}
    >
      <Button icon="expand" content="Popup with wrapped content"/>
    </Popup>
  </Flex>
)

export default PopupExample
```