### PR TITLE
fix(Loader): use Text component for `label` slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `ChatMessage`'s focus border overlays `actionMenu` in Teams theme @mnajdova ([#1637](https://github.com/stardust-ui/react/pull/1637))
-- `Loader` uses `Text` component for `label` slot instead of `Box` @layershifter ([#X](https://github.com/stardust-ui/react/pull/X))
+- `Loader` uses `Text` component for `label` slot instead of `Box` @layershifter ([#1701](https://github.com/stardust-ui/react/pull/1701))
 
 ### Documentation
 - Make sidebar categories collapsible @lucivpav ([#1611](https://github.com/stardust-ui/react/pull/1611))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `ChatMessage`'s focus border overlays `actionMenu` in Teams theme @mnajdova ([#1637](https://github.com/stardust-ui/react/pull/1637))
+- `Loader` uses `Text` component for `label` slot instead of `Box` @layershifter ([#X](https://github.com/stardust-ui/react/pull/X))
 
 ### Documentation
 - Make sidebar categories collapsible @lucivpav ([#1611](https://github.com/stardust-ui/react/pull/1611))

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -14,6 +14,7 @@ import { loaderBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
 import Box, { BoxProps } from '../Box/Box'
+import Text, { TextProps } from '../Text/Text'
 
 export interface LoaderSlotClassNames {
   indicator: string
@@ -35,7 +36,7 @@ export interface LoaderProps extends UIComponentProps, ColorComponentProps {
   inline?: boolean
 
   /** A loader can contain a label. */
-  label?: ShorthandValue<BoxProps>
+  label?: ShorthandValue<TextProps>
 
   /** A label in the loader can have different positions. */
   labelPosition?: 'above' | 'below' | 'start' | 'end'
@@ -134,7 +135,7 @@ class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
               styles: styles.indicator,
             },
           })}
-          {Box.create(label, {
+          {Text.create(label, {
             defaultProps: { className: Loader.slotClassNames.label, styles: styles.label },
           })}
         </ElementType>


### PR DESCRIPTION
Extracted from #1670.

`Loader` component should use `Text` component to display text.