### PR TITLE
fix(Dialog|Segment): update support of `color` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `ChatMessage`'s focus border overlays `actionMenu` in Teams theme @mnajdova ([#1637](https://github.com/stardust-ui/react/pull/1637))
+- Add `color` prop to `Segment` typings @layershifter ([#1702](https://github.com/stardust-ui/react/pull/1702))
+- Remove `color` prop from `Dialog` typings @layershifter ([#1702](https://github.com/stardust-ui/react/pull/1702))
 
 ### Documentation
 - Make sidebar categories collapsible @lucivpav ([#1611](https://github.com/stardust-ui/react/pull/1611))

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -7,7 +7,6 @@ import * as React from 'react'
 import {
   UIComponentProps,
   commonPropTypes,
-  ColorComponentProps,
   ContentComponentProps,
   AutoControlledComponent,
   doesNodeContainClick,
@@ -32,8 +31,7 @@ export interface DialogSlotClassNames {
 
 export interface DialogProps
   extends UIComponentProps,
-    ContentComponentProps<ShorthandValue<BoxProps>>,
-    ColorComponentProps {
+    ContentComponentProps<ShorthandValue<BoxProps>> {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility
 
@@ -105,7 +103,6 @@ class Dialog extends AutoControlledComponent<WithAsProp<DialogProps>, DialogStat
     ...commonPropTypes.createCommon({
       children: false,
       content: 'shorthand',
-      color: true,
     }),
     actions: customPropTypes.itemShorthand,
     headerAction: customPropTypes.itemShorthand,

--- a/packages/react/src/components/Segment/Segment.tsx
+++ b/packages/react/src/components/Segment/Segment.tsx
@@ -8,6 +8,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  ColorComponentProps,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -17,6 +18,7 @@ import Box, { BoxProps } from '../Box/Box'
 export interface SegmentProps
   extends UIComponentProps<SegmentProps>,
     ChildrenComponentProps,
+    ColorComponentProps,
     ContentComponentProps<ShorthandValue<BoxProps>> {
   /**
    * Accessibility behavior if overridden by the user.
@@ -38,6 +40,7 @@ class Segment extends UIComponent<WithAsProp<SegmentProps>, any> {
   static propTypes = {
     ...commonPropTypes.createCommon({
       content: 'shorthand',
+      color: true,
     }),
     disabled: PropTypes.bool,
     inverted: PropTypes.bool,


### PR DESCRIPTION
Picked from #1670.

- `Dialog` never had support of `color` prop, so I removed it from `Dialog`
- `Segment` had support, but typings were not complete, so I added them 