### PR TITLE
docs(Button): separate overflow example

### DIFF
--- a/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react'
-import { Button, Flex } from '@stardust-ui/react'
+import { Button } from '@stardust-ui/react'
 
-const ButtonExample = () => (
-  <Flex gap="gap.smaller">
-    <Button content="Click here" />
-    <Button content="See how this very long text shows up on the button" />
-  </Flex>
-)
+const ButtonExample = () => <Button content="Click here" />
 
 export default ButtonExample

--- a/docs/src/examples/components/Button/Types/ButtonExample.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react'
-import { Button, Flex } from '@stardust-ui/react'
+import { Button } from '@stardust-ui/react'
 
-const ButtonExample = () => (
-  <Flex gap="gap.smaller">
-    <Button>Click here</Button>
-    <Button>See how this very long text shows up on the button</Button>
-  </Flex>
-)
+const ButtonExample = () => <Button>Click here</Button>
 
 export default ButtonExample

--- a/docs/src/examples/components/Button/Usage/ButtonExampleOverflow.shorthand.tsx
+++ b/docs/src/examples/components/Button/Usage/ButtonExampleOverflow.shorthand.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { Button } from '@stardust-ui/react'
+
+const ButtonExampleOverflow = () => (
+  <Button content="See how this very long text shows up in the button" />
+)
+
+export default ButtonExampleOverflow

--- a/docs/src/examples/components/Button/Usage/ButtonExampleOverflow.tsx
+++ b/docs/src/examples/components/Button/Usage/ButtonExampleOverflow.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { Button } from '@stardust-ui/react'
+
+const ButtonExampleOverflow = () => (
+  <Button>See how this very long text shows up in the button</Button>
+)
+
+export default ButtonExampleOverflow

--- a/docs/src/examples/components/Button/Usage/index.tsx
+++ b/docs/src/examples/components/Button/Usage/index.tsx
@@ -6,6 +6,11 @@ import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 const Usage = () => (
   <ExampleSection title="Usage">
     <ComponentExample
+      title="Overflow"
+      description="A button can have content that overflows."
+      examplePath="components/Button/Usage/ButtonExampleOverflow"
+    />
+    <ComponentExample
       title="Tinted Example"
       description='A button used in cards is a "tinted" version of a default button.'
       examplePath="components/Button/Usage/ButtonUsageExample"


### PR DESCRIPTION
This PR separates the default button example from the text overflow example.

Why?
1. Examples should be as minimal as possible to show the component feature.
1. Overflow is not a type of button but a usage of the default button.

# Before
![image](https://user-images.githubusercontent.com/5067638/61657356-84c37b00-ac77-11e9-920a-7664ef17bed8.png)
```jsx
const ButtonExample = () => (
  <Flex gap="gap.smaller">
    <Button content="Click here" />
    <Button content="See how this very long text shows up on the button" />
  </Flex>
)
```
# After

![image](https://user-images.githubusercontent.com/5067638/61657280-6e1d2400-ac77-11e9-8723-07a6c98c471f.png)
```jsx
const ButtonExample = () => <Button content="Click here" />
```
***
![image](https://user-images.githubusercontent.com/5067638/61657266-665d7f80-ac77-11e9-93d0-6ecc8085db08.png)
```jsx
const ButtonExampleOverflow = () => (
  <Button content="See how this very long text shows up in the button" />
)
```