### PR TITLE
fix(DropdownSelectedItem): apply 'button' role

### DIFF
--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -165,6 +165,7 @@ class DropdownSelectedItem extends UIComponent<WithAsProp<DropdownSelectedItemPr
         <Label
           className={classes.root}
           tabIndex={active ? 0 : -1}
+          role="button"
           styles={styles.root}
           circular
           onClick={this.handleClick}


### PR DESCRIPTION
Fixes https://github.com/stardust-ui/react/issues/1653.

Now it should focus without any issues.
MaterialUI also has them as buttons. https://material-ui.com/components/autocomplete/

Since we also have onClick on it then maybe it should be a button.

@kolaps33 @jurokapsiar @mshoho @sophieH29 