### PR TITLE
fix(FocusTrapZone): firstFocusableSelector is fragile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Expose `isFromKeyboard` in `Grid` component @sophieH29 ([#1729](https://github.com/stardust-ui/react/pull/1729))
 
+### Fixes
+- Fix `firstFocusableSelector` in `FocusTrapZone` and `AutoFocusZone` @sophieH29 ([#1732](https://github.com/stardust-ui/react/pull/1732))
+
 
 <!--------------------------------[ v0.35.0 ]------------------------------- -->
 ## [v0.35.0](https://github.com/stardust-ui/react/tree/v0.35.0) (2019-07-26)

--- a/docs/src/views/AutoFocusZoneDoc.tsx
+++ b/docs/src/views/AutoFocusZoneDoc.tsx
@@ -51,7 +51,7 @@ export default () => (
       label="PopupExample.jsx"
       value={`
         const Popup = () => (
-          <Popup autoFocus={{ firstFocusableSelector: "btn-submit" }} />
+          <Popup autoFocus={{ firstFocusableSelector: ".btn-submit" }} />
         )`}
     />
     <p>Read more about:</p>

--- a/packages/react/src/lib/accessibility/FocusZone/AutoFocusZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/AutoFocusZone.tsx
@@ -48,7 +48,7 @@ export default class AutoFocusZone extends React.Component<AutoFocusZoneProps> {
     const focusSelector = callable(firstFocusableSelector)()
 
     const firstFocusableChild = focusSelector
-      ? (this.root.current.querySelector(`.${focusSelector}`) as HTMLElement)
+      ? (this.root.current.querySelector(focusSelector) as HTMLElement)
       : getNextElement(
           this.root.current,
           this.root.current.firstChild as HTMLElement,

--- a/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -181,7 +181,7 @@ export default class FocusTrapZone extends React.Component<FocusTrapZoneProps, {
         : firstFocusableSelector())
 
     const firstFocusableChild = focusSelector
-      ? (this._root.current.querySelector(`.${focusSelector}`) as HTMLElement)
+      ? (this._root.current.querySelector(focusSelector) as HTMLElement)
       : getNextElement(
           this._root.current,
           this._root.current.firstChild as HTMLElement,

--- a/packages/react/test/specs/lib/AutoFocusZone-test.tsx
+++ b/packages/react/test/specs/lib/AutoFocusZone-test.tsx
@@ -100,7 +100,7 @@ describe('AutoFocusZone', () => {
 
     it('goes to the element with containing the firstFocusableSelector if provided when focusing the ATZ', async () => {
       expect.assertions(1)
-      const { autoFocusZone, buttonB } = setupTest('b')
+      const { autoFocusZone, buttonB } = setupTest('.b')
 
       // By calling `componentDidMount`, AFZ will behave as just initialized and focus needed element
       // Focus within should go to the element containing the selector.


### PR DESCRIPTION
Fixes https://github.com/stardust-ui/react/issues/1566

### Breaking change
Before:
`firstFocusableSelector` was used only to specify the class name string selector. `.` was appended to the passed value.

After:
`firstFocusableSelector` can be any string selector as is used in API for `document.querySelector`



--------------------------------
This PR introduces changes to `FocusTrapZone` and `AutoFocusZone` to not limit a user to using class selectors only.
Now it's a user responsibility to pass the whole string selector whether it's a `.blah` or `#blah` or tag `blah` etc. If this element won't be found in the container, the first tabbable element will be selected