### PR TITLE
fix(Icon): Export broadcast icon in Teams theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Fix `firstFocusableSelector` in `FocusTrapZone` and `AutoFocusZone` @sophieH29 ([#1732](https://github.com/stardust-ui/react/pull/1732))
 
+### Fixes
+- Require `name` prop in `Icon` component @lucivpav ([#1723](https://github.com/stardust-ui/react/pull/1723))
+- Export `broadcast` icon in Teams theme @miroslavstastny ([#1737](https://github.com/stardust-ui/react/pull/1737))
+
 ### Features
 - Expose `isFromKeyboard` in `Grid` component @sophieH29 ([#1729](https://github.com/stardust-ui/react/pull/1729))
 - Add `onActiveIndexChange` prop to `Tree` component @lucivpav ([#1728](https://github.com/stardust-ui/react/pull/1728))
 - Add `horizontal` prop for `List` component @mnajdova ([#1721](https://github.com/stardust-ui/react/pull/1721))
 - Export `call-blocked` icon to Teams theme @francescopalmiotto ([#1736](https://github.com/stardust-ui/react/pull/1736))
-
-### Fixes
-- Require `name` prop in `Icon` component @lucivpav ([#1723](https://github.com/stardust-ui/react/pull/1723))
 
 ### Documentation
 - Fix code in changing component variables section of theming examples @lucivpav ([#1626](https://github.com/stardust-ui/react/pull/1626))

--- a/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
+++ b/packages/react/src/themes/teams/components/Icon/svg/icons/index.ts
@@ -8,6 +8,7 @@ import arrowDown from './arrowDown'
 import ban from './ban'
 import bold from './bold'
 import bookmark from './bookmark'
+import broadcast from './broadcast'
 import bullets from './bullets'
 import calendar from './calendar'
 import call from './call'
@@ -154,6 +155,7 @@ export default {
   ban,
   bold,
   bookmark,
+  broadcast,
   bullets,
   calendar,
   call,


### PR DESCRIPTION
Broadcast icon added in #1509 was not correctly exported.