### PR TITLE
chore(Tree): rename to HierarchicalTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING CHANGES
 - Fix `firstFocusableSelector` in `FocusTrapZone` and `AutoFocusZone` @sophieH29 ([#1732](https://github.com/stardust-ui/react/pull/1732))
+- Rename `Tree` to `HierarchicalTree` @silviuavram ([#1752](https://github.com/stardust-ui/react/pull/1752))
 
 ### Fixes
 - Require `name` prop in `Icon` component @lucivpav ([#1723](https://github.com/stardust-ui/react/pull/1723))

--- a/build/gulp/tasks/test-circulars/config.ts
+++ b/build/gulp/tasks/test-circulars/config.ts
@@ -3,7 +3,10 @@ import config from '../../../../config'
 const reactPackageDist = (filePath: string) => config.paths.packageDist('react', 'es', filePath)
 
 export const cyclesToSkip = [
-  [reactPackageDist('components/Tree/Tree.js'), reactPackageDist('components/Tree/TreeItem.js')],
+  [
+    reactPackageDist('components/HierarchicalTree/HierarchicalTree.js'),
+    reactPackageDist('components/HierarchicalTree/HierarchicalTreeItem.js'),
+  ],
   [reactPackageDist('components/Menu/Menu.js'), reactPackageDist('components/Menu/MenuItem.js')],
   [
     reactPackageDist('components/Button/Button.js'),

--- a/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebarSection.tsx
+++ b/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebarSection.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
-import { Icon, Tree } from '@stardust-ui/react'
+import { Icon, HierarchicalTree } from '@stardust-ui/react'
 
 import { examplePathToHash } from 'docs/src/utils'
 
@@ -103,6 +103,6 @@ export default class ComponentSidebarSection extends React.PureComponent<any, an
       </Component>
     )
 
-    return <Tree items={items} renderItemTitle={titleRenderer} />
+    return <HierarchicalTree items={items} renderItemTitle={titleRenderer} />
   }
 }

--- a/docs/src/components/ComponentPlayground/ComponentPlayground.tsx
+++ b/docs/src/components/ComponentPlayground/ComponentPlayground.tsx
@@ -19,6 +19,7 @@ const unsupportedComponents = [
   'Flex',
   'Form',
   'Grid',
+  'HierarchicalTree',
   'ItemLayout',
   'Layout',
   'List',
@@ -26,7 +27,6 @@ const unsupportedComponents = [
   'Provider',
   'RadioGroup',
   'Toolbar',
-  'Tree',
 ]
 
 const ComponentPlayground: React.FunctionComponent<ComponentPlaygroundProps> = props => {

--- a/docs/src/components/DocsLayout.tsx
+++ b/docs/src/components/DocsLayout.tsx
@@ -96,7 +96,7 @@ class DocsLayout extends React.Component<any, any> {
           theme={mergeThemes(themes.teamsDark, {
             // adjust Teams' theme to Semantic UI's font size scheme
             componentVariables: {
-              TreeItem: {
+              HierarchicalTreeItem: {
                 padding: `${pxToRem(7)} ${pxToRem(16)}`,
                 textDecoration: 'none',
                 fontSize: pxToRem(12),
@@ -109,13 +109,13 @@ class DocsLayout extends React.Component<any, any> {
               },
             },
             componentStyles: {
-              TreeItem: {
+              HierarchicalTreeItem: {
                 root: ({ variables: v, props: p }) => ({
                   ...(!p.items && treeItemStyle),
                   ...(p.items && treeSectionStyle),
                 }),
               },
-              TreeTitle: {
+              HierarchicalTreeTitle: {
                 root: {
                   display: 'block',
                   width: '100%',

--- a/docs/src/components/Sidebar/Sidebar.tsx
+++ b/docs/src/components/Sidebar/Sidebar.tsx
@@ -1,15 +1,15 @@
 import {
   Icon,
-  Tree,
+  HierarchicalTree,
   Segment,
   Text,
   ICSSInJSStyle,
-  TreeItemProps,
-  TreeProps,
+  HierarchicalTreeItemProps,
+  HierarchicalTreeProps,
   Input,
   Flex,
   Box,
-  TreeTitleProps,
+  HierarchicalTreeTitleProps,
 } from '@stardust-ui/react'
 import { ShorthandValue } from '../../../../packages/react/src/types'
 import Logo from 'docs/src/components/Logo/Logo'
@@ -51,7 +51,7 @@ class Sidebar extends React.Component<any, any> {
   }
 
   findActiveCategoryIndex = (at: string, sections: ShorthandValue<any>[]): number => {
-    return _.findIndex(sections, (section: ShorthandValue<TreeItemProps>) => {
+    return _.findIndex(sections, (section: ShorthandValue<HierarchicalTreeItemProps>) => {
       return _.find((section as any).items, item => item.title.to === at)
     })
   }
@@ -65,7 +65,7 @@ class Sidebar extends React.Component<any, any> {
     if (!hasModifier && isAZ && bodyHasFocus) this.searchInputRef.current.focus()
   }
 
-  handleItemClick = (e: React.SyntheticEvent, data: TreeItemProps) => {
+  handleItemClick = (e: React.SyntheticEvent, data: HierarchicalTreeItemProps) => {
     const { query } = this.state
 
     if (query) {
@@ -76,7 +76,7 @@ class Sidebar extends React.Component<any, any> {
     }
   }
 
-  treeActiveIndexChanged = (e: React.SyntheticEvent, props: TreeProps) => {
+  treeActiveIndexChanged = (e: React.SyntheticEvent, props: HierarchicalTreeProps) => {
     this.setState({ activeCategoryIndex: props.activeIndex })
   }
 
@@ -120,7 +120,7 @@ class Sidebar extends React.Component<any, any> {
     }
   }
 
-  getTreeItems(): TreeProps['items'] {
+  getTreeItems(): HierarchicalTreeProps['items'] {
     return [
       {
         key: 'concepts',
@@ -246,7 +246,7 @@ class Sidebar extends React.Component<any, any> {
     this.setState({ query: data.value })
   }
 
-  getSectionsWithoutSearchFilter = (): TreeItemProps[] => {
+  getSectionsWithoutSearchFilter = (): HierarchicalTreeItemProps[] => {
     const treeItemsByType = _.map(constants.typeOrder, nextType => {
       const items = _.chain([...componentMenu, ...behaviorMenu])
         .filter(({ type }) => type === nextType)
@@ -379,11 +379,11 @@ class Sidebar extends React.Component<any, any> {
     const regexQuery = new RegExp(`^${escapedQuery}`, 'i')
     const allSectionsWithPossibleEmptySections = _.map(
       allSectionsWithoutSearchFilter,
-      (section: TreeItemProps) => {
+      (section: HierarchicalTreeItemProps) => {
         return {
           ...section,
-          items: _.filter(section.items as TreeItemProps[], item =>
-            regexQuery.test((item.title as TreeTitleProps).content as string),
+          items: _.filter(section.items as HierarchicalTreeItemProps[], item =>
+            regexQuery.test((item.title as HierarchicalTreeTitleProps).content as string),
           ),
         }
       },
@@ -391,11 +391,12 @@ class Sidebar extends React.Component<any, any> {
 
     let allSections = _.filter(
       allSectionsWithPossibleEmptySections,
-      (section: TreeItemProps) => Array.isArray(section.items) && section.items.length > 0,
+      (section: HierarchicalTreeItemProps) =>
+        Array.isArray(section.items) && section.items.length > 0,
     )
 
     if (this.state.query !== '') {
-      allSections = _.map(allSections, (section: TreeItemProps) => {
+      allSections = _.map(allSections, (section: HierarchicalTreeItemProps) => {
         return { ...section, open: true }
       })
     }
@@ -467,7 +468,7 @@ class Sidebar extends React.Component<any, any> {
             inputRef={this.searchInputRef}
           />
         </Flex>
-        <Tree
+        <HierarchicalTree
           items={allSections}
           renderItemTitle={titleRenderer}
           activeIndex={this.state.activeCategoryIndex}

--- a/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeExample.shorthand.tsx
+++ b/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Tree } from '@stardust-ui/react'
+import { HierarchicalTree } from '@stardust-ui/react'
 
 const items = [
   {
@@ -70,6 +70,6 @@ const items = [
   },
 ]
 
-const TreeExampleShorthand = () => <Tree items={items} />
+const TreeExampleShorthand = () => <HierarchicalTree items={items} />
 
 export default TreeExampleShorthand

--- a/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeExclusiveExample.shorthand.tsx
+++ b/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeExclusiveExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Icon, Tree } from '@stardust-ui/react'
+import { Icon, HierarchicalTree } from '@stardust-ui/react'
 
 const items = [
   {
@@ -47,6 +47,8 @@ const titleRenderer = (Component, { content, open, hasSubtree, ...restProps }) =
   </Component>
 )
 
-const TreeExclusiveExample = () => <Tree items={items} renderItemTitle={titleRenderer} exclusive />
+const TreeExclusiveExample = () => (
+  <HierarchicalTree items={items} renderItemTitle={titleRenderer} exclusive />
+)
 
 export default TreeExclusiveExample

--- a/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeTitleCustomizationExample.shorthand.tsx
+++ b/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeTitleCustomizationExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Icon, Tree } from '@stardust-ui/react'
+import { Icon, HierarchicalTree } from '@stardust-ui/react'
 
 const items = [
   {
@@ -37,6 +37,8 @@ const titleRenderer = (Component, { content, open, hasSubtree, ...restProps }) =
   </Component>
 )
 
-const TreeTitleCustomizationExample = () => <Tree items={items} renderItemTitle={titleRenderer} />
+const TreeTitleCustomizationExample = () => (
+  <HierarchicalTree items={items} renderItemTitle={titleRenderer} />
+)
 
 export default TreeTitleCustomizationExample

--- a/docs/src/examples/components/HierarchicalTree/Types/index.tsx
+++ b/docs/src/examples/components/HierarchicalTree/Types/index.tsx
@@ -7,17 +7,17 @@ const Types = () => (
     <ComponentExample
       title="Default"
       description="A default Tree."
-      examplePath="components/Tree/Types/TreeExample"
+      examplePath="components/HierarchicalTree/Types/HierarchicalTreeExample"
     />
     <ComponentExample
       title="Custom Title"
       description="A Tree with customized title rendering."
-      examplePath="components/Tree/Types/TreeTitleCustomizationExample"
+      examplePath="components/HierarchicalTree/Types/HierarchicalTreeTitleCustomizationExample"
     />
     <ComponentExample
       title="Exclusive"
       description="A Tree with only one subtree open at a time."
-      examplePath="components/Tree/Types/TreeExclusiveExample"
+      examplePath="components/HierarchicalTree/Types/HierarchicalTreeExclusiveExample"
     />
   </ExampleSection>
 )

--- a/docs/src/examples/components/HierarchicalTree/index.tsx
+++ b/docs/src/examples/components/HierarchicalTree/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import Types from './Types'
 
-const TreeExamples = () => (
+const HierarchicalTreeExamples = () => (
   <div>
     <Types />
   </div>
 )
 
-export default TreeExamples
+export default HierarchicalTreeExamples

--- a/e2e/tests/hierarchicalTree-example.tsx
+++ b/e2e/tests/hierarchicalTree-example.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Tree, TreeItem, TreeTitle } from '@stardust-ui/react'
+import * as React from 'react'
+import { HierarchicalTree, HierarchicalTreeItem, HierarchicalTreeTitle } from '@stardust-ui/react'
 
 const items = [
   {
@@ -71,11 +71,11 @@ const items = [
 ]
 
 export const selectors = {
-  treeClass: Tree.className,
-  treeItemClass: TreeItem.className,
-  treeTitleClass: TreeTitle.className,
+  treeClass: HierarchicalTree.className,
+  treeItemClass: HierarchicalTreeItem.className,
+  treeTitleClass: HierarchicalTreeTitle.className,
 }
 
-const TreeExample = () => <Tree items={items} />
+const TreeExample = () => <HierarchicalTree items={items} />
 
 export default TreeExample

--- a/e2e/tests/hierarchicalTree-test.ts
+++ b/e2e/tests/hierarchicalTree-test.ts
@@ -1,4 +1,4 @@
-import { selectors } from './tree-example'
+import { selectors } from './hierarchicalTree-example'
 
 const tree = `.${selectors.treeClass}`
 const treeItem = index => `.${selectors.treeItemClass}:nth-child(${index})`

--- a/e2e/tests/hierarchicalTree-test.ts
+++ b/e2e/tests/hierarchicalTree-test.ts
@@ -4,7 +4,7 @@ const tree = `.${selectors.treeClass}`
 const treeItem = index => `.${selectors.treeItemClass}:nth-child(${index})`
 const treeTitle = index => `.${selectors.treeTitleClass}:nth-child(${index})`
 
-describe('Tree', () => {
+describe('HierarchialTree', () => {
   describe('Focus behavior', () => {
     beforeEach(async () => {
       await e2e.gotoTestCase(__filename, tree)

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
@@ -208,7 +208,7 @@ HierarchicalTree.create = createShorthandFactory({
 })
 
 /**
- * A Tree displays data organised in tree hierarchy.
+ * (DEPRECATED) A Tree displays data organised in tree hierarchy.
  *
  * @accessibility
  * Implements [ARIA TreeView](https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView) design pattern.

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
-import TreeItem, { TreeItemProps } from './TreeItem'
+import HierarchicalTreeItem, { HierarchicalTreeItemProps } from './HierarchicalTreeItem'
 import {
   AutoControlledComponent,
   childrenExist,
@@ -23,13 +23,13 @@ import {
   ComponentEventHandler,
 } from '../../types'
 import { Accessibility } from '../../lib/accessibility/types'
-import { treeBehavior } from '../../lib/accessibility'
+import { hierarchicalTreeBehavior } from '../../lib/accessibility'
 
-export interface TreeSlotClassNames {
+export interface HierarchicalTreeSlotClassNames {
   item: string
 }
 
-export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
+export interface HierarchicalTreeProps extends UIComponentProps, ChildrenComponentProps {
   /** Index of the currently active subtree. */
   activeIndex?: number[] | number
 
@@ -43,7 +43,7 @@ export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
   exclusive?: boolean
 
   /** Shorthand array of props for Tree. */
-  items?: ShorthandCollection<TreeItemProps>
+  items?: ShorthandCollection<HierarchicalTreeItemProps>
 
   /**
    * A custom render function for the title slot.
@@ -59,22 +59,25 @@ export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props and proposed value.
    */
-  onActiveIndexChange?: ComponentEventHandler<TreeProps>
+  onActiveIndexChange?: ComponentEventHandler<HierarchicalTreeProps>
 }
 
-export interface TreeState {
+export interface HierarchicalTreeState {
   activeIndex: number[] | number
 }
 
-class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
+class HierarchicalTree extends AutoControlledComponent<
+  WithAsProp<HierarchicalTreeProps>,
+  HierarchicalTreeState
+> {
   static create: Function
 
-  static displayName = 'Tree'
+  static displayName = 'HierarchicalTree'
 
-  static className = 'ui-tree'
+  static className = 'ui-hierarchicaltree'
 
-  static slotClassNames: TreeSlotClassNames = {
-    item: `${Tree.className}__item`,
+  static slotClassNames: HierarchicalTreeSlotClassNames = {
+    item: `${HierarchicalTree.className}__item`,
   }
 
   static propTypes = {
@@ -98,7 +101,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
   static defaultProps = {
     as: 'ul',
-    accessibility: treeBehavior,
+    accessibility: hierarchicalTreeBehavior,
   }
 
   static autoControlledProps = ['activeIndex']
@@ -129,7 +132,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     _.invoke(this.props, 'onActiveIndexChange', e, { ...this.props, activeIndex })
   }
 
-  getInitialAutoControlledState({ exclusive }): TreeState {
+  getInitialAutoControlledState({ exclusive }): HierarchicalTreeState {
     return {
       activeIndex: exclusive ? -1 : [],
     }
@@ -140,7 +143,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     return _.isArray(activeIndex) ? activeIndex : [activeIndex]
   }
 
-  computeNewIndex = (treeItemProps: TreeItemProps) => {
+  computeNewIndex = (treeItemProps: HierarchicalTreeItemProps) => {
     const { index, items } = treeItemProps
     const activeIndexes = this.getActiveIndexes()
     const { exclusive } = this.props
@@ -156,8 +159,8 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
       : [...activeIndexes, index]
   }
 
-  handleTreeItemOverrides = (predefinedProps: TreeItemProps) => ({
-    onTitleClick: (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => {
+  handleTreeItemOverrides = (predefinedProps: HierarchicalTreeItemProps) => ({
+    onTitleClick: (e: React.SyntheticEvent, treeItemProps: HierarchicalTreeItemProps) => {
       this.trySetActiveIndexAndTriggerEvent(e, this.computeNewIndex(treeItemProps))
       _.invoke(predefinedProps, 'onTitleClick', e, treeItemProps)
     },
@@ -168,10 +171,10 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     const { activeIndex } = this.state
     const activeIndexes = this.getActiveIndexes()
 
-    return _.map(items, (item: ShorthandValue<TreeItemProps>, index: number) =>
-      TreeItem.create(item, {
+    return _.map(items, (item: ShorthandValue<HierarchicalTreeItemProps>, index: number) =>
+      HierarchicalTreeItem.create(item, {
         defaultProps: {
-          className: Tree.slotClassNames.item,
+          className: HierarchicalTree.slotClassNames.item,
           index,
           exclusive,
           renderItemTitle,
@@ -199,7 +202,10 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
   }
 }
 
-Tree.create = createShorthandFactory({ Component: Tree, mappedArrayProp: 'items' })
+HierarchicalTree.create = createShorthandFactory({
+  Component: HierarchicalTree,
+  mappedArrayProp: 'items',
+})
 
 /**
  * A Tree displays data organised in tree hierarchy.
@@ -207,4 +213,6 @@ Tree.create = createShorthandFactory({ Component: Tree, mappedArrayProp: 'items'
  * @accessibility
  * Implements [ARIA TreeView](https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView) design pattern.
  */
-export default withSafeTypeForAs<typeof Tree, TreeProps, 'ul'>(Tree)
+export default withSafeTypeForAs<typeof HierarchicalTree, HierarchicalTreeProps, 'ul'>(
+  HierarchicalTree,
+)

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
@@ -4,9 +4,9 @@ import * as _ from 'lodash'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
-import Tree, { TreeProps } from './Tree'
-import TreeTitle, { TreeTitleProps } from './TreeTitle'
-import { treeItemBehavior, subtreeBehavior } from '../../lib/accessibility'
+import HierarchicalTree, { HierarchicalTreeProps } from './HierarchicalTree'
+import HierarchicalTreeTitle, { HierarchicalTreeTitleProps } from './HierarchicalTreeTitle'
+import { hierarchicalTreeItemBehavior, hierarchicalSubtreeBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 import {
   UIComponent,
@@ -28,12 +28,12 @@ import {
 } from '../../types'
 import { getFirstFocusable } from '../../lib/accessibility/FocusZone/focusUtilities'
 
-export interface TreeItemSlotClassNames {
+export interface HierarchicalTreeItemSlotClassNames {
   title: string
   subtree: string
 }
 
-export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps {
+export interface HierarchicalTreeItemProps extends UIComponentProps, ChildrenComponentProps {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility
 
@@ -44,10 +44,10 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   index?: number
 
   /** Array of props for sub tree. */
-  items?: ShorthandValue<TreeProps> | ShorthandCollection<TreeItemProps>
+  items?: ShorthandValue<HierarchicalTreeProps> | ShorthandCollection<HierarchicalTreeItemProps>
 
   /** Called when a tree title is clicked. */
-  onTitleClick?: ComponentEventHandler<TreeItemProps>
+  onTitleClick?: ComponentEventHandler<HierarchicalTreeItemProps>
 
   /** Whether or not the subtree of the item is in the open state. */
   open?: boolean
@@ -63,19 +63,19 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   renderItemTitle?: ShorthandRenderFunction
 
   /** Properties for TreeTitle. */
-  title?: ShorthandValue<TreeTitleProps>
+  title?: ShorthandValue<HierarchicalTreeTitleProps>
 }
 
-class TreeItem extends UIComponent<WithAsProp<TreeItemProps>> {
+class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemProps>> {
   static create: Function
 
-  static displayName = 'TreeItem'
+  static displayName = 'HierarchicalTreeItem'
 
-  static className = 'ui-tree__item'
+  static className = 'ui-hierarchicaltree__item'
 
-  static slotClassNames: TreeItemSlotClassNames = {
-    title: `${TreeItem.className}__title`,
-    subtree: `${TreeItem.className}__subtree`,
+  static slotClassNames: HierarchicalTreeItemSlotClassNames = {
+    title: `${HierarchicalTreeItem.className}__title`,
+    subtree: `${HierarchicalTreeItem.className}__subtree`,
   }
 
   static propTypes = {
@@ -94,7 +94,7 @@ class TreeItem extends UIComponent<WithAsProp<TreeItemProps>> {
 
   static defaultProps = {
     as: 'li',
-    accessibility: treeItemBehavior,
+    accessibility: hierarchicalTreeItemBehavior,
   }
 
   itemRef = React.createRef<HTMLElement>()
@@ -150,7 +150,7 @@ class TreeItem extends UIComponent<WithAsProp<TreeItemProps>> {
     _.invoke(this.props, 'onTitleClick', e, this.props)
   }
 
-  handleTitleOverrides = (predefinedProps: TreeTitleProps) => ({
+  handleTitleOverrides = (predefinedProps: HierarchicalTreeTitleProps) => ({
     onClick: (e, titleProps) => {
       this.handleTitleClick(e)
       _.invoke(predefinedProps, 'onClick', e, titleProps)
@@ -163,9 +163,9 @@ class TreeItem extends UIComponent<WithAsProp<TreeItemProps>> {
 
     return (
       <>
-        {TreeTitle.create(title, {
+        {HierarchicalTreeTitle.create(title, {
           defaultProps: {
-            className: TreeItem.slotClassNames.title,
+            className: HierarchicalTreeItem.slotClassNames.title,
             open,
             hasSubtree,
             as: hasSubtree ? 'span' : 'a',
@@ -175,10 +175,10 @@ class TreeItem extends UIComponent<WithAsProp<TreeItemProps>> {
         })}
         {hasSubtree && open && (
           <Ref innerRef={this.treeRef}>
-            {Tree.create(items, {
+            {HierarchicalTree.create(items, {
               defaultProps: {
-                accessibility: subtreeBehavior,
-                className: TreeItem.slotClassNames.subtree,
+                accessibility: hierarchicalSubtreeBehavior,
+                className: HierarchicalTreeItem.slotClassNames.subtree,
                 exclusive,
                 renderItemTitle,
               },
@@ -208,7 +208,10 @@ class TreeItem extends UIComponent<WithAsProp<TreeItemProps>> {
   }
 }
 
-TreeItem.create = createShorthandFactory({ Component: TreeItem, mappedProp: 'title' })
+HierarchicalTreeItem.create = createShorthandFactory({
+  Component: HierarchicalTreeItem,
+  mappedProp: 'title',
+})
 
 /**
  * A TreeItem renders an item of a Tree.
@@ -216,4 +219,6 @@ TreeItem.create = createShorthandFactory({ Component: TreeItem, mappedProp: 'tit
  * @accessibility
  * Implements [ARIA TreeView](https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView) design pattern.
  */
-export default withSafeTypeForAs<typeof TreeItem, TreeItemProps, 'li'>(TreeItem)
+export default withSafeTypeForAs<typeof HierarchicalTreeItem, HierarchicalTreeItemProps, 'li'>(
+  HierarchicalTreeItem,
+)

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
@@ -13,11 +13,11 @@ import {
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
 } from '../../lib'
-import { treeTitleBehavior } from '../../lib/accessibility'
+import { hierarchicalTreeTitleBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 import { ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
 
-export interface TreeTitleProps
+export interface HierarchicalTreeTitleProps
   extends UIComponentProps,
     ChildrenComponentProps,
     ContentComponentProps {
@@ -30,7 +30,7 @@ export interface TreeTitleProps
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props.
    */
-  onClick?: ComponentEventHandler<TreeTitleProps>
+  onClick?: ComponentEventHandler<HierarchicalTreeTitleProps>
 
   /** Whether or not the subtree of the item is in the open state. */
   open?: boolean
@@ -39,12 +39,12 @@ export interface TreeTitleProps
   hasSubtree?: boolean
 }
 
-class TreeTitle extends UIComponent<WithAsProp<TreeTitleProps>> {
+class HierarchicalTreeTitle extends UIComponent<WithAsProp<HierarchicalTreeTitleProps>> {
   static create: Function
 
-  static className = 'ui-tree__title'
+  static className = 'ui-hierarchicaltree__title'
 
-  static displayName = 'TreeTitle'
+  static displayName = 'HierarchicalTreeTitle'
 
   static propTypes = {
     ...commonPropTypes.createCommon(),
@@ -55,7 +55,7 @@ class TreeTitle extends UIComponent<WithAsProp<TreeTitleProps>> {
 
   static defaultProps = {
     as: 'a',
-    accessibility: treeTitleBehavior,
+    accessibility: hierarchicalTreeTitleBehavior,
   }
 
   actionHandlers = {
@@ -87,9 +87,14 @@ class TreeTitle extends UIComponent<WithAsProp<TreeTitleProps>> {
   }
 }
 
-TreeTitle.create = createShorthandFactory({ Component: TreeTitle, mappedProp: 'content' })
+HierarchicalTreeTitle.create = createShorthandFactory({
+  Component: HierarchicalTreeTitle,
+  mappedProp: 'content',
+})
 
 /**
  * A TreeTitle renders a title of TreeItem.
  */
-export default withSafeTypeForAs<typeof TreeTitle, TreeTitleProps, 'a'>(TreeTitle)
+export default withSafeTypeForAs<typeof HierarchicalTreeTitle, HierarchicalTreeTitleProps, 'a'>(
+  HierarchicalTreeTitle,
+)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -168,12 +168,14 @@ export { default as ToolbarMenuItem } from './components/Toolbar/ToolbarMenuItem
 export * from './components/Toolbar/ToolbarRadioGroup'
 export { default as ToolbarRadioGroup } from './components/Toolbar/ToolbarRadioGroup'
 
-export * from './components/Tree/Tree'
-export { default as Tree } from './components/Tree/Tree'
-export * from './components/Tree/TreeItem'
-export { default as TreeItem } from './components/Tree/TreeItem'
-export * from './components/Tree/TreeTitle'
-export { default as TreeTitle } from './components/Tree/TreeTitle'
+export * from './components/HierarchicalTree/HierarchicalTree'
+export { default as HierarchicalTree } from './components/HierarchicalTree/HierarchicalTree'
+export * from './components/HierarchicalTree/HierarchicalTreeItem'
+export { default as HierarchicalTreeItem } from './components/HierarchicalTree/HierarchicalTreeItem'
+export * from './components/HierarchicalTree/HierarchicalTreeTitle'
+export {
+  default as HierarchicalTreeTitle,
+} from './components/HierarchicalTree/HierarchicalTreeTitle'
 
 export * from './components/Reaction/Reaction'
 export { default as Reaction } from './components/Reaction/Reaction'

--- a/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalSubtreeBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalSubtreeBehavior.ts
@@ -6,7 +6,7 @@ import * as keyboardKey from 'keyboard-key'
  * Triggers 'expandSiblings' action with '*' on 'root'.
  * Adds role 'group' to 'root' slot.
  */
-const subtreeBehavior: Accessibility = () => ({
+const hierarchicalSubtreeBehavior: Accessibility = () => ({
   attributes: {
     root: {
       role: 'group',
@@ -21,4 +21,4 @@ const subtreeBehavior: Accessibility = () => ({
   },
 })
 
-export default subtreeBehavior
+export default hierarchicalSubtreeBehavior

--- a/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalTreeBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalTreeBehavior.ts
@@ -1,6 +1,6 @@
 import { Accessibility, AccessibilityAttributes, FocusZoneMode } from '../../types'
 import { FocusZoneDirection } from '../../FocusZone'
-import subtreeBehavior from './subtreeBehavior'
+import hierarchicalSubtreeBehavior from './hierarchicalSubtreeBehavior'
 
 /**
  * @specification
@@ -10,8 +10,8 @@ import subtreeBehavior from './subtreeBehavior'
  * Provides arrow key navigation in vertical direction.
  * Triggers 'expandSiblings' action with '*' on 'root'.
  */
-const treeBehavior: Accessibility<TreeBehaviorProps> = props => {
-  const subtreeBehaviorData = subtreeBehavior({})
+const hierarchicalTreeBehavior: Accessibility<TreeBehaviorProps> = props => {
+  const subtreeBehaviorData = hierarchicalSubtreeBehavior({})
   return {
     attributes: {
       root: {
@@ -36,4 +36,4 @@ const treeBehavior: Accessibility<TreeBehaviorProps> = props => {
 
 type TreeBehaviorProps = {} & Pick<AccessibilityAttributes, 'aria-labelledby'>
 
-export default treeBehavior
+export default hierarchicalTreeBehavior

--- a/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalTreeItemBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalTreeItemBehavior.ts
@@ -15,7 +15,7 @@ import { IS_FOCUSABLE_ATTRIBUTE } from '../../FocusZone/focusUtilities'
  * Triggers 'expand' action with 'ArrowRight' on 'root', when has a closed subtree.
  * Triggers 'focusSubtree' action with 'ArrowRight' on 'root', when has an opened subtree.
  */
-const treeItemBehavior: Accessibility<TreeItemBehaviorProps> = props => ({
+const hierarchicalTreeItemBehavior: Accessibility<TreeItemBehaviorProps> = props => ({
   attributes: {
     root: {
       role: 'none',
@@ -66,4 +66,4 @@ const isSubtreeOpen = (props: TreeItemBehaviorProps): boolean => {
   return !!(items && items.length && open)
 }
 
-export default treeItemBehavior
+export default hierarchicalTreeItemBehavior

--- a/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalTreeTitleBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/HierarchicalTree/hierarchicalTreeTitleBehavior.ts
@@ -10,7 +10,7 @@ import { IS_FOCUSABLE_ATTRIBUTE } from '../../FocusZone/focusUtilities'
  * @specification
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  */
-const treeTitleBehavior: Accessibility<TreeTitleBehavior> = props => ({
+const hierarchicalTreeTitleBehavior: Accessibility<TreeTitleBehavior> = props => ({
   attributes: {
     root: {
       ...(!props.hasSubtree && {
@@ -29,7 +29,7 @@ const treeTitleBehavior: Accessibility<TreeTitleBehavior> = props => ({
   },
 })
 
-export default treeTitleBehavior
+export default hierarchicalTreeTitleBehavior
 
 type TreeTitleBehavior = {
   /** Indicated if tree title has a subtree */

--- a/packages/react/src/lib/accessibility/index.ts
+++ b/packages/react/src/lib/accessibility/index.ts
@@ -36,10 +36,18 @@ export { default as chatBehavior } from './Behaviors/Chat/chatBehavior'
 export { default as chatMessageBehavior } from './Behaviors/Chat/chatMessageBehavior'
 export { default as gridBehavior } from './Behaviors/Grid/gridBehavior'
 export { default as gridHorizontalBehavior } from './Behaviors/Grid/gridHorizontalBehavior'
-export { default as treeBehavior } from './Behaviors/Tree/treeBehavior'
-export { default as treeItemBehavior } from './Behaviors/Tree/treeItemBehavior'
-export { default as treeTitleBehavior } from './Behaviors/Tree/treeTitleBehavior'
-export { default as subtreeBehavior } from './Behaviors/Tree/subtreeBehavior'
+export {
+  default as hierarchicalTreeBehavior,
+} from './Behaviors/HierarchicalTree/hierarchicalTreeBehavior'
+export {
+  default as hierarchicalTreeItemBehavior,
+} from './Behaviors/HierarchicalTree/hierarchicalTreeItemBehavior'
+export {
+  default as hierarchicalTreeTitleBehavior,
+} from './Behaviors/HierarchicalTree/hierarchicalTreeTitleBehavior'
+export {
+  default as hierarchicalSubtreeBehavior,
+} from './Behaviors/HierarchicalTree/hierarchicalSubtreeBehavior'
 export { default as dialogBehavior } from './Behaviors/Dialog/dialogBehavior'
 export { default as statusBehavior } from './Behaviors/Status/statusBehavior'
 export { default as embedBehavior } from './Behaviors/Embed/embedBehavior'

--- a/packages/react/src/themes/teams-dark/componentVariables.ts
+++ b/packages/react/src/themes/teams-dark/componentVariables.ts
@@ -11,7 +11,9 @@ export { default as ListItem } from './components/List/listItemVariables'
 export { default as RadioGroupItem } from './components/RadioGroup/radioGroupItemVariables'
 export { default as Segment } from './components/Segment/segmentVariables'
 export { default as Text } from './components/Text/textVariables'
-export { default as TreeTitle } from './components/Tree/treeTitleVariables'
+export {
+  default as HierarchicalTreeTitle,
+} from './components/HierarchicalTree/hierarchicalTreeTitleVariables'
 export { default as Menu } from './components/Menu/menuVariables'
 export { default as Icon } from './components/Icon/iconVariables'
 export { default as Reaction } from './components/Reaction/reactionVariables'

--- a/packages/react/src/themes/teams-dark/components/HierarchicalTree/hierarchicalTreeTitleVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/HierarchicalTree/hierarchicalTreeTitleVariables.ts
@@ -1,0 +1,7 @@
+import { HierarchicalTreeTitleVariables } from '../../../teams/components/HierarchicalTree/hierarchicalTreeTitleVariables'
+
+export default (siteVars: any): HierarchicalTreeTitleVariables => {
+  return {
+    defaultColor: siteVars.colors.white,
+  }
+}

--- a/packages/react/src/themes/teams-dark/components/Tree/treeTitleVariables.ts
+++ b/packages/react/src/themes/teams-dark/components/Tree/treeTitleVariables.ts
@@ -1,7 +1,0 @@
-import { TreeTitleVariables } from '../../../teams/components/Tree/treeTitleVariables'
-
-export default (siteVars: any): TreeTitleVariables => {
-  return {
-    defaultColor: siteVars.colors.white,
-  }
-}

--- a/packages/react/src/themes/teams-high-contrast/componentVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/componentVariables.ts
@@ -14,7 +14,9 @@ export { default as RadioGroupItem } from './components/RadioGroup/radioGroupIte
 export { default as Segment } from './components/Segment/segmentVariables'
 export { default as Text } from './components/Text/textVariables'
 export { default as Toolbar } from './components/Toolbar/toolbarVariables'
-export { default as TreeTitle } from './components/Tree/treeTitleVariables'
+export {
+  default as HierarchicalTreeTitle,
+} from './components/HierarchicalTree/hierarchicalTreeTitleVariables'
 export { default as Status } from './components/Status/statusVariables'
 export { default as Reaction } from './components/Reaction/reactionVariables'
 export { default as Alert } from './components/Alert/alertVariables'

--- a/packages/react/src/themes/teams-high-contrast/components/HierarchicalTree/hierarchicalTreeTitleVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/HierarchicalTree/hierarchicalTreeTitleVariables.ts
@@ -1,0 +1,7 @@
+import { HierarchicalTreeTitleVariables } from '../../../teams/components/HierarchicalTree/hierarchicalTreeTitleVariables'
+
+export default (siteVars: any): HierarchicalTreeTitleVariables => {
+  return {
+    defaultColor: siteVars.colors.white,
+  }
+}

--- a/packages/react/src/themes/teams-high-contrast/components/Tree/treeTitleVariables.ts
+++ b/packages/react/src/themes/teams-high-contrast/components/Tree/treeTitleVariables.ts
@@ -1,7 +1,0 @@
-import { TreeTitleVariables } from '../../../teams/components/Tree/treeTitleVariables'
-
-export default (siteVars: any): TreeTitleVariables => {
-  return {
-    defaultColor: siteVars.colors.white,
-  }
-}

--- a/packages/react/src/themes/teams/componentStyles.ts
+++ b/packages/react/src/themes/teams/componentStyles.ts
@@ -78,9 +78,13 @@ export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuStyles'
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerStyles'
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemStyles'
 
-export { default as Tree } from './components/Tree/treeStyles'
-export { default as TreeItem } from './components/Tree/treeItemStyles'
-export { default as TreeTitle } from './components/Tree/treeTitleStyles'
+export { default as HierarchicalTree } from './components/HierarchicalTree/hierarchicalTreeStyles'
+export {
+  default as HierarchicalTreeItem,
+} from './components/HierarchicalTree/hierarchicalTreeItemStyles'
+export {
+  default as HierarchicalTreeTitle,
+} from './components/HierarchicalTree/hierarchicalTreeTitleStyles'
 
 export { default as Animation } from './components/Animation/animationStyles'
 

--- a/packages/react/src/themes/teams/componentVariables.ts
+++ b/packages/react/src/themes/teams/componentVariables.ts
@@ -75,7 +75,9 @@ export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuVariable
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerVariables'
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemVariables'
 
-export { default as TreeTitle } from './components/HierarchicalTree/hierarchicalTreeTitleVariables'
+export {
+  default as HierarchicalTreeTitle,
+} from './components/HierarchicalTree/hierarchicalTreeTitleVariables'
 
 export { default as Animation } from './components/Animation/animationVariables'
 

--- a/packages/react/src/themes/teams/componentVariables.ts
+++ b/packages/react/src/themes/teams/componentVariables.ts
@@ -75,7 +75,7 @@ export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuVariable
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerVariables'
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemVariables'
 
-export { default as TreeTitle } from './components/Tree/treeTitleVariables'
+export { default as TreeTitle } from './components/HierarchicalTree/hierarchicalTreeTitleVariables'
 
 export { default as Animation } from './components/Animation/animationVariables'
 

--- a/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeItemStyles.ts
+++ b/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeItemStyles.ts
@@ -1,15 +1,15 @@
 import { ICSSInJSStyle } from '../../../types'
 import { pxToRem } from '../../../../lib'
 import getBorderFocusStyles from '../../getBorderFocusStyles'
-import TreeTitle from '../../../../components/Tree/TreeTitle'
+import HierarchicalTreeTitle from '../../../../components/HierarchicalTree/HierarchicalTreeTitle'
 
-const treeItemStyles = {
+const hierarchicalTreeItemStyles = {
   root: ({ theme: { siteVariables } }): ICSSInJSStyle => ({
     listStyleType: 'none',
     padding: `0 0 0 ${pxToRem(1)}`,
     ':focus': {
       outline: 0,
-      [`> .${TreeTitle.className}`]: {
+      [`> .${HierarchicalTreeTitle.className}`]: {
         position: 'relative',
         ...getBorderFocusStyles({
           siteVariables,
@@ -20,4 +20,4 @@ const treeItemStyles = {
   }),
 }
 
-export default treeItemStyles
+export default hierarchicalTreeItemStyles

--- a/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeStyles.ts
+++ b/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeStyles.ts
@@ -1,11 +1,11 @@
 import { ICSSInJSStyle } from '../../../types'
 import { pxToRem } from '../../../../lib'
 
-const treeStyles = {
+const hierarchicalTreeStyles = {
   root: (): ICSSInJSStyle => ({
     display: 'block',
     paddingLeft: `${pxToRem(10)}`,
   }),
 }
 
-export default treeStyles
+export default hierarchicalTreeStyles

--- a/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeTitleStyles.ts
+++ b/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeTitleStyles.ts
@@ -2,7 +2,7 @@ import { ICSSInJSStyle } from '../../../types'
 import { pxToRem } from '../../../../lib'
 import getBorderFocusStyles from '../../getBorderFocusStyles'
 
-const treeTitleStyles = {
+const hierarchicalTreeTitleStyles = {
   root: ({ variables, theme: { siteVariables } }): ICSSInJSStyle => ({
     padding: `${pxToRem(1)} 0`,
     cursor: 'pointer',
@@ -15,4 +15,4 @@ const treeTitleStyles = {
   }),
 }
 
-export default treeTitleStyles
+export default hierarchicalTreeTitleStyles

--- a/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeTitleVariables.ts
+++ b/packages/react/src/themes/teams/components/HierarchicalTree/hierarchicalTreeTitleVariables.ts
@@ -1,0 +1,9 @@
+export interface HierarchicalTreeTitleVariables {
+  defaultColor: string
+}
+
+export default (siteVars: any): HierarchicalTreeTitleVariables => {
+  return {
+    defaultColor: siteVars.colors.grey[750],
+  }
+}

--- a/packages/react/src/themes/teams/components/Tree/treeTitleVariables.ts
+++ b/packages/react/src/themes/teams/components/Tree/treeTitleVariables.ts
@@ -1,9 +1,0 @@
-export interface TreeTitleVariables {
-  defaultColor: string
-}
-
-export default (siteVars: any): TreeTitleVariables => {
-  return {
-    defaultColor: siteVars.colors.grey[750],
-  }
-}

--- a/packages/react/src/themes/types.ts
+++ b/packages/react/src/themes/types.ts
@@ -53,9 +53,9 @@ import { ToolbarProps } from '../components/Toolbar/Toolbar'
 import { ToolbarRadioGroupProps } from '../components/Toolbar/ToolbarRadioGroup'
 import { TooltipContentProps } from '../components/Tooltip/TooltipContent'
 import { TooltipProps } from '../components/Tooltip/Tooltip'
-import { TreeItemProps } from '../components/Tree/TreeItem'
-import { TreeProps } from '../components/Tree/Tree'
-import { TreeTitleProps } from '../components/Tree/TreeTitle'
+import { HierarchicalTreeItemProps } from '../components/HierarchicalTree/HierarchicalTreeItem'
+import { HierarchicalTreeProps } from '../components/HierarchicalTree/HierarchicalTree'
+import { HierarchicalTreeTitleProps } from '../components/HierarchicalTree/HierarchicalTreeTitle'
 import { VideoProps } from '../components/Video/Video'
 
 // Themes go through 3 phases.
@@ -457,9 +457,9 @@ type ThemeStylesProps = {
   Tooltip?: TooltipProps
   TooltipContent?: TooltipContentProps
   Text?: TextProps
-  Tree?: TreeProps
-  TreeItem?: TreeItemProps
-  TreeTitle?: TreeTitleProps
+  Tree?: HierarchicalTreeProps
+  TreeItem?: HierarchicalTreeItemProps
+  TreeTitle?: HierarchicalTreeTitleProps
   Video?: VideoProps
 }
 

--- a/packages/react/src/themes/types.ts
+++ b/packages/react/src/themes/types.ts
@@ -457,9 +457,9 @@ type ThemeStylesProps = {
   Tooltip?: TooltipProps
   TooltipContent?: TooltipContentProps
   Text?: TextProps
-  Tree?: HierarchicalTreeProps
-  TreeItem?: HierarchicalTreeItemProps
-  TreeTitle?: HierarchicalTreeTitleProps
+  HierarchicalTree?: HierarchicalTreeProps
+  HierarchicalTreeItem?: HierarchicalTreeItemProps
+  HierarchicalTreeTitle?: HierarchicalTreeTitleProps
   Video?: VideoProps
 }
 

--- a/packages/react/test/specs/behaviors/behavior-test.tsx
+++ b/packages/react/test/specs/behaviors/behavior-test.tsx
@@ -31,10 +31,10 @@ import {
   toggleButtonBehavior,
   menuAsToolbarBehavior,
   menuItemAsToolbarButtonBehavior,
-  treeBehavior,
-  treeTitleBehavior,
-  treeItemBehavior,
-  subtreeBehavior,
+  hierarchicalTreeBehavior,
+  hierarchicalTreeTitleBehavior,
+  hierarchicalTreeItemBehavior,
+  hierarchicalSubtreeBehavior,
   gridBehavior,
   gridHorizontalBehavior,
   statusBehavior,
@@ -84,10 +84,10 @@ testHelper.addBehavior('tabListBehavior', tabListBehavior)
 testHelper.addBehavior('menuAsToolbarBehavior', menuAsToolbarBehavior)
 testHelper.addBehavior('toggleButtonBehavior', toggleButtonBehavior)
 testHelper.addBehavior('menuItemAsToolbarButtonBehavior', menuItemAsToolbarButtonBehavior)
-testHelper.addBehavior('treeTitleBehavior', treeTitleBehavior)
-testHelper.addBehavior('treeBehavior', treeBehavior)
-testHelper.addBehavior('treeItemBehavior', treeItemBehavior)
-testHelper.addBehavior('subtreeBehavior', subtreeBehavior)
+testHelper.addBehavior('hierarchicalTreeTitleBehavior', hierarchicalTreeTitleBehavior)
+testHelper.addBehavior('hierarchicalTreeBehavior', hierarchicalTreeBehavior)
+testHelper.addBehavior('hierarchicalTreeItemBehavior', hierarchicalTreeItemBehavior)
+testHelper.addBehavior('hierarchicalSubtreeBehavior', hierarchicalSubtreeBehavior)
 testHelper.addBehavior('gridBehavior', gridBehavior)
 testHelper.addBehavior('gridHorizontalBehavior', gridHorizontalBehavior)
 testHelper.addBehavior('dialogBehavior', dialogBehavior)

--- a/packages/react/test/specs/behaviors/hierarchicalTreeItemBehavior-test.tsx
+++ b/packages/react/test/specs/behaviors/hierarchicalTreeItemBehavior-test.tsx
@@ -1,6 +1,6 @@
 import { hierarchicalTreeItemBehavior } from 'src/lib/accessibility'
 
-describe('TreeItemBehavior', () => {
+describe('HierarchicalTreeItemBehavior', () => {
   describe('tabIndex', () => {
     test(`is added with '0' value to an item that is expandable`, () => {
       const expectedResult = hierarchicalTreeItemBehavior({ items: [{ key: '1' }] })

--- a/packages/react/test/specs/behaviors/hierarchicalTreeTitleBehavior-test.tsx
+++ b/packages/react/test/specs/behaviors/hierarchicalTreeTitleBehavior-test.tsx
@@ -1,6 +1,6 @@
 import { hierarchicalTreeTitleBehavior } from 'src/lib/accessibility'
 
-describe('TreeTitleBehavior', () => {
+describe('HierarchicalTreeTitleBehavior', () => {
   describe('tabIndex', () => {
     test(`is added with '0' value to a title with hasSubtree prop false`, () => {
       const expectedResult = hierarchicalTreeTitleBehavior({ hasSubtree: false })

--- a/packages/react/test/specs/behaviors/treeItemBehavior-test.tsx
+++ b/packages/react/test/specs/behaviors/treeItemBehavior-test.tsx
@@ -1,48 +1,48 @@
-import { treeItemBehavior } from 'src/lib/accessibility'
+import { hierarchicalTreeItemBehavior } from 'src/lib/accessibility'
 
 describe('TreeItemBehavior', () => {
   describe('tabIndex', () => {
     test(`is added with '0' value to an item that is expandable`, () => {
-      const expectedResult = treeItemBehavior({ items: [{ key: '1' }] })
+      const expectedResult = hierarchicalTreeItemBehavior({ items: [{ key: '1' }] })
       expect(expectedResult.attributes.root.tabIndex).toEqual(-1)
     })
 
     test(`is not added to a leaf item (no items)`, () => {
-      const expectedResult = treeItemBehavior({})
+      const expectedResult = hierarchicalTreeItemBehavior({})
       expect(expectedResult.attributes.root.tabIndex).toBeUndefined()
     })
 
     test(`is not added to a leaf item (empty items)`, () => {
-      const expectedResult = treeItemBehavior({ items: [] })
+      const expectedResult = hierarchicalTreeItemBehavior({ items: [] })
       expect(expectedResult.attributes.root.tabIndex).toBeUndefined()
     })
   })
 
   describe('aria-expanded', () => {
     test(`is not added to a leaf item`, () => {
-      const expectedResult = treeItemBehavior({})
+      const expectedResult = hierarchicalTreeItemBehavior({})
       expect(expectedResult.attributes.root['aria-expanded']).toBeUndefined()
     })
 
     test(`is added with 'false' value to an item that is expandable but not open`, () => {
-      const expectedResult = treeItemBehavior({ items: [{ key: '1' }], open: false })
+      const expectedResult = hierarchicalTreeItemBehavior({ items: [{ key: '1' }], open: false })
       expect(expectedResult.attributes.root['aria-expanded']).toEqual('false')
     })
 
     test(`is added with 'false' value to an item that is expandable and open`, () => {
-      const expectedResult = treeItemBehavior({ items: [{ key: '1' }], open: true })
+      const expectedResult = hierarchicalTreeItemBehavior({ items: [{ key: '1' }], open: true })
       expect(expectedResult.attributes.root['aria-expanded']).toEqual('true')
     })
   })
 
   describe('role', () => {
     test(`is 'none' if not a leaf`, () => {
-      const expectedResult = treeItemBehavior({ items: [{ key: '1' }] })
+      const expectedResult = hierarchicalTreeItemBehavior({ items: [{ key: '1' }] })
       expect(expectedResult.attributes.root.role).toEqual('treeitem')
     })
 
     test(`is 'treeitem' if not a leaf`, () => {
-      const expectedResult = treeItemBehavior({})
+      const expectedResult = hierarchicalTreeItemBehavior({})
       expect(expectedResult.attributes.root.role).toEqual('none')
     })
   })

--- a/packages/react/test/specs/behaviors/treeTitleBehavior-test.tsx
+++ b/packages/react/test/specs/behaviors/treeTitleBehavior-test.tsx
@@ -1,26 +1,26 @@
-import { treeTitleBehavior } from 'src/lib/accessibility'
+import { hierarchicalTreeTitleBehavior } from 'src/lib/accessibility'
 
 describe('TreeTitleBehavior', () => {
   describe('tabIndex', () => {
     test(`is added with '0' value to a title with hasSubtree prop false`, () => {
-      const expectedResult = treeTitleBehavior({ hasSubtree: false })
+      const expectedResult = hierarchicalTreeTitleBehavior({ hasSubtree: false })
       expect(expectedResult.attributes.root.tabIndex).toEqual(-1)
     })
 
     test(`is not added to a title with hasSubtree prop true`, () => {
-      const expectedResult = treeTitleBehavior({ hasSubtree: true })
+      const expectedResult = hierarchicalTreeTitleBehavior({ hasSubtree: true })
       expect(expectedResult.attributes.root.tabIndex).toBeUndefined()
     })
   })
 
   describe('role', () => {
     test(`is added with 'treeitem' value to a title with hasSubtree prop false`, () => {
-      const expectedResult = treeTitleBehavior({ hasSubtree: false })
+      const expectedResult = hierarchicalTreeTitleBehavior({ hasSubtree: false })
       expect(expectedResult.attributes.root.role).toEqual('treeitem')
     })
 
     test(`is not added to a title with hasSubtree prop true`, () => {
-      const expectedResult = treeTitleBehavior({ hasSubtree: true })
+      const expectedResult = hierarchicalTreeTitleBehavior({ hasSubtree: true })
       expect(expectedResult.attributes.root.role).toBeUndefined()
     })
   })

--- a/packages/react/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
+++ b/packages/react/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
@@ -3,9 +3,9 @@ import * as keyboardKey from 'keyboard-key'
 
 import { isConformant } from 'test/specs/commonTests'
 import { mountWithProvider } from 'test/utils'
-import Tree from 'src/components/Tree/Tree'
-import TreeTitle from 'src/components/Tree/TreeTitle'
-import TreeItem from 'src/components/Tree/TreeItem'
+import HierarchicalTree from 'src/components/HierarchicalTree/HierarchicalTree'
+import HierarchicalTreeTitle from 'src/components/HierarchicalTree/HierarchicalTreeTitle'
+import HierarchicalTreeItem from 'src/components/HierarchicalTree/HierarchicalTreeItem'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
 
 const items = [
@@ -56,9 +56,9 @@ const items = [
 ]
 
 const getTitles = (wrapper: ReactWrapper): CommonWrapper =>
-  wrapper.find(`.${TreeTitle.className}`).filterWhere(n => typeof n.type() === 'string')
+  wrapper.find(`.${HierarchicalTreeTitle.className}`).filterWhere(n => typeof n.type() === 'string')
 const getItems = (wrapper: ReactWrapper): CommonWrapper =>
-  wrapper.find(`.${TreeItem.className}`).filterWhere(n => typeof n.type() === 'string')
+  wrapper.find(`.${HierarchicalTreeItem.className}`).filterWhere(n => typeof n.type() === 'string')
 
 const checkOpenTitles = (wrapper: ReactWrapper, expected: string[]): void => {
   const titles = getTitles(wrapper)
@@ -70,11 +70,11 @@ const checkOpenTitles = (wrapper: ReactWrapper, expected: string[]): void => {
 }
 
 describe('Tree', () => {
-  isConformant(Tree)
+  isConformant(HierarchicalTree)
 
   describe('activeIndex', () => {
     it('should contain index of item open at click', () => {
-      const wrapper = mountWithProvider(<Tree items={items} />)
+      const wrapper = mountWithProvider(<HierarchicalTree items={items} />)
 
       getTitles(wrapper)
         .at(0) // title 1
@@ -88,7 +88,9 @@ describe('Tree', () => {
     })
 
     it('should have index of item removed when closed at click', () => {
-      const wrapper = mountWithProvider(<Tree items={items} defaultActiveIndex={[0, 1]} />)
+      const wrapper = mountWithProvider(
+        <HierarchicalTree items={items} defaultActiveIndex={[0, 1]} />,
+      )
 
       getTitles(wrapper)
         .at(0) // title 1
@@ -97,7 +99,7 @@ describe('Tree', () => {
     })
 
     it('should contain only one index at a time if exclusive', () => {
-      const wrapper = mountWithProvider(<Tree items={items} exclusive />)
+      const wrapper = mountWithProvider(<HierarchicalTree items={items} exclusive />)
 
       getTitles(wrapper)
         .at(0) // title 1
@@ -111,7 +113,7 @@ describe('Tree', () => {
     })
 
     it('should contain index of item open by ArrowRight', () => {
-      const wrapper = mountWithProvider(<Tree items={items} />)
+      const wrapper = mountWithProvider(<HierarchicalTree items={items} />)
 
       getTitles(wrapper)
         .at(0) // title 1
@@ -120,7 +122,9 @@ describe('Tree', () => {
     })
 
     it('should have index of item removed if closed by ArrowLeft', () => {
-      const wrapper = mountWithProvider(<Tree items={items} defaultActiveIndex={[0, 1]} />)
+      const wrapper = mountWithProvider(
+        <HierarchicalTree items={items} defaultActiveIndex={[0, 1]} />,
+      )
 
       getItems(wrapper)
         .at(0) // title 1
@@ -129,7 +133,7 @@ describe('Tree', () => {
     })
 
     it('should have all TreeItems with a subtree open on asterisk key', () => {
-      const wrapper = mountWithProvider(<Tree items={items} />)
+      const wrapper = mountWithProvider(<HierarchicalTree items={items} />)
 
       getTitles(wrapper)
         .at(0) // title 1
@@ -138,7 +142,7 @@ describe('Tree', () => {
     })
 
     it('should expand subtrees only on current level on asterisk key', () => {
-      const wrapper = mountWithProvider(<Tree items={items} defaultActiveIndex={[0]} />)
+      const wrapper = mountWithProvider(<HierarchicalTree items={items} defaultActiveIndex={[0]} />)
 
       getTitles(wrapper)
         .at(1) // title 11
@@ -147,7 +151,9 @@ describe('Tree', () => {
     })
 
     it('should not be changed on asterisk key if all siblings are already expanded', () => {
-      const wrapper = mountWithProvider(<Tree items={items} defaultActiveIndex={[0, 1, 2]} />)
+      const wrapper = mountWithProvider(
+        <HierarchicalTree items={items} defaultActiveIndex={[0, 1, 2]} />,
+      )
 
       getTitles(wrapper)
         .at(0) // title 1

--- a/packages/react/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
+++ b/packages/react/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
@@ -69,7 +69,7 @@ const checkOpenTitles = (wrapper: ReactWrapper, expected: string[]): void => {
   })
 }
 
-describe('Tree', () => {
+describe('HierarchialTree', () => {
   isConformant(HierarchicalTree)
 
   describe('activeIndex', () => {


### PR DESCRIPTION
Renamed `Tree` to `HierarchicalTree`, `TreeItem` to `HierarchicalTreeItem` and `TreeTitle` to `HierarchicalTreeTitle`.
Renamed `treeBehavior` to `hierarchicalTreeBehavior`, `treeItemBehavior` to `hierarchicalTreeItemBehavior`, `treeTitleBehavior` to `hierarchicalTreeTitleBehavior` and `subtreeBehavior` to `hierarchicalSubtreeBehavior`.

## BREAKING CHANGE MITIGATION
Perform the renames where the components and behaviors are used. 