### PR TITLE
chore(List): use FocusZone in selectable list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `horizontal` prop for `List` component @mnajdova ([#1721](https://github.com/stardust-ui/react/pull/1721))
 - Export `call-blocked` icon to Teams theme @francescopalmiotto ([#1736](https://github.com/stardust-ui/react/pull/1736))
 - Add support for component styles debugging @kuzhelov ([#1726](https://github.com/stardust-ui/react/pull/1726))
+- Use FocusZone in selectable list @jurokapsiar ([#1757](https://github.com/stardust-ui/react/pull/1757))
 
 ### Documentation
 - Fix code in changing component variables section of theming examples @lucivpav ([#1626](https://github.com/stardust-ui/react/pull/1626))

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,7 +1,6 @@
 import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as _ from 'lodash'
 import * as React from 'react'
-import * as ReactDOM from 'react-dom'
 import * as PropTypes from 'prop-types'
 
 import {
@@ -16,7 +15,6 @@ import {
 import ListItem, { ListItemProps } from './ListItem'
 import { listBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
-import { ContainerFocusHandler } from '../../lib/accessibility/FocusHandling/FocusContainer'
 import {
   WithAsProp,
   ComponentEventHandler,
@@ -109,44 +107,6 @@ class List extends AutoControlledComponent<WithAsProp<ListProps>, ListState> {
   // List props that are passed to each individual Item props
   static itemProps = ['debug', 'selectable', 'truncateContent', 'truncateHeader', 'variables']
 
-  focusHandler: ContainerFocusHandler = null
-  itemRefs = []
-
-  actionHandlers = {
-    moveNext: e => {
-      e.preventDefault()
-      this.focusHandler.moveNext()
-    },
-    movePrevious: e => {
-      e.preventDefault()
-      this.focusHandler.movePrevious()
-    },
-    moveFirst: e => {
-      e.preventDefault()
-      this.focusHandler.moveFirst()
-    },
-    moveLast: e => {
-      e.preventDefault()
-      this.focusHandler.moveLast()
-    },
-  }
-
-  constructor(props, context) {
-    super(props, context)
-
-    this.focusHandler = new ContainerFocusHandler(
-      () => this.props.items.length,
-      index => {
-        this.setState({ focusedIndex: index }, () => {
-          const targetComponent = this.itemRefs[index] && this.itemRefs[index].current
-          const targetDomNode = ReactDOM.findDOMNode(targetComponent) as any
-
-          targetDomNode && targetDomNode.focus()
-        })
-      },
-    )
-  }
-
   handleItemOverrides = (predefinedProps: ListItemProps) => {
     const { selectable } = this.props
 
@@ -192,18 +152,10 @@ class List extends AutoControlledComponent<WithAsProp<ListProps>, ListState> {
     const { items, selectable } = this.props
     const { focusedIndex, selectedIndex } = this.state
 
-    this.focusHandler.syncFocusedIndex(focusedIndex)
-
-    this.itemRefs = []
-
     return _.map(items, (item, index) => {
       const maybeSelectableItemProps = {} as any
 
       if (selectable) {
-        const ref = React.createRef()
-        this.itemRefs[index] = ref
-
-        maybeSelectableItemProps.ref = ref
         maybeSelectableItemProps.selected = index === selectedIndex
         maybeSelectableItemProps.tabIndex = index === focusedIndex ? 0 : -1
       }

--- a/packages/react/src/lib/accessibility/Behaviors/List/selectableListBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/List/selectableListBehavior.ts
@@ -1,6 +1,6 @@
-import * as keyboardKey from 'keyboard-key'
-import { Accessibility } from '../../types'
+import { Accessibility, FocusZoneMode } from '../../types'
 import { ListBehaviorProps } from './listBehavior'
+import { FocusZoneDirection } from '../../FocusZone'
 
 /**
  * @description
@@ -9,12 +9,8 @@ import { ListBehaviorProps } from './listBehavior'
  * @specification
  * Adds role='listbox'.
  * Adds attribute 'aria-orientation=horizontal' to 'root' slot if 'horizontal' property is true. Does not set the attribute otherwise.
- * Triggers the 'moveNext' action with 'ArrowDown' on 'root', when orientation is vertical.
- * Triggers the 'moveNext' action with 'ArrowRight' on 'root', when orientation is horizontal.
- * Triggers the 'movePrevious' action with 'ArrowUp' on 'root', when orientation is vertical.
- * Triggers the 'movePrevious' action with 'ArrowLeft' on 'root', when orientation is horizontal.
- * Triggers 'moveFirst' action with 'Home' on 'root'.
- * Triggers 'moveLast' action with 'End' on 'root'.
+ * Embeds component into FocusZone.
+ * Provides arrow key navigation in bidirectionalDomOrder direction.
  */
 const selectableListBehavior: Accessibility<ListBehaviorProps> = props => ({
   attributes: {
@@ -25,24 +21,11 @@ const selectableListBehavior: Accessibility<ListBehaviorProps> = props => ({
       }),
     },
   },
-  keyActions: {
-    root: {
-      moveNext: {
-        keyCombinations: [
-          { keyCode: props.horizontal ? keyboardKey.ArrowRight : keyboardKey.ArrowDown },
-        ],
-      },
-      movePrevious: {
-        keyCombinations: [
-          { keyCode: props.horizontal ? keyboardKey.ArrowLeft : keyboardKey.ArrowUp },
-        ],
-      },
-      moveFirst: {
-        keyCombinations: [{ keyCode: keyboardKey.Home }],
-      },
-      moveLast: {
-        keyCombinations: [{ keyCode: keyboardKey.End }],
-      },
+  focusZone: {
+    mode: FocusZoneMode.Embed,
+    props: {
+      shouldFocusInnerElementWhenReceivedFocus: true,
+      direction: FocusZoneDirection.bidirectionalDomOrder,
     },
   },
 })

--- a/packages/react/src/lib/accessibility/Behaviors/List/selectableListItemBehavior.ts
+++ b/packages/react/src/lib/accessibility/Behaviors/List/selectableListItemBehavior.ts
@@ -1,10 +1,12 @@
 import { Accessibility } from '../../types'
 import * as keyboardKey from 'keyboard-key'
 import { ListItemBehaviorProps } from './listItemBehavior'
+import { IS_FOCUSABLE_ATTRIBUTE } from '../../FocusZone/focusUtilities'
 
 /**
  * @specification
  * Adds role='option'. This role is used for a selectable item in a list.
+ * Adds attribute 'data-is-focusable=true' to 'root' slot.
  * Adds attribute 'aria-selected=true' based on the property 'selected'. Based on this screen readers will recognize the selected state of the item.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  */
@@ -13,6 +15,7 @@ const selectableListItemBehavior: Accessibility<ListItemBehaviorProps> = props =
     root: {
       role: 'option',
       'aria-selected': !!props.selected,
+      [IS_FOCUSABLE_ATTRIBUTE]: true,
     },
   },
   keyActions: {


### PR DESCRIPTION
Use FocusZone for selectable list instead of the FocusHandler. This will allow us to use focus restoration on item removed once the appropriate change from fabric gets merged. It is also much more performant as the List does not have to update state on each keypress.