### PR TITLE
feat(Provider): add overwrite prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Features
+- Add `overwrite` prop to `Provider` @layershifter ([#1780](https://github.com/stardust-ui/react/pull/1780))
+
 ### Documentation
 - Restore docs for `Ref` component @layershifter ([#1777](https://github.com/stardust-ui/react/pull/1777))
 

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -158,11 +158,11 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
       disableAnimations,
       renderer,
     }
+
+    const incomingContext: ProviderContextPrepared = overwrite ? {} : this.context
     // rehydration disabled to avoid leaking styles between renderers
     // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
-    const outgoingContext: ProviderContextPrepared = overwrite
-      ? mergeContexts(this.context, inputContext)
-      : mergeContexts(inputContext)
+    const outgoingContext: ProviderContextPrepared = mergeContexts(incomingContext, inputContext)
 
     this.renderStaticStylesOnce(outgoingContext.theme)
 

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -34,6 +34,7 @@ export interface ProviderProps extends ChildrenComponentProps {
   renderer?: Renderer
   rtl?: boolean
   disableAnimations?: boolean
+  overwrite?: boolean
   target?: Document
   theme?: ThemeInput
   variables?: ComponentVariablesInput
@@ -141,13 +142,14 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
   render() {
     const {
       as,
-      theme,
-      rtl,
-      disableAnimations,
-      renderer,
-      variables,
       children,
+      disableAnimations,
+      overwrite,
+      renderer,
+      rtl,
       target,
+      theme,
+      variables,
       ...unhandledProps
     } = this.props
     const inputContext: ProviderContextInput = {
@@ -158,7 +160,9 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
     }
     // rehydration disabled to avoid leaking styles between renderers
     // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
-    const outgoingContext: ProviderContextPrepared = mergeContexts(this.context, inputContext)
+    const outgoingContext: ProviderContextPrepared = overwrite
+      ? mergeContexts(this.context, inputContext)
+      : mergeContexts(inputContext)
 
     this.renderStaticStylesOnce(outgoingContext.theme)
 
@@ -177,7 +181,7 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
         target={target}
         {...{ rehydrate: false }}
       >
-        <ThemeProvider theme={outgoingContext}>
+        <ThemeProvider theme={outgoingContext} overwrite>
           <ProviderBox as={as} variables={variables} {...unhandledProps} {...rtlProps}>
             {children}
           </ProviderBox>

--- a/packages/react/test/specs/components/Provider/Provider-test.tsx
+++ b/packages/react/test/specs/components/Provider/Provider-test.tsx
@@ -1,7 +1,8 @@
+import { mount } from 'enzyme'
 import * as React from 'react'
+
 import Provider from 'src/components/Provider/Provider'
 import ProviderConsumer from 'src/components/Provider/ProviderConsumer'
-import { mount } from 'enzyme'
 
 describe('Provider', () => {
   test('is exported', () => {
@@ -10,6 +11,64 @@ describe('Provider', () => {
 
   test('has a ProviderConsumer subcomponent', () => {
     expect(require('src/index.ts').Provider.Consumer).toEqual(ProviderConsumer)
+  })
+
+  describe('overwrite', () => {
+    const outerTheme = { siteVariables: { brand: 'blue' } }
+    const innerTheme = { siteVariables: { secondary: 'yellow' } }
+
+    test('do not overwrite by default', () => {
+      const wrapper = mount(
+        <Provider theme={outerTheme}>
+          <Provider theme={innerTheme}>
+            <span />
+          </Provider>
+        </Provider>,
+      )
+
+      expect(
+        wrapper
+          .find('ThemeProvider')
+          .at(1)
+          .prop('theme'),
+      ).toEqual(
+        expect.objectContaining({
+          theme: expect.objectContaining({
+            siteVariables: {
+              brand: 'blue',
+              secondary: 'yellow',
+              fontSizes: {},
+            },
+          }),
+        }),
+      )
+    })
+
+    test('does overwrite when is true', () => {
+      const wrapper = mount(
+        <Provider theme={outerTheme}>
+          <Provider overwrite theme={innerTheme}>
+            <span />
+          </Provider>
+        </Provider>,
+      )
+
+      expect(
+        wrapper
+          .find('ThemeProvider')
+          .at(1)
+          .prop('theme'),
+      ).toEqual(
+        expect.objectContaining({
+          theme: expect.objectContaining({
+            siteVariables: {
+              secondary: 'yellow',
+              fontSizes: {},
+            },
+          }),
+        }),
+      )
+    })
   })
 
   describe('staticStyles', () => {


### PR DESCRIPTION
# ♻️ `overwrite` prop

This PR adds `overwrite` prop for `Provider` component. It allows to reset current context and avoid merging with existing themes. Existing behavior is preserved.

### `overwrite=false`

```jsx
<Provider theme={themes.teams}> // Teams theme
  <Provider theme={themes.base} /> // Teams + Base theme
```

### `overwrite=true`

```jsx
<Provider theme={themes.teams}> // Teams theme
  <Provider overwrite theme={themes.base} /> // Base theme
```