### PR TITLE
chore: Export FocusTrapZoneProps and AutoFocusZoneProps from main package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add possibility for a Toolbar to rearrange its items according to space available @miroslavstastny ([#1657](https://github.com/stardust-ui/react/pull/1657))
 - Edit `buttonBehavior` Adding aria-disabled when button has loading state @kolaps33 ([#1789](https://github.com/stardust-ui/react/pull/1789))
 - Added `audio-off` and `clipboard-copied-to` icon to Teams theme @bcalvery ([#1792](https://github.com/stardust-ui/react/pull/1792))
+- Export `FocusTrapZoneProps` and `AutoFocusZoneProps` from the main package @sophieH29 ([#1795](https://github.com/stardust-ui/react/pull/1795))
 
 ### Documentation
 - Restore docs for `Ref` component @layershifter ([#1777](https://github.com/stardust-ui/react/pull/1777))

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -231,6 +231,8 @@ export const FocusZoneUtilities = {
   focusAsync,
 }
 export * from './lib/accessibility/FocusZone/FocusZone.types'
+export * from './lib/accessibility/FocusZone/FocusTrapZone.types'
+export * from './lib/accessibility/FocusZone/AutoFocusZone.types'
 export * from './lib/accessibility/types'
 export * from './lib/accessibility/reactTypes'
 


### PR DESCRIPTION
Export `FocusTrapZoneProps` and `AutoFocusZoneProps` from the main package.
