### PR TITLE
fix(Checkbox): Change checkbox background to transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Menu` and `MenuItem` styles to match [redlines] @bcalvery ([#1712](https://github.com/stardust-ui/react/pull/1712))
 - Update vulnerable version of `lodash` dependency @layershifter ([#1700](https://github.com/stardust-ui/react/pull/1700))
 - Make `Embed` focusable via keyboard @lucivpav ([#1758](https://github.com/stardust-ui/react/pull/1758))
+- Fix `Checkbox` style bug in background color [redlines] @bcalvery ([#1796](https://github.com/stardust-ui/react/pull/1796))
 
 ### Features
 - Add `overwrite` prop to `Provider` @layershifter ([#1780](https://github.com/stardust-ui/react/pull/1780))

--- a/packages/react/src/themes/teams/components/Checkbox/checkboxVariables.ts
+++ b/packages/react/src/themes/teams/components/Checkbox/checkboxVariables.ts
@@ -27,7 +27,7 @@ const defaultValue = 'red'
 
 export default (siteVars: any): CheckboxVariables => ({
   textColor: _.get(siteVars, 'colorScheme.default.foreground1', defaultValue),
-  background: _.get(siteVars, 'colorScheme.default.background', defaultValue),
+  background: 'transparent',
   borderColor: _.get(siteVars, 'colorScheme.default.foreground1', defaultValue),
   borderStyle: 'solid',
   borderRadius: pxToRem(3),


### PR DESCRIPTION
Checkbox background was visible in dark theme when it should have been transparent in all cases.

Before:
![image](https://user-images.githubusercontent.com/15043460/63041002-aaf5c880-be7b-11e9-8bfd-0ca1777147ea.png)
After:
![image](https://user-images.githubusercontent.com/15043460/63040924-77b33980-be7b-11e9-94cd-ee92ff76d8f7.png)
