### PR TITLE
docs(QuickStart): improve code example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restore docs for `Ref` component @layershifter ([#1777](https://github.com/stardust-ui/react/pull/1777))
 - Add prototype for expandable control messages in `Chat` @sophieH29 ([#1765](https://github.com/stardust-ui/react/pull/1765))
 - Remove Font Awesome icons from docs examples @lucivpav ([#1764](https://github.com/stardust-ui/react/pull/1764))
+- Improve QuickStart code example @lucivpav ([#1797](https://github.com/stardust-ui/react/pull/1797))
 
 <!--------------------------------[ v0.36.1 ]------------------------------- -->
 ## [v0.36.1](https://github.com/stardust-ui/react/tree/v0.36.1) (2019-08-09)

--- a/docs/src/views/QuickStart.tsx
+++ b/docs/src/views/QuickStart.tsx
@@ -49,7 +49,7 @@ export default () => (
         import React from 'react'
         import { Button } from '@stardust-ui/react'
 
-        export default () => <Button content="Theming" icon="arrow-right" iconPosition="after" primary />
+        export default () => <Button content="Get started" icon="play" iconPosition="after" primary />
       `}
     />
 


### PR DESCRIPTION
The original code example at the bottom of QuickStart page was quite strange, as it didn't correspond to the `Button` below it. Relevant issue #1759. Since the docs website is using FontAwesome icons, while the code examples use Teams icons, I have decided to make the example independent of the button below it.