### PR TITLE
fix(Screener): Update screener test for Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Menu` and `MenuItem` styles to match [redlines] @bcalvery ([#1712](https://github.com/stardust-ui/react/pull/1712))
 - Update vulnerable version of `lodash` dependency @layershifter ([#1700](https://github.com/stardust-ui/react/pull/1700))
 - Make `Embed` focusable via keyboard @lucivpav ([#1758](https://github.com/stardust-ui/react/pull/1758))
+- Update screener tests for `Input` to only capture Teams themes @codepretty ([#1801](https://github.com/stardust-ui/react/pull/1801))
 - Fix `Checkbox` style bug in background color [redlines] @bcalvery ([#1796](https://github.com/stardust-ui/react/pull/1796))
 
 ### Features

--- a/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
+++ b/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
@@ -2,7 +2,7 @@ import { Input } from '@stardust-ui/react'
 
 const config: ScreenerTestsConfig = {
   steps: [builder => builder.focus(`.${Input.className} input`).snapshot('Can be focused')],
-  themes: ['teams', 'base'],
+  themes: ['teams', 'teamsDark', 'teamsHighContrast'],
 }
 
 export default config


### PR DESCRIPTION
We don't need to capture screener tests for Input in base theme.