### PR TITLE
fix(Video): fix `muted` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix `muted` prop in `Video` component @layershifter ([#1719](https://github.com/stardust-ui/react/pull/1719))
+
 <!--------------------------------[ v0.37.0 ]------------------------------- -->
 ## [v0.37.0](https://github.com/stardust-ui/react/tree/v0.37.0) (2019-08-26)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.36.2...v0.37.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
-- Fix `muted` prop in `Video` component @layershifter ([#1719](https://github.com/stardust-ui/react/pull/1719))
+- Fix `muted` prop in `Video` component @layershifter ([#1847](https://github.com/stardust-ui/react/pull/1847))
 
 <!--------------------------------[ v0.37.0 ]------------------------------- -->
 ## [v0.37.0](https://github.com/stardust-ui/react/tree/v0.37.0) (2019-08-26)

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -67,11 +67,7 @@ class Video extends UIComponent<WithAsProp<VideoProps>> {
     // React doesn't guaranty that props will be set:
     // https://github.com/facebook/react/issues/10389
     if (this.videoRef.current) {
-      if (this.props.muted) {
-        this.videoRef.current.setAttribute('muted', 'true')
-      } else {
-        this.videoRef.current.removeAttribute('muted')
-      }
+      this.videoRef.current.muted = !!this.props.muted
     }
   }
 


### PR DESCRIPTION
This PR fixes the `muted` prop on `Video` component, now it works properly.

Tested in Chrome, FF, Edge and IE11.