### PR TITLE
chore: fix broken screener tests

### DIFF
--- a/build/screener/screener.states.ts
+++ b/build/screener/screener.states.ts
@@ -31,12 +31,14 @@ const getStateForPath = (examplePath: string) => {
   const rtl = exampleNameWithExtension.endsWith('.rtl.tsx')
   const exampleUrl = _.kebabCase(exampleNameWithoutExtension)
 
+  const pageUrl = `http://${config.server_host}:${config.server_port}/maximize/${exampleUrl}/${rtl}`
+
   return {
-    url: `http://${config.server_host}:${config.server_port}/maximize/${exampleUrl}/${rtl}`,
+    url: pageUrl,
     name: exampleNameWithExtension,
 
     // https://www.npmjs.com/package/screener-runner#testing-interactions
-    steps: getScreenerSteps(`${exampleDir}/${exampleNameWithoutExtension}.steps`),
+    steps: getScreenerSteps(pageUrl, `${exampleDir}/${exampleNameWithoutExtension}.steps`),
   }
 }
 

--- a/build/screener/screener.steps.ts
+++ b/build/screener/screener.steps.ts
@@ -13,7 +13,7 @@ Steps.prototype.switchTheme = function switchTheme(themeName: ScreenerThemeName)
   return this.executeScript(`window.switchTheme("${themeName}")`)
 }
 
-const getScreenerSteps = (stepsModulePath: string): any[] => {
+const getScreenerSteps = (pageUrl: string, stepsModulePath: string): any[] => {
   if (!fs.existsSync(`${stepsModulePath}.ts`)) {
     return undefined
   }
@@ -29,7 +29,9 @@ const getScreenerSteps = (stepsModulePath: string): any[] => {
 
     _.forEach(screenerSteps, screenerStep => {
       screenerStep(stepsBuilder, keys)
-      stepsBuilder.resetExternalLayout()
+
+      // We need to reload page to reset mouse position between tests
+      stepsBuilder.url(pageUrl).switchTheme(themeName)
     })
   })
 


### PR DESCRIPTION
Extracted from #1855.

---

Fixes an issus with wrongly persisted mouse state between steps and themes. We found it when verified new portion of screenshots in #1855. The easiest repro can be found with high contrast theme examples. For example I compare below `PopupExample.shorthand.tsx: Theme: teamsHighContrast`:

### Wrong

![image](https://user-images.githubusercontent.com/14183168/63863303-4aec3f80-c9ae-11e9-9ad8-c1f9a9065381.png)

_It's wrong because the button is hovered on default screenshot 💥_ 

### Correct

![image](https://user-images.githubusercontent.com/14183168/63863321-517ab700-c9ae-11e9-9e44-34b960c14698.png)

***

I also tried to use a trick with _hovering `body`_, but it produces wrong screenshots: elements are not hovered on click anymore. So there is only one correct solution, to reload page between tests.
