### PR TITLE
RFC: `enhanceName` and `replaceName` to customize styles

### DIFF
--- a/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -1,6 +1,86 @@
 import * as React from 'react'
-import { Button } from '@stardust-ui/react'
+import {
+  Button,
+  ButtonProps,
+  ComponentSlotStylesInput,
+  ComponentVariablesPrepared,
+  Flex,
+  Provider,
+  ThemeInput,
+} from '@stardust-ui/react'
 
-const ButtonExample = () => <Button content="Click here" />
+import { ButtonVariables } from 'src/themes/teams/components/Button/buttonVariables'
+
+type ButtonTertiaryVariables = {
+  backgroundColor: string
+  color: string
+  colorHover: string
+  fontWeight: string
+  fontWeightHover: string
+}
+
+type CustomTheme = ThemeInput & {
+  componentStyles: {
+    ButtonTertiary: ComponentSlotStylesInput<ButtonProps, ButtonTertiaryVariables>
+  }
+  componentVariables: { ButtonTertiary: ComponentVariablesPrepared }
+}
+
+const customTheme: CustomTheme = {
+  componentStyles: {
+    'Button:Disabled': {
+      root: { cursor: 'not-allowed' },
+    },
+    ButtonTertiary: {
+      root: ({ variables: v }) => ({
+        backgroundColor: v.backgroundColor,
+        border: 0,
+        color: v.color,
+        fontWeight: v.fontWeight,
+        textDecoration: 'underline',
+
+        ':hover': {
+          color: v.colorHover,
+          cursor: 'pointer',
+          fontWeight: v.fontWeightHover,
+        },
+      }),
+    },
+  },
+  componentVariables: {
+    'Button:Danger': (siteVariables): Partial<ButtonVariables> => ({
+      backgroundColor: siteVariables.colorScheme.red.background1,
+      backgroundColorHover: siteVariables.colorScheme.red.backgroundHover,
+      color: siteVariables.colorScheme.red.foreground,
+      colorHover: siteVariables.colorScheme.red.foregroundHover,
+      borderColorHover: siteVariables.colorScheme.red.background3,
+    }),
+    ButtonTertiary: (siteVariables): ButtonTertiaryVariables => ({
+      backgroundColor: 'transparent',
+      color: siteVariables.colorScheme.brand.foreground,
+      colorHover: siteVariables.colorScheme.brand.foregroundHover,
+      fontWeight: siteVariables.fontWeightRegular,
+      fontWeightHover: siteVariables.fontWeightSemibold,
+    }),
+  },
+}
+
+const ButtonExample = () => (
+  <>
+    <Provider theme={customTheme}>
+      <Flex gap="gap.medium">
+        <Button content="Button:Danger" enhanceName="Button:Danger" />
+        <Button content="Button:Disabled" disabled enhanceName="Button:Disabled" />
+
+        <Button content="ButtonTertiary" replaceName="ButtonTertiary" />
+      </Flex>
+    </Provider>
+    <div style={{ margin: 20 }}>
+      <button onClick={() => window.switchTheme('teams')}>Light theme</button>
+      <button onClick={() => window.switchTheme('teamsDark')}>Dark theme</button>
+      <button onClick={() => window.switchTheme('teamsHighContrast')}>HC theme</button>
+    </div>
+  </>
+)
 
 export default ButtonExample

--- a/packages/react/src/lib/commonPropInterfaces.ts
+++ b/packages/react/src/lib/commonPropInterfaces.ts
@@ -3,6 +3,12 @@ import { ComponentVariablesInput, ComponentSlotStyle, AnimationProp } from '../t
 import { ReactChildren } from '../types'
 
 export interface StyledComponentProps<P = any, V = any> {
+  /** FIX ME */
+  enhanceName?: string
+
+  /** FIX ME */
+  replaceName?: string
+
   /** Additional CSS styles to apply to the component instance.  */
   styles?: ComponentSlotStyle<P, V>
 

--- a/packages/react/src/lib/renderComponent.tsx
+++ b/packages/react/src/lib/renderComponent.tsx
@@ -173,7 +173,7 @@ const renderComponent = <P extends {}>(
 
   /** FIX ME */
   if (props.enhanceName) {
-    if (!props.enhanceName.starsWith(`${displayName}:`)) {
+    if (!props.enhanceName.startsWith(`${displayName}:`)) {
       throw new Error(
         `"enhanceName" prop should start with "displayName" of matching component, i.e. "${displayName}:Variant"`,
       )

--- a/packages/react/src/lib/renderComponent.tsx
+++ b/packages/react/src/lib/renderComponent.tsx
@@ -166,9 +166,24 @@ const renderComponent = <P extends {}>(
   const ElementType = getElementType({ defaultProps }, props) as React.ReactType<P>
   const stateAndProps = { ...state, ...props }
 
+  /** FIX ME */
+  if (props.enhanceName && props.replaceName) {
+    throw new Error('"enhanceName" and "replaceName" props can not be combined')
+  }
+
+  /** FIX ME */
+  if (props.enhanceName) {
+    if (!props.enhanceName.starsWith(`${displayName}:`)) {
+      throw new Error(
+        `"enhanceName" prop should start with "displayName" of matching component, i.e. "${displayName}:Variant"`,
+      )
+    }
+  }
+
   // Resolve variables for this component, allow props.variables to override
   const resolvedVariables: ComponentVariablesObject = mergeComponentVariables(
-    theme.componentVariables[displayName],
+    theme.componentVariables[props.replaceName || displayName],
+    theme.componentVariables[props.enhanceName],
     props.variables,
   )(theme.siteVariables)
 
@@ -178,7 +193,8 @@ const renderComponent = <P extends {}>(
 
   // Resolve styles using resolved variables, merge results, allow props.styles to override
   const mergedStyles: ComponentSlotStylesPrepared = mergeComponentStyles(
-    theme.componentStyles[displayName],
+    theme.componentStyles[props.replaceName || displayName],
+    theme.componentStyles[props.enhanceName],
     { root: props.styles },
     { root: animationCSSProp },
   )


### PR DESCRIPTION
This PR continues my idea about having `styleName` name.

***

### ⭐️  Goal
- customize existing components and keep this customizations inside theme
- use `variables` from themes as much as possible
- allow to replace styles at all

### ❓ How?

Naming is not final and is debatable, however:
- `enchanceName` to combine existing styles in a new component, allows to reuse existing variables and introduce new. Should contain the name of original component
- `replaceName` to reset all component styles and style components from stratch

_These props can't be combined._

### 🐺 Try it

I updated a `Button` example, so you can simply try it. _Use `Popup out` mode._

### 🔨  Unresolved issues?

I don't have ideas about nested components like `Menu`, `Dropdown`, etc. 🤔 

### Pros
- 👍 it's still `Button` component, no conflicts with factories
- 👍 to create `Button:Danger` I reused **existing** `Button` variables and used `colorSchema`
- 👍 to create `ButtonTertiary` I was able to follow existing Stardust patterns and used custom variables and custom styles. _Accessibility and all other concerns are still there. And I didn't introduce a new component 🏆_ 
- 👍 under `replaceName` I don't need to fight with existing styles
- 👍 API and changes are dumb
- 👍 custom styles are scoped and there no conflicts and conditions
- 👍 theming capabilities are kept

### Cons
Post yours!

