### PR TITLE
feat(Alert): add `fitted` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add `yellow`, `green`, `orange`, `pink`, `amethyst`, `silver` and `onyx` color schemes in Teams theme @mnajdova ([#1826](https://github.com/stardust-ui/react/pull/1826))
 - Add `Tree` component that is flat DOM structured @silviuavram ([#1779](https://github.com/stardust-ui/react/pull/1779))
+- Add `compact` prop to `Alert` component @layershifter ([#1872](https://github.com/stardust-ui/react/pull/1872))
 
 ### Fixes
 - Fix `muted` prop in `Video` component @layershifter ([#1847](https://github.com/stardust-ui/react/pull/1847))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add `yellow`, `green`, `orange`, `pink`, `amethyst`, `silver` and `onyx` color schemes in Teams theme @mnajdova ([#1826](https://github.com/stardust-ui/react/pull/1826))
 - Add `Tree` component that is flat DOM structured @silviuavram ([#1779](https://github.com/stardust-ui/react/pull/1779))
-- Add `compact` prop to `Alert` component @layershifter ([#1872](https://github.com/stardust-ui/react/pull/1872))
+- Add `fitted` prop to `Alert` component @layershifter ([#1872](https://github.com/stardust-ui/react/pull/1872))
 
 ### Fixes
 - Fix `muted` prop in `Video` component @layershifter ([#1847](https://github.com/stardust-ui/react/pull/1847))

--- a/docs/src/examples/components/Alert/Usage/AlertExampleWidth.shorthand.tsx
+++ b/docs/src/examples/components/Alert/Usage/AlertExampleWidth.shorthand.tsx
@@ -1,0 +1,20 @@
+import { useRangeKnob } from '@stardust-ui/docs-components'
+import { Alert } from '@stardust-ui/react'
+import * as React from 'react'
+
+const AlertExampleWidth = () => {
+  const [width] = useRangeKnob({ name: 'width', initialValue: '500px' })
+
+  return (
+    <div style={{ minWidth: 350, maxWidth: 800, width }}>
+      <Alert
+        actions={[{ content: 'Join and add the room', primary: true }]}
+        header="There is a conference room close to you."
+        dismissible
+        icon="screencast"
+      />
+    </div>
+  )
+}
+
+export default AlertExampleWidth

--- a/docs/src/examples/components/Alert/Usage/index.tsx
+++ b/docs/src/examples/components/Alert/Usage/index.tsx
@@ -15,6 +15,11 @@ const Usage = () => (
       description="An Alert that displays an important information."
       examplePath="components/Alert/Usage/AlertExampleImportantMessage"
     />
+    <ComponentExample
+      title="Width"
+      description="An Alert can fit container width."
+      examplePath="components/Alert/Usage/AlertExampleWidth"
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/components/Alert/Variations/AlertExampleCompact.shorthand.tsx
+++ b/docs/src/examples/components/Alert/Variations/AlertExampleCompact.shorthand.tsx
@@ -1,8 +1,0 @@
-import { Alert } from '@stardust-ui/react'
-import * as React from 'react'
-
-const AlertExampleCompact = () => (
-  <Alert compact content="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
-)
-
-export default AlertExampleCompact

--- a/docs/src/examples/components/Alert/Variations/AlertExampleCompact.shorthand.tsx
+++ b/docs/src/examples/components/Alert/Variations/AlertExampleCompact.shorthand.tsx
@@ -1,0 +1,8 @@
+import { Alert } from '@stardust-ui/react'
+import * as React from 'react'
+
+const AlertExampleCompact = () => (
+  <Alert compact content="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
+)
+
+export default AlertExampleCompact

--- a/docs/src/examples/components/Alert/Variations/AlertExampleFitted.shorthand.tsx
+++ b/docs/src/examples/components/Alert/Variations/AlertExampleFitted.shorthand.tsx
@@ -1,0 +1,8 @@
+import { Alert } from '@stardust-ui/react'
+import * as React from 'react'
+
+const AlertExampleFitted = () => (
+  <Alert content="Lorem ipsum dolor sit amet, consectetur adipiscing elit." fitted />
+)
+
+export default AlertExampleFitted

--- a/docs/src/examples/components/Alert/Variations/index.tsx
+++ b/docs/src/examples/components/Alert/Variations/index.tsx
@@ -39,6 +39,11 @@ const Variations = () => (
       description="An Alert can be can be formatted to attach itself to other content."
       examplePath="components/Alert/Variations/AlertExampleAttached"
     />
+    <ComponentExample
+      title="Compact"
+      description="An alert can only take up the width of its content."
+      examplePath="components/Alert/Variations/AlertExampleCompact"
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/components/Alert/Variations/index.tsx
+++ b/docs/src/examples/components/Alert/Variations/index.tsx
@@ -40,9 +40,9 @@ const Variations = () => (
       examplePath="components/Alert/Variations/AlertExampleAttached"
     />
     <ComponentExample
-      title="Compact"
+      title="Fitted"
       description="An alert can only take up the width of its content."
-      examplePath="components/Alert/Variations/AlertExampleCompact"
+      examplePath="components/Alert/Variations/AlertExampleFitted"
     />
   </ExampleSection>
 )

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -60,7 +60,7 @@ export interface AlertProps
   attached?: boolean | 'top' | 'bottom'
 
   /** An alert can only take up the width of its content. */
-  compact?: boolean
+  fitted?: boolean
 
   /** An alert may be formatted to display a danger message. */
   danger?: boolean
@@ -135,7 +135,7 @@ class Alert extends AutoControlledComponent<WithAsProp<AlertProps>, AlertState> 
     icon: customPropTypes.itemShorthandWithoutJSX,
     header: customPropTypes.itemShorthand,
     attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['top', 'bottom'])]),
-    compact: PropTypes.bool,
+    fitted: PropTypes.bool,
     danger: PropTypes.bool,
     defaultVisible: PropTypes.bool,
     dismissible: PropTypes.bool,

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -59,6 +59,9 @@ export interface AlertProps
   /** Controls Alert's relation to neighboring items. */
   attached?: boolean | 'top' | 'bottom'
 
+  /** An alert can only take up the width of its content. */
+  compact?: boolean
+
   /** An alert may be formatted to display a danger message. */
   danger?: boolean
 
@@ -132,6 +135,7 @@ class Alert extends AutoControlledComponent<WithAsProp<AlertProps>, AlertState> 
     icon: customPropTypes.itemShorthandWithoutJSX,
     header: customPropTypes.itemShorthand,
     attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['top', 'bottom'])]),
+    compact: PropTypes.bool,
     danger: PropTypes.bool,
     defaultVisible: PropTypes.bool,
     dismissible: PropTypes.bool,

--- a/packages/react/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertStyles.ts
@@ -90,7 +90,7 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
       borderRadius: `0 0 ${v.borderRadius} ${v.borderRadius}`,
     }),
 
-    ...(p.compact && { display: 'inline-flex' }),
+    ...(p.fitted && { display: 'inline-flex' }),
 
     ...(p.dismissible && { padding: v.dismissiblePadding }),
 

--- a/packages/react/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertStyles.ts
@@ -72,7 +72,6 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
     display: 'flex',
     alignItems: 'center',
     position: 'relative',
-    width: '100%',
     borderStyle: v.borderStyle,
     borderWidth: v.borderWidth,
     borderRadius: v.borderRadius,
@@ -90,6 +89,10 @@ const alertStyles: ComponentSlotStylesInput<AlertProps, AlertVariables> = {
     ...(p.attached === 'bottom' && {
       borderRadius: `0 0 ${v.borderRadius} ${v.borderRadius}`,
     }),
+
+    ...(p.compact && { display: 'inline-flex' }),
+
+    ...(p.dismissible && { padding: v.dismissiblePadding }),
 
     ...(!p.visible && {
       visibility: 'hidden',

--- a/packages/react/src/themes/teams/components/Alert/alertVariables.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertVariables.ts
@@ -18,6 +18,7 @@ export interface AlertVariables {
 
   dismissActionSize: string
   dismissActionColor: string
+  dismissiblePadding: string
 
   dangerColor: string
   dangerBackgroundColor: string
@@ -55,12 +56,13 @@ export default (siteVars: SiteVariablesPrepared): AlertVariables => {
     color: siteVars.colors.grey[500],
     fontWeight: siteVars.fontWeightRegular,
     minHeight,
-    padding: `0 0 0 ${pxToRem(16)}`,
+    padding: `0 ${pxToRem(16)}`,
 
     actionsMargin: pxToRem(5),
 
     dismissActionSize: minHeight,
     dismissActionColor: undefined,
+    dismissiblePadding: `0 0 0 ${pxToRem(16)}`,
 
     dangerColor: siteVars.colors.red[400],
     dangerBackgroundColor: siteVars.colors.red[50],


### PR DESCRIPTION
### `fitted` prop

This PR adds a new prop to `Alert` component, it allows to only take up the width of its content.

***

Also adds an example into `Usage` with fixed container width that wraps `Alert`.