### PR TITLE
fix(doesNodeContainClick): use proper `document` to find nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `muted` prop in `Video` component @layershifter ([#1847](https://github.com/stardust-ui/react/pull/1847))
 - Fix `felaRenderer` is used in `Provider` explicitly @lucivpav ([#1842](https://github.com/stardust-ui/react/pull/1842))
 - Fix `selectableListBehavior` to set `tabindex=-1` to `List`'s container to work correctly with screen readers @sophieH29 ([#1858](https://github.com/stardust-ui/react/pull/1858))
+- Use a proper `document` to find nodes in `doesNodeContainClick()` @layershifter ([#1874](https://github.com/stardust-ui/react/pull/1874))
 
 ### Documentation
 - Add usage example regarding `Checkbox` in `Form` @lucivpav ([#1845](https://github.com/stardust-ui/react/pull/1845))

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -194,8 +194,16 @@ class Dialog extends AutoControlledComponent<WithAsProp<DialogProps>, DialogStat
   handleOverlayClick = (e: MouseEvent) => {
     // Dialog has different conditions to close than Popup, so we don't need to iterate across all
     // refs
-    const isInsideContentClick = doesNodeContainClick(this.contentRef.current, e)
-    const isInsideOverlayClick = doesNodeContainClick(this.overlayRef.current, e)
+    const isInsideContentClick = doesNodeContainClick(
+      this.contentRef.current,
+      e,
+      this.context.target,
+    )
+    const isInsideOverlayClick = doesNodeContainClick(
+      this.overlayRef.current,
+      e,
+      this.context.target,
+    )
 
     const shouldClose = !isInsideContentClick && isInsideOverlayClick
 

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -320,8 +320,8 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
   outsideClickHandler = e => {
     if (!this.isSubmenuOpen()) return
     if (
-      !doesNodeContainClick(this.itemRef.current, e) &&
-      !doesNodeContainClick(this.menuRef.current, e)
+      !doesNodeContainClick(this.itemRef.current, e, this.context.target) &&
+      !doesNodeContainClick(this.menuRef.current, e, this.context.target)
     ) {
       this.trySetMenuOpen(false, e)
     }
@@ -331,7 +331,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
     const { active, menu } = this.props
 
     if (menu) {
-      if (doesNodeContainClick(this.menuRef.current, e)) {
+      if (doesNodeContainClick(this.menuRef.current, e, this.context.target)) {
         // submenu was clicked => close it and propagate
         this.trySetMenuOpen(false, e, () => focusAsync(this.itemRef.current))
       } else {

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -283,14 +283,15 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
   isOutsidePopupElementAndOutsideTriggerElement(refs: NodeRef[], e) {
     const isOutsidePopupElement = this.isOutsidePopupElement(refs, e)
     const isOutsideTriggerElement =
-      this.triggerRef.current && !doesNodeContainClick(this.triggerRef.current, e)
+      this.triggerRef.current &&
+      !doesNodeContainClick(this.triggerRef.current, e, this.context.target)
 
     return isOutsidePopupElement && isOutsideTriggerElement
   }
 
   isOutsidePopupElement(refs: NodeRef[], e) {
     const isInsideNested = _.some(refs, (childRef: NodeRef) => {
-      return doesNodeContainClick(childRef.current, e)
+      return doesNodeContainClick(childRef.current as HTMLElement, e, this.context.target)
     })
 
     const isOutsidePopupElement = this.popupDomElement && !isInsideNested

--- a/packages/react/src/components/Portal/Portal.tsx
+++ b/packages/react/src/components/Portal/Portal.tsx
@@ -189,8 +189,8 @@ class Portal extends AutoControlledComponent<PortalProps, PortalState> {
   handleDocumentClick = (e: MouseEvent) => {
     if (
       !this.portalNode || // no portal
-      doesNodeContainClick(this.triggerNode, e) || // event happened in trigger (delegate to trigger handlers)
-      doesNodeContainClick(this.portalNode, e) // event happened in the portal
+      doesNodeContainClick(this.triggerNode, e, this.context.target) || // event happened in trigger (delegate to trigger handlers)
+      doesNodeContainClick(this.portalNode, e, this.context.target) // event happened in the portal
     ) {
       return // ignore the click
     }

--- a/packages/react/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarItem.tsx
@@ -300,10 +300,10 @@ class ToolbarItem extends UIComponent<WithAsProp<ToolbarItemProps>, ToolbarItemS
     _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  handleOutsideClick = (e: Event) => {
+  handleOutsideClick = (e: MouseEvent) => {
     if (
-      !doesNodeContainClick(this.menuRef.current, e) &&
-      !doesNodeContainClick(this.itemRef.current, e)
+      !doesNodeContainClick(this.menuRef.current, e, this.context.target) &&
+      !doesNodeContainClick(this.itemRef.current, e, this.context.target)
     ) {
       this.trySetMenuOpen(false, e)
     }

--- a/packages/react/src/lib/doesNodeContainClick.tsx
+++ b/packages/react/src/lib/doesNodeContainClick.tsx
@@ -5,20 +5,21 @@ import * as _ from 'lodash'
  *
  * @see https://github.com/Semantic-Org/Semantic-UI-React/pull/2384
  *
- * @param {object} node - A DOM node.
- * @param {object} e - A SyntheticEvent or DOM Event.
+ * @param {object} node A DOM node.
+ * @param {Event} e A SyntheticEvent or DOM Event.
+ * @param {Document} target A target document.
  * @returns {boolean}
  */
-const doesNodeContainClick = (node, e) => {
+const doesNodeContainClick = (node: HTMLElement, e: MouseEvent, target: Document = document) => {
   if (_.some([e, node], _.isNil)) return false
 
   // if there is an e.target and it is in the document, use a simple node.contains() check
   if (e.target) {
     _.invoke(e.target, 'setAttribute', 'data-suir-click-target', true)
 
-    if (document.querySelector('[data-suir-click-target=true]')) {
+    if (target.querySelector('[data-suir-click-target=true]')) {
       _.invoke(e.target, 'removeAttribute', 'data-suir-click-target')
-      return node.contains(e.target)
+      return node.contains(e.target as HTMLElement)
     }
   }
 
@@ -39,7 +40,7 @@ const doesNodeContainClick = (node, e) => {
   if (!node.offsetWidth || !node.offsetHeight || !clientRects || !clientRects.length) return false
 
   // false if the node doesn't have a valid bounding rect
-  const { top, bottom, left, right } = _.first(clientRects) as any
+  const { top, bottom, left, right } = _.first(clientRects)
   if (_.some([top, bottom, left, right], _.isNil)) return false
 
   // we add a small decimal to the upper bound just to make it inclusive


### PR DESCRIPTION
Fixes #1873.
Also improved typings in `doesNodeContains()`.

### Before

![popup-before](https://user-images.githubusercontent.com/14183168/64111795-d63a4c00-cd85-11e9-86b2-98727e127f2c.gif)

### After 
![popup-after](https://user-images.githubusercontent.com/14183168/64111238-78593480-cd84-11e9-9979-40bed5451f85.gif)

