### PR TITLE
fix(factories): add types to createShorthandFactory() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `felaRenderer` is used in `Provider` explicitly @lucivpav ([#1842](https://github.com/stardust-ui/react/pull/1842))
 - Fix `selectableListBehavior` to set `tabindex=-1` to `List`'s container to work correctly with screen readers @sophieH29 ([#1858](https://github.com/stardust-ui/react/pull/1858))
 - Fix `Checkbox` changed to be vertically aligned to the top of it's content @bcalvery ([#1857](https://github.com/stardust-ui/react/pull/1857))
+- Fix `createShorthandFactory` types @lucivpav ([#1875](https://github.com/stardust-ui/react/pull/1875))
 
 ### Documentation
 - Add usage example regarding `Checkbox` in `Form` @lucivpav ([#1845](https://github.com/stardust-ui/react/pull/1845))

--- a/docs/src/components/ColorSchemes.tsx
+++ b/docs/src/components/ColorSchemes.tsx
@@ -57,7 +57,7 @@ const ColorSchemes = createComponent<ColorVariantsProps>({
     return (
       <div className={classes.root}>
         <Grid columns={columns}>
-          {headers && headers.map(header => Header.create(header))}
+          {headers && headers.map(header => Header.create(header, {}))}
           {elements}
         </Grid>
       </div>

--- a/docs/src/components/ColorSchemes.tsx
+++ b/docs/src/components/ColorSchemes.tsx
@@ -57,7 +57,7 @@ const ColorSchemes = createComponent<ColorVariantsProps>({
     return (
       <div className={classes.root}>
         <Grid columns={columns}>
-          {headers && headers.map(header => Header.create(header, {}))}
+          {headers && headers.map(header => Header.create(header))}
           {elements}
         </Grid>
       </div>

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -11,7 +11,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { WithAsProp, ComponentEventHandler, withSafeTypeForAs } from '../../types'
 import { accordionContentBehavior } from '../../lib/accessibility'
@@ -38,7 +38,7 @@ export interface AccordionContentProps
 class AccordionContent extends UIComponent<WithAsProp<AccordionContentProps>, any> {
   static displayName = 'AccordionContent'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-accordion__content'
 

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -38,7 +38,7 @@ export interface AccordionContentProps
 class AccordionContent extends UIComponent<WithAsProp<AccordionContentProps>, any> {
   static displayName = 'AccordionContent'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<AccordionContentProps>
 
   static className = 'ui-accordion__content'
 

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -11,6 +11,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { WithAsProp, ComponentEventHandler, withSafeTypeForAs } from '../../types'
 import { accordionContentBehavior } from '../../lib/accessibility'
@@ -37,7 +38,7 @@ export interface AccordionContentProps
 class AccordionContent extends UIComponent<WithAsProp<AccordionContentProps>, any> {
   static displayName = 'AccordionContent'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-accordion__content'
 

--- a/packages/react/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/react/src/components/Accordion/AccordionTitle.tsx
@@ -66,7 +66,7 @@ export interface AccordionTitleProps
 class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
   static displayName = 'AccordionTitle'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<AccordionTitleProps>
 
   static className = 'ui-accordion__title'
 
@@ -107,7 +107,8 @@ class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
 
   renderComponent({ ElementType, classes, unhandledProps, styles, accessibility }) {
     const { contentRef, children, content, indicator, active } = this.props
-    const indicatorWithDefaults = indicator === undefined ? {} : indicator
+    const defaultIndicator = { name: active ? 'stardust-arrow-down' : 'stardust-arrow-end' }
+    const indicatorWithDefaults = indicator === undefined ? defaultIndicator : indicator
 
     const contentElement = (
       <Ref innerRef={contentRef}>
@@ -119,7 +120,6 @@ class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
           {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.content, unhandledProps)}
           start={Icon.create(indicatorWithDefaults, {
             defaultProps: {
-              name: active ? 'stardust-arrow-down' : 'stardust-arrow-end',
               styles: styles.indicator,
             },
           })}

--- a/packages/react/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/react/src/components/Accordion/AccordionTitle.tsx
@@ -14,7 +14,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { WithAsProp, ComponentEventHandler, ShorthandValue, withSafeTypeForAs } from '../../types'
 import Icon, { IconProps } from '../Icon/Icon'
@@ -66,7 +66,7 @@ export interface AccordionTitleProps
 class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
   static displayName = 'AccordionTitle'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-accordion__title'
 

--- a/packages/react/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/react/src/components/Accordion/AccordionTitle.tsx
@@ -14,6 +14,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { WithAsProp, ComponentEventHandler, ShorthandValue, withSafeTypeForAs } from '../../types'
 import Icon, { IconProps } from '../Icon/Icon'
@@ -65,7 +66,7 @@ export interface AccordionTitleProps
 class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
   static displayName = 'AccordionTitle'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-accordion__title'
 

--- a/packages/react/src/components/Animation/Animation.tsx
+++ b/packages/react/src/components/Animation/Animation.tsx
@@ -80,7 +80,7 @@ export interface AnimationProps
 }
 
 class Animation extends UIComponent<WithAsProp<AnimationProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<AnimationProps>
 
   static className = 'ui-animation'
 

--- a/packages/react/src/components/Animation/Animation.tsx
+++ b/packages/react/src/components/Animation/Animation.tsx
@@ -8,7 +8,7 @@ import {
   StyledComponentProps,
   commonPropTypes,
   ChildrenComponentProps,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
 
@@ -80,7 +80,7 @@ export interface AnimationProps
 }
 
 class Animation extends UIComponent<WithAsProp<AnimationProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-animation'
 

--- a/packages/react/src/components/Animation/Animation.tsx
+++ b/packages/react/src/components/Animation/Animation.tsx
@@ -8,6 +8,7 @@ import {
   StyledComponentProps,
   commonPropTypes,
   ChildrenComponentProps,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
 
@@ -79,7 +80,7 @@ export interface AnimationProps
 }
 
 class Animation extends UIComponent<WithAsProp<AnimationProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-animation'
 

--- a/packages/react/src/components/Attachment/Attachment.tsx
+++ b/packages/react/src/components/Attachment/Attachment.tsx
@@ -68,7 +68,7 @@ export interface AttachmentSlotClassNames {
 }
 
 class Attachment extends UIComponent<WithAsProp<AttachmentProps>, AttachmentState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<AttachmentProps>
 
   static className = 'ui-attachment'
 

--- a/packages/react/src/components/Attachment/Attachment.tsx
+++ b/packages/react/src/components/Attachment/Attachment.tsx
@@ -9,7 +9,7 @@ import {
   commonPropTypes,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Button, { ButtonProps } from '../Button/Button'
@@ -68,7 +68,7 @@ export interface AttachmentSlotClassNames {
 }
 
 class Attachment extends UIComponent<WithAsProp<AttachmentProps>, AttachmentState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-attachment'
 

--- a/packages/react/src/components/Attachment/Attachment.tsx
+++ b/packages/react/src/components/Attachment/Attachment.tsx
@@ -9,6 +9,7 @@ import {
   commonPropTypes,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Button, { ButtonProps } from '../Button/Button'
@@ -67,7 +68,7 @@ export interface AttachmentSlotClassNames {
 }
 
 class Attachment extends UIComponent<WithAsProp<AttachmentProps>, AttachmentState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-attachment'
 

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -41,7 +41,7 @@ export interface AvatarProps extends UIComponentProps {
 }
 
 class Avatar extends UIComponent<WithAsProp<AvatarProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<AvatarProps>
 
   static className = 'ui-avatar'
 

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -12,6 +12,7 @@ import {
   UIComponentProps,
   commonPropTypes,
   SizeValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 
 export interface AvatarProps extends UIComponentProps {
@@ -40,7 +41,7 @@ export interface AvatarProps extends UIComponentProps {
 }
 
 class Avatar extends UIComponent<WithAsProp<AvatarProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-avatar'
 

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -12,7 +12,7 @@ import {
   UIComponentProps,
   commonPropTypes,
   SizeValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 
 export interface AvatarProps extends UIComponentProps {
@@ -41,7 +41,7 @@ export interface AvatarProps extends UIComponentProps {
 }
 
 class Avatar extends UIComponent<WithAsProp<AvatarProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-avatar'
 

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -88,7 +88,7 @@ export interface ButtonState {
 }
 
 class Button extends UIComponent<WithAsProp<ButtonProps>, ButtonState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ButtonProps>
 
   static displayName = 'Button'
 

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -15,6 +15,7 @@ import {
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
   SizeValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Box, { BoxProps } from '../Box/Box'
@@ -87,7 +88,7 @@ export interface ButtonState {
 }
 
 class Button extends UIComponent<WithAsProp<ButtonProps>, ButtonState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'Button'
 

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -15,7 +15,7 @@ import {
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
   SizeValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Box, { BoxProps } from '../Box/Box'
@@ -88,7 +88,7 @@ export interface ButtonState {
 }
 
 class Button extends UIComponent<WithAsProp<ButtonProps>, ButtonState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'Button'
 

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -35,7 +35,7 @@ export interface ButtonGroupProps
 }
 
 class ButtonGroup extends UIComponent<WithAsProp<ButtonGroupProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ButtonGroupProps>
 
   static displayName = 'ButtonGroup'
 

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -13,7 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   createShorthandFactory,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import Button, { ButtonProps } from './Button'
@@ -35,7 +35,7 @@ export interface ButtonGroupProps
 }
 
 class ButtonGroup extends UIComponent<WithAsProp<ButtonGroupProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'ButtonGroup'
 

--- a/packages/react/src/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/components/Button/ButtonGroup.tsx
@@ -13,6 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   createShorthandFactory,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import Button, { ButtonProps } from './Button'
@@ -34,7 +35,7 @@ export interface ButtonGroupProps
 }
 
 class ButtonGroup extends UIComponent<WithAsProp<ButtonGroupProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'ButtonGroup'
 

--- a/packages/react/src/components/Chat/ChatItem.tsx
+++ b/packages/react/src/components/Chat/ChatItem.tsx
@@ -13,6 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   getElementProp,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Box, { BoxProps } from '../Box/Box'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -46,7 +47,7 @@ export interface ChatItemProps extends UIComponentProps, ChildrenComponentProps 
 
 class ChatItem extends UIComponent<WithAsProp<ChatItemProps>, any> {
   static className = 'ui-chat__item'
-  static create: Function
+  static create: CreateShorthandFactoryResult
   static displayName = 'ChatItem'
   static slotClassNames: ChatItemSlotClassNames
 

--- a/packages/react/src/components/Chat/ChatItem.tsx
+++ b/packages/react/src/components/Chat/ChatItem.tsx
@@ -47,7 +47,7 @@ export interface ChatItemProps extends UIComponentProps, ChildrenComponentProps 
 
 class ChatItem extends UIComponent<WithAsProp<ChatItemProps>, any> {
   static className = 'ui-chat__item'
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ChatItemProps>
   static displayName = 'ChatItem'
   static slotClassNames: ChatItemSlotClassNames
 

--- a/packages/react/src/components/Chat/ChatItem.tsx
+++ b/packages/react/src/components/Chat/ChatItem.tsx
@@ -13,7 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   getElementProp,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Box, { BoxProps } from '../Box/Box'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -47,7 +47,7 @@ export interface ChatItemProps extends UIComponentProps, ChildrenComponentProps 
 
 class ChatItem extends UIComponent<WithAsProp<ChatItemProps>, any> {
   static className = 'ui-chat__item'
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
   static displayName = 'ChatItem'
   static slotClassNames: ChatItemSlotClassNames
 

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -107,7 +107,7 @@ export interface ChatMessageState {
 class ChatMessage extends UIComponent<WithAsProp<ChatMessageProps>, ChatMessageState> {
   static className = 'ui-chat__message'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ChatMessageProps>
 
   static slotClassNames: ChatMessageSlotClassNames
 

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -18,6 +18,7 @@ import {
   isFromKeyboard,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import {
   WithAsProp,
@@ -106,7 +107,7 @@ export interface ChatMessageState {
 class ChatMessage extends UIComponent<WithAsProp<ChatMessageProps>, ChatMessageState> {
   static className = 'ui-chat__message'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static slotClassNames: ChatMessageSlotClassNames
 

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -18,7 +18,7 @@ import {
   isFromKeyboard,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import {
   WithAsProp,
@@ -107,7 +107,7 @@ export interface ChatMessageState {
 class ChatMessage extends UIComponent<WithAsProp<ChatMessageProps>, ChatMessageState> {
   static className = 'ui-chat__message'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static slotClassNames: ChatMessageSlotClassNames
 

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -11,7 +11,7 @@ import {
   commonPropTypes,
   isFromKeyboard,
   UIComponentProps,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { ComponentEventHandler, WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
 import Icon, { IconProps } from '../Icon/Icon'
@@ -73,7 +73,7 @@ export interface CheckboxState {
 class Checkbox extends AutoControlledComponent<WithAsProp<CheckboxProps>, CheckboxState> {
   static slotClassNames: CheckboxSlotClassNames
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'Checkbox'
 

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -73,7 +73,7 @@ export interface CheckboxState {
 class Checkbox extends AutoControlledComponent<WithAsProp<CheckboxProps>, CheckboxState> {
   static slotClassNames: CheckboxSlotClassNames
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<CheckboxProps>
 
   static displayName = 'Checkbox'
 

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -11,6 +11,7 @@ import {
   commonPropTypes,
   isFromKeyboard,
   UIComponentProps,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { ComponentEventHandler, WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
 import Icon, { IconProps } from '../Icon/Icon'
@@ -72,7 +73,7 @@ export interface CheckboxState {
 class Checkbox extends AutoControlledComponent<WithAsProp<CheckboxProps>, CheckboxState> {
   static slotClassNames: CheckboxSlotClassNames
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'Checkbox'
 

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -40,7 +40,7 @@ export interface DividerProps
 class Divider extends UIComponent<WithAsProp<DividerProps>, any> {
   static displayName = 'Divider'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<DividerProps>
 
   static className = 'ui-divider'
 

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -11,7 +11,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -40,7 +40,7 @@ export interface DividerProps
 class Divider extends UIComponent<WithAsProp<DividerProps>, any> {
   static displayName = 'Divider'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-divider'
 

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -11,6 +11,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -39,7 +40,7 @@ export interface DividerProps
 class Divider extends UIComponent<WithAsProp<DividerProps>, any> {
   static displayName = 'Divider'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-divider'
 

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -743,8 +743,10 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       !loading &&
         items.length === 0 &&
         ListItem.create(noResultsMessage, {
-          key: 'no-results-message',
-          styles: styles.noResultsMessage,
+          defaultProps: {
+            key: 'no-results-message',
+            styles: styles.noResultsMessage,
+          },
         }),
     ]
   }

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -64,7 +64,7 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
 class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
   static displayName = 'DropdownItem'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<DropdownItemProps>
 
   static className = 'ui-dropdown__item'
 

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -8,7 +8,7 @@ import {
   RenderResultConfig,
   createShorthandFactory,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { ShorthandValue, ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
@@ -64,7 +64,7 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
 class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
   static displayName = 'DropdownItem'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-dropdown__item'
 

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -3,7 +3,13 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
-import { UIComponent, RenderResultConfig, createShorthandFactory, commonPropTypes } from '../../lib'
+import {
+  UIComponent,
+  RenderResultConfig,
+  createShorthandFactory,
+  commonPropTypes,
+  CreateShorthandFactoryResult,
+} from '../../lib'
 import { ShorthandValue, ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import ListItem from '../List/ListItem'
@@ -58,7 +64,7 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
 class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
   static displayName = 'DropdownItem'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-dropdown__item'
 

--- a/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -8,7 +8,7 @@ import {
   RenderResultConfig,
   createShorthandFactory,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
@@ -70,7 +70,7 @@ export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearc
 
 class DropdownSearchInput extends UIComponent<WithAsProp<DropdownSearchInputProps>, any> {
   static displayName = 'DropdownSearchInput'
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
   static slotClassNames: DropdownSearchInputSlotClassNames
   static className = 'ui-dropdown__searchinput'
 

--- a/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -3,7 +3,13 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
 
-import { UIComponent, RenderResultConfig, createShorthandFactory, commonPropTypes } from '../../lib'
+import {
+  UIComponent,
+  RenderResultConfig,
+  createShorthandFactory,
+  commonPropTypes,
+  CreateShorthandFactoryResult,
+} from '../../lib'
 import { ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
 import Input from '../Input/Input'
@@ -64,7 +70,7 @@ export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearc
 
 class DropdownSearchInput extends UIComponent<WithAsProp<DropdownSearchInputProps>, any> {
   static displayName = 'DropdownSearchInput'
-  static create: Function
+  static create: CreateShorthandFactoryResult
   static slotClassNames: DropdownSearchInputSlotClassNames
   static className = 'ui-dropdown__searchinput'
 

--- a/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -70,7 +70,7 @@ export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearc
 
 class DropdownSearchInput extends UIComponent<WithAsProp<DropdownSearchInputProps>, any> {
   static displayName = 'DropdownSearchInput'
-  static create: ShorthandFactory
+  static create: ShorthandFactory<DropdownSearchInputProps>
   static slotClassNames: DropdownSearchInputSlotClassNames
   static className = 'ui-dropdown__searchinput'
 

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -73,7 +73,7 @@ class DropdownSelectedItem extends UIComponent<WithAsProp<DropdownSelectedItemPr
   itemRef = React.createRef<HTMLElement>()
 
   static displayName = 'DropdownSelectedItem'
-  static create: ShorthandFactory
+  static create: ShorthandFactory<DropdownSelectedItemProps>
   static slotClassNames: DropdownSelectedItemSlotClassNames
   static className = 'ui-dropdown__selecteditem'
 

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -18,7 +18,7 @@ import {
   UIComponent,
   RenderResultConfig,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Image, { ImageProps } from '../Image/Image'
@@ -73,7 +73,7 @@ class DropdownSelectedItem extends UIComponent<WithAsProp<DropdownSelectedItemPr
   itemRef = React.createRef<HTMLElement>()
 
   static displayName = 'DropdownSelectedItem'
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
   static slotClassNames: DropdownSelectedItemSlotClassNames
   static className = 'ui-dropdown__selecteditem'
 

--- a/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -13,7 +13,13 @@ import {
   withSafeTypeForAs,
 } from '../../types'
 import { UIComponentProps } from '../../lib/commonPropInterfaces'
-import { createShorthandFactory, UIComponent, RenderResultConfig, commonPropTypes } from '../../lib'
+import {
+  createShorthandFactory,
+  UIComponent,
+  RenderResultConfig,
+  commonPropTypes,
+  CreateShorthandFactoryResult,
+} from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Image, { ImageProps } from '../Image/Image'
 import Label from '../Label/Label'
@@ -67,7 +73,7 @@ class DropdownSelectedItem extends UIComponent<WithAsProp<DropdownSelectedItemPr
   itemRef = React.createRef<HTMLElement>()
 
   static displayName = 'DropdownSelectedItem'
-  static create: Function
+  static create: CreateShorthandFactoryResult
   static slotClassNames: DropdownSelectedItemSlotClassNames
   static className = 'ui-dropdown__selecteditem'
 

--- a/packages/react/src/components/Embed/Embed.tsx
+++ b/packages/react/src/components/Embed/Embed.tsx
@@ -10,6 +10,7 @@ import {
   commonPropTypes,
   AutoControlledComponent,
   isFromKeyboard,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { embedBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -74,7 +75,7 @@ export interface EmbedState {
 }
 
 class Embed extends AutoControlledComponent<WithAsProp<EmbedProps>, EmbedState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-embed'
 

--- a/packages/react/src/components/Embed/Embed.tsx
+++ b/packages/react/src/components/Embed/Embed.tsx
@@ -10,7 +10,7 @@ import {
   commonPropTypes,
   AutoControlledComponent,
   isFromKeyboard,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { embedBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -75,7 +75,7 @@ export interface EmbedState {
 }
 
 class Embed extends AutoControlledComponent<WithAsProp<EmbedProps>, EmbedState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-embed'
 

--- a/packages/react/src/components/Embed/Embed.tsx
+++ b/packages/react/src/components/Embed/Embed.tsx
@@ -75,7 +75,7 @@ export interface EmbedState {
 }
 
 class Embed extends AutoControlledComponent<WithAsProp<EmbedProps>, EmbedState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<EmbedProps>
 
   static className = 'ui-embed'
 

--- a/packages/react/src/components/Flex/FlexItem.tsx
+++ b/packages/react/src/components/Flex/FlexItem.tsx
@@ -81,7 +81,7 @@ class FlexItem extends UIComponent<FlexItemProps> {
 
   displayName: 'FlexItem'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<FlexItemProps>
 
   // Boolean flag for now, Symbol-based approach may be used instead.
   // However, there are  concerns related to browser compatibility if Symbols will be used.

--- a/packages/react/src/components/Flex/FlexItem.tsx
+++ b/packages/react/src/components/Flex/FlexItem.tsx
@@ -2,7 +2,13 @@ import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import cx from 'classnames'
 import * as _ from 'lodash'
-import { UIComponent, commonPropTypes, UIComponentProps, ChildrenComponentProps } from '../../lib'
+import {
+  UIComponent,
+  commonPropTypes,
+  UIComponentProps,
+  ChildrenComponentProps,
+  CreateShorthandFactoryResult,
+} from '../../lib'
 import { mergeStyles } from '../../lib/mergeThemes'
 import { ComponentSlotStylesPrepared } from '../../themes/types'
 
@@ -75,7 +81,7 @@ class FlexItem extends UIComponent<FlexItemProps> {
 
   displayName: 'FlexItem'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   // Boolean flag for now, Symbol-based approach may be used instead.
   // However, there are  concerns related to browser compatibility if Symbols will be used.

--- a/packages/react/src/components/Flex/FlexItem.tsx
+++ b/packages/react/src/components/Flex/FlexItem.tsx
@@ -7,7 +7,7 @@ import {
   commonPropTypes,
   UIComponentProps,
   ChildrenComponentProps,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { mergeStyles } from '../../lib/mergeThemes'
 import { ComponentSlotStylesPrepared } from '../../themes/types'
@@ -81,7 +81,7 @@ class FlexItem extends UIComponent<FlexItemProps> {
 
   displayName: 'FlexItem'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   // Boolean flag for now, Symbol-based approach may be used instead.
   // However, there are  concerns related to browser compatibility if Symbols will be used.

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -10,7 +10,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import {
@@ -46,7 +46,7 @@ export interface FormProps extends UIComponentProps, ChildrenComponentProps {
 }
 
 class Form extends UIComponent<WithAsProp<FormProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'Form'
 

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -10,6 +10,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import {
@@ -45,7 +46,7 @@ export interface FormProps extends UIComponentProps, ChildrenComponentProps {
 }
 
 class Form extends UIComponent<WithAsProp<FormProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'Form'
 

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -46,7 +46,7 @@ export interface FormProps extends UIComponentProps, ChildrenComponentProps {
 }
 
 class Form extends UIComponent<WithAsProp<FormProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<FormProps>
 
   static displayName = 'Form'
 

--- a/packages/react/src/components/Form/FormField.tsx
+++ b/packages/react/src/components/Form/FormField.tsx
@@ -54,7 +54,7 @@ class FormField extends UIComponent<WithAsProp<FormFieldProps>, any> {
 
   static className = 'ui-form__field'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<FormFieldProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Form/FormField.tsx
+++ b/packages/react/src/components/Form/FormField.tsx
@@ -9,7 +9,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -54,7 +54,7 @@ class FormField extends UIComponent<WithAsProp<FormFieldProps>, any> {
 
   static className = 'ui-form__field'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Form/FormField.tsx
+++ b/packages/react/src/components/Form/FormField.tsx
@@ -9,6 +9,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -53,7 +54,7 @@ class FormField extends UIComponent<WithAsProp<FormFieldProps>, any> {
 
   static className = 'ui-form__field'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -50,7 +50,7 @@ class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
     description: `${Header.className}__description`,
   }
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<HeaderProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon({ color: true }),

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -13,6 +13,7 @@ import {
   ColorComponentProps,
   rtlTextContainer,
   AlignValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import HeaderDescription, { HeaderDescriptionProps } from './HeaderDescription'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -49,7 +50,7 @@ class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
     description: `${Header.className}__description`,
   }
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon({ color: true }),

--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -13,7 +13,7 @@ import {
   ColorComponentProps,
   rtlTextContainer,
   AlignValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import HeaderDescription, { HeaderDescriptionProps } from './HeaderDescription'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -50,7 +50,7 @@ class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
     description: `${Header.className}__description`,
   }
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon({ color: true }),

--- a/packages/react/src/components/Header/HeaderDescription.tsx
+++ b/packages/react/src/components/Header/HeaderDescription.tsx
@@ -10,7 +10,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -28,7 +28,7 @@ export interface HeaderDescriptionProps
 }
 
 class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-header__description'
 

--- a/packages/react/src/components/Header/HeaderDescription.tsx
+++ b/packages/react/src/components/Header/HeaderDescription.tsx
@@ -28,7 +28,7 @@ export interface HeaderDescriptionProps
 }
 
 class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<HeaderDescriptionProps>
 
   static className = 'ui-header__description'
 

--- a/packages/react/src/components/Header/HeaderDescription.tsx
+++ b/packages/react/src/components/Header/HeaderDescription.tsx
@@ -10,6 +10,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -27,7 +28,7 @@ export interface HeaderDescriptionProps
 }
 
 class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-header__description'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
@@ -13,6 +13,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import {
   ShorthandValue,
@@ -70,7 +71,7 @@ class HierarchicalTree extends AutoControlledComponent<
   WithAsProp<HierarchicalTreeProps>,
   HierarchicalTreeState
 > {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'HierarchicalTree'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
@@ -71,7 +71,7 @@ class HierarchicalTree extends AutoControlledComponent<
   WithAsProp<HierarchicalTreeProps>,
   HierarchicalTreeState
 > {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<HierarchicalTreeProps>
 
   static displayName = 'HierarchicalTree'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTree.tsx
@@ -13,7 +13,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import {
   ShorthandValue,
@@ -71,7 +71,7 @@ class HierarchicalTree extends AutoControlledComponent<
   WithAsProp<HierarchicalTreeProps>,
   HierarchicalTreeState
 > {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'HierarchicalTree'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
@@ -68,7 +68,7 @@ export interface HierarchicalTreeItemProps extends UIComponentProps, ChildrenCom
 }
 
 class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<HierarchicalTreeItemProps>
 
   static displayName = 'HierarchicalTreeItem'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
@@ -17,7 +17,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import {
   ComponentEventHandler,
@@ -68,7 +68,7 @@ export interface HierarchicalTreeItemProps extends UIComponentProps, ChildrenCom
 }
 
 class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'HierarchicalTreeItem'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
@@ -17,6 +17,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import {
   ComponentEventHandler,
@@ -67,7 +68,7 @@ export interface HierarchicalTreeItemProps extends UIComponentProps, ChildrenCom
 }
 
 class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'HierarchicalTreeItem'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
@@ -12,6 +12,7 @@ import {
   ContentComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { hierarchicalTreeTitleBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -40,7 +41,7 @@ export interface HierarchicalTreeTitleProps
 }
 
 class HierarchicalTreeTitle extends UIComponent<WithAsProp<HierarchicalTreeTitleProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-hierarchicaltree__title'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
@@ -41,7 +41,7 @@ export interface HierarchicalTreeTitleProps
 }
 
 class HierarchicalTreeTitle extends UIComponent<WithAsProp<HierarchicalTreeTitleProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<HierarchicalTreeTitleProps>
 
   static className = 'ui-hierarchicaltree__title'
 

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
@@ -12,7 +12,7 @@ import {
   ContentComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { hierarchicalTreeTitleBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -41,7 +41,7 @@ export interface HierarchicalTreeTitleProps
 }
 
 class HierarchicalTreeTitle extends UIComponent<WithAsProp<HierarchicalTreeTitleProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-hierarchicaltree__title'
 

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -9,6 +9,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   SizeValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { iconBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -46,7 +47,7 @@ export interface IconProps extends UIComponentProps, ColorComponentProps {
 }
 
 class Icon extends UIComponent<WithAsProp<IconProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-icon'
 

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -9,7 +9,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   SizeValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { iconBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -47,7 +47,7 @@ export interface IconProps extends UIComponentProps, ColorComponentProps {
 }
 
 class Icon extends UIComponent<WithAsProp<IconProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-icon'
 

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -47,7 +47,7 @@ export interface IconProps extends UIComponentProps, ColorComponentProps {
 }
 
 class Icon extends UIComponent<WithAsProp<IconProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<IconProps>
 
   static className = 'ui-icon'
 

--- a/packages/react/src/components/Image/Image.tsx
+++ b/packages/react/src/components/Image/Image.tsx
@@ -31,7 +31,7 @@ export interface ImageProps extends UIComponentProps {
 }
 
 class Image extends UIComponent<WithAsProp<ImageProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ImageProps>
 
   static className = 'ui-image'
 

--- a/packages/react/src/components/Image/Image.tsx
+++ b/packages/react/src/components/Image/Image.tsx
@@ -6,7 +6,7 @@ import {
   UIComponent,
   UIComponentProps,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { imageBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -31,7 +31,7 @@ export interface ImageProps extends UIComponentProps {
 }
 
 class Image extends UIComponent<WithAsProp<ImageProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-image'
 

--- a/packages/react/src/components/Image/Image.tsx
+++ b/packages/react/src/components/Image/Image.tsx
@@ -1,7 +1,13 @@
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
-import { createShorthandFactory, UIComponent, UIComponentProps, commonPropTypes } from '../../lib'
+import {
+  createShorthandFactory,
+  UIComponent,
+  UIComponentProps,
+  commonPropTypes,
+  CreateShorthandFactoryResult,
+} from '../../lib'
 import { imageBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -25,7 +31,7 @@ export interface ImageProps extends UIComponentProps {
 }
 
 class Image extends UIComponent<WithAsProp<ImageProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-image'
 

--- a/packages/react/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/react/src/components/ItemLayout/ItemLayout.tsx
@@ -66,7 +66,7 @@ export interface ItemLayoutProps extends UIComponentProps, ContentComponentProps
 }
 
 class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ItemLayoutProps>
 
   static displayName = 'ItemLayout'
 

--- a/packages/react/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/react/src/components/ItemLayout/ItemLayout.tsx
@@ -10,7 +10,7 @@ import {
   commonPropTypes,
   ContentComponentProps,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Layout from '../Layout/Layout'
 import { ComponentSlotClasses } from '../../themes/types'
@@ -66,7 +66,7 @@ export interface ItemLayoutProps extends UIComponentProps, ContentComponentProps
 }
 
 class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'ItemLayout'
 

--- a/packages/react/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/react/src/components/ItemLayout/ItemLayout.tsx
@@ -10,6 +10,7 @@ import {
   commonPropTypes,
   ContentComponentProps,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Layout from '../Layout/Layout'
 import { ComponentSlotClasses } from '../../themes/types'
@@ -65,7 +66,7 @@ export interface ItemLayoutProps extends UIComponentProps, ContentComponentProps
 }
 
 class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'ItemLayout'
 

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -55,7 +55,7 @@ export interface LabelProps
 class Label extends UIComponent<WithAsProp<LabelProps>, any> {
   static displayName = 'Label'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<LabelProps>
 
   static className = 'ui-label'
 

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -13,7 +13,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 
 import Icon, { IconProps } from '../Icon/Icon'
@@ -55,7 +55,7 @@ export interface LabelProps
 class Label extends UIComponent<WithAsProp<LabelProps>, any> {
   static displayName = 'Label'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-label'
 

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -13,6 +13,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 
 import Icon, { IconProps } from '../Icon/Icon'
@@ -54,7 +55,7 @@ export interface LabelProps
 class Label extends UIComponent<WithAsProp<LabelProps>, any> {
   static displayName = 'Label'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-label'
 

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -72,7 +72,7 @@ export interface ListItemState {
 }
 
 class ListItem extends UIComponent<WithAsProp<ListItemProps>, ListItemState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ListItemProps>
 
   static displayName = 'ListItem'
 

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -9,6 +9,7 @@ import {
   ContentComponentProps,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Flex from '../Flex/Flex'
 import { listItemBehavior } from '../../lib/accessibility'
@@ -71,7 +72,7 @@ export interface ListItemState {
 }
 
 class ListItem extends UIComponent<WithAsProp<ListItemProps>, ListItemState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'ListItem'
 

--- a/packages/react/src/components/List/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem.tsx
@@ -9,7 +9,7 @@ import {
   ContentComponentProps,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Flex from '../Flex/Flex'
 import { listItemBehavior } from '../../lib/accessibility'
@@ -72,7 +72,7 @@ export interface ListItemState {
 }
 
 class ListItem extends UIComponent<WithAsProp<ListItemProps>, ListItemState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'ListItem'
 

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -56,7 +56,7 @@ export interface LoaderState {
  * A loader alerts a user that content is being loaded or processed and they should wait for the activity to complete.
  */
 class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<LoaderProps>
   static displayName = 'Loader'
   static className = 'ui-loader'
   static slotClassNames: LoaderSlotClassNames = {

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -8,7 +8,7 @@ import {
   UIComponentProps,
   commonPropTypes,
   SizeValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { loaderBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -56,7 +56,7 @@ export interface LoaderState {
  * A loader alerts a user that content is being loaded or processed and they should wait for the activity to complete.
  */
 class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
   static displayName = 'Loader'
   static className = 'ui-loader'
   static slotClassNames: LoaderSlotClassNames = {

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -8,6 +8,7 @@ import {
   UIComponentProps,
   commonPropTypes,
   SizeValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { loaderBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -55,7 +56,7 @@ export interface LoaderState {
  * A loader alerts a user that content is being loaded or processed and they should wait for the activity to complete.
  */
 class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
   static displayName = 'Loader'
   static className = 'ui-loader'
   static slotClassNames: LoaderSlotClassNames = {

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -12,6 +12,7 @@ import {
   commonPropTypes,
   getKindProp,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -109,7 +110,7 @@ class Menu extends AutoControlledComponent<WithAsProp<MenuProps>, MenuState> {
     item: `${Menu.className}__item`,
   }
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -12,7 +12,7 @@ import {
   commonPropTypes,
   getKindProp,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -110,7 +110,7 @@ class Menu extends AutoControlledComponent<WithAsProp<MenuProps>, MenuState> {
     item: `${Menu.className}__item`,
   }
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -110,7 +110,7 @@ class Menu extends AutoControlledComponent<WithAsProp<MenuProps>, MenuState> {
     item: `${Menu.className}__item`,
   }
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<MenuProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -12,7 +12,7 @@ import {
   ChildrenComponentProps,
   ContentComponentProps,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
 
@@ -32,7 +32,7 @@ export interface MenuDividerProps
 class MenuDivider extends UIComponent<WithAsProp<MenuDividerProps>> {
   static displayName = 'MenuDivider'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-menu__divider'
 

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -12,6 +12,7 @@ import {
   ChildrenComponentProps,
   ContentComponentProps,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
 
@@ -31,7 +32,7 @@ export interface MenuDividerProps
 class MenuDivider extends UIComponent<WithAsProp<MenuDividerProps>> {
   static displayName = 'MenuDivider'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-menu__divider'
 

--- a/packages/react/src/components/Menu/MenuDivider.tsx
+++ b/packages/react/src/components/Menu/MenuDivider.tsx
@@ -32,7 +32,7 @@ export interface MenuDividerProps
 class MenuDivider extends UIComponent<WithAsProp<MenuDividerProps>> {
   static displayName = 'MenuDivider'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<MenuDividerProps>
 
   static className = 'ui-menu__divider'
 

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -18,6 +18,7 @@ import {
   isFromKeyboard,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Menu, { MenuProps, MenuShorthandKinds } from './Menu'
@@ -157,7 +158,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
     wrapper: `${MenuItem.className}__wrapper`,
   }
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -158,7 +158,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
     wrapper: `${MenuItem.className}__wrapper`,
   }
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<MenuItemProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon(),
@@ -215,7 +215,8 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
     } = this.props
     const { menuOpen } = this.state
 
-    const indicatorWithDefaults = indicator === undefined ? {} : indicator
+    const defaultIndicator = { name: vertical ? 'stardust-arrow-end' : 'stardust-arrow-down' }
+    const indicatorWithDefaults = indicator === undefined ? defaultIndicator : indicator
     const targetRef = toRefObject(this.context.target)
 
     const menuItemInner = childrenExist(children) ? (
@@ -244,7 +245,6 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
           {menu &&
             Icon.create(indicatorWithDefaults, {
               defaultProps: {
-                name: vertical ? 'stardust-arrow-end' : 'stardust-arrow-down',
                 styles: styles.indicator,
               },
             })}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -18,7 +18,7 @@ import {
   isFromKeyboard,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Icon, { IconProps } from '../Icon/Icon'
 import Menu, { MenuProps, MenuShorthandKinds } from './Menu'
@@ -158,7 +158,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
     wrapper: `${MenuItem.className}__wrapper`,
   }
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/MenuButton/MenuButton.tsx
+++ b/packages/react/src/components/MenuButton/MenuButton.tsx
@@ -98,7 +98,7 @@ export default class MenuButton extends AutoControlledComponent<MenuButtonProps,
 
   static className = 'ui-menubutton'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<MenuButtonProps>
 
   static slotClassNames: MenuButtonSlotClassNames = {
     menu: `${MenuButton.className}__menu`,

--- a/packages/react/src/components/MenuButton/MenuButton.tsx
+++ b/packages/react/src/components/MenuButton/MenuButton.tsx
@@ -14,7 +14,7 @@ import {
 import { ShorthandValue, ComponentEventHandler, ShorthandCollection } from '../../types'
 
 import { Accessibility } from '../../lib/accessibility/types'
-import { createShorthandFactory, CreateShorthandFactoryResult } from '../../lib/factories'
+import { createShorthandFactory, ShorthandFactory } from '../../lib/factories'
 import Popup, { PopupProps, PopupEvents, PopupEventsArray } from '../Popup/Popup'
 import Menu, { MenuProps } from '../Menu/Menu'
 import { MenuItemProps } from '../Menu/MenuItem'
@@ -98,7 +98,7 @@ export default class MenuButton extends AutoControlledComponent<MenuButtonProps,
 
   static className = 'ui-menubutton'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static slotClassNames: MenuButtonSlotClassNames = {
     menu: `${MenuButton.className}__menu`,

--- a/packages/react/src/components/MenuButton/MenuButton.tsx
+++ b/packages/react/src/components/MenuButton/MenuButton.tsx
@@ -14,7 +14,7 @@ import {
 import { ShorthandValue, ComponentEventHandler, ShorthandCollection } from '../../types'
 
 import { Accessibility } from '../../lib/accessibility/types'
-import { createShorthandFactory } from '../../lib/factories'
+import { createShorthandFactory, CreateShorthandFactoryResult } from '../../lib/factories'
 import Popup, { PopupProps, PopupEvents, PopupEventsArray } from '../Popup/Popup'
 import Menu, { MenuProps } from '../Menu/Menu'
 import { MenuItemProps } from '../Menu/MenuItem'
@@ -98,7 +98,7 @@ export default class MenuButton extends AutoControlledComponent<MenuButtonProps,
 
   static className = 'ui-menubutton'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static slotClassNames: MenuButtonSlotClassNames = {
     menu: `${MenuButton.className}__menu`,

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -34,7 +34,7 @@ import { AutoFocusZoneProps, FocusTrapZoneProps } from '../../lib/accessibility/
 
 import { Accessibility } from '../../lib/accessibility/types'
 import { ReactAccessibilityBehavior } from '../../lib/accessibility/reactTypes'
-import { createShorthandFactory, CreateShorthandFactoryResult } from '../../lib/factories'
+import { createShorthandFactory, ShorthandFactory } from '../../lib/factories'
 import createReferenceFromContextClick from './createReferenceFromContextClick'
 import isRightClick from '../../lib/isRightClick'
 import PortalInner from '../Portal/PortalInner'
@@ -133,7 +133,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
 
   static className = 'ui-popup'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static slotClassNames: PopupSlotClassNames = {
     content: `${Popup.className}__content`,

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -34,7 +34,7 @@ import { AutoFocusZoneProps, FocusTrapZoneProps } from '../../lib/accessibility/
 
 import { Accessibility } from '../../lib/accessibility/types'
 import { ReactAccessibilityBehavior } from '../../lib/accessibility/reactTypes'
-import { createShorthandFactory } from '../../lib/factories'
+import { createShorthandFactory, CreateShorthandFactoryResult } from '../../lib/factories'
 import createReferenceFromContextClick from './createReferenceFromContextClick'
 import isRightClick from '../../lib/isRightClick'
 import PortalInner from '../Portal/PortalInner'
@@ -133,7 +133,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
 
   static className = 'ui-popup'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static slotClassNames: PopupSlotClassNames = {
     content: `${Popup.className}__content`,

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -133,7 +133,7 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
 
   static className = 'ui-popup'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<PopupProps>
 
   static slotClassNames: PopupSlotClassNames = {
     content: `${Popup.className}__content`,

--- a/packages/react/src/components/Popup/PopupContent.tsx
+++ b/packages/react/src/components/Popup/PopupContent.tsx
@@ -69,7 +69,7 @@ export interface PopupContentProps
 }
 
 class PopupContent extends UIComponent<WithAsProp<PopupContentProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<PopupContentProps>
 
   static displayName = 'PopupContent'
   static className = 'ui-popup__content'

--- a/packages/react/src/components/Popup/PopupContent.tsx
+++ b/packages/react/src/components/Popup/PopupContent.tsx
@@ -14,7 +14,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import {
@@ -69,7 +69,7 @@ export interface PopupContentProps
 }
 
 class PopupContent extends UIComponent<WithAsProp<PopupContentProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'PopupContent'
   static className = 'ui-popup__content'

--- a/packages/react/src/components/Popup/PopupContent.tsx
+++ b/packages/react/src/components/Popup/PopupContent.tsx
@@ -14,6 +14,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import {
@@ -68,7 +69,7 @@ export interface PopupContentProps
 }
 
 class PopupContent extends UIComponent<WithAsProp<PopupContentProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'PopupContent'
   static className = 'ui-popup__content'

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -62,7 +62,7 @@ class RadioGroup extends AutoControlledComponent<WithAsProp<RadioGroupProps>, an
     item: `${RadioGroup.className}__item`,
   }
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<RadioGroupProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -13,6 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import RadioGroupItem, { RadioGroupItemProps } from './RadioGroupItem'
 import { radioGroupBehavior } from '../../lib/accessibility'
@@ -61,7 +62,7 @@ class RadioGroup extends AutoControlledComponent<WithAsProp<RadioGroupProps>, an
     item: `${RadioGroup.className}__item`,
   }
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -13,7 +13,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import RadioGroupItem, { RadioGroupItemProps } from './RadioGroupItem'
 import { radioGroupBehavior } from '../../lib/accessibility'
@@ -62,7 +62,7 @@ class RadioGroup extends AutoControlledComponent<WithAsProp<RadioGroupProps>, an
     item: `${RadioGroup.className}__item`,
   }
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
@@ -12,7 +12,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import Box, { BoxProps } from '../Box/Box'
 import { ComponentEventHandler, WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
@@ -91,7 +91,7 @@ class RadioGroupItem extends AutoControlledComponent<
 > {
   elementRef = React.createRef<HTMLElement>()
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'RadioGroupItem'
 

--- a/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
@@ -91,7 +91,7 @@ class RadioGroupItem extends AutoControlledComponent<
 > {
   elementRef = React.createRef<HTMLElement>()
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<RadioGroupItemProps>
 
   static displayName = 'RadioGroupItem'
 

--- a/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroupItem.tsx
@@ -12,6 +12,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import Box, { BoxProps } from '../Box/Box'
 import { ComponentEventHandler, WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
@@ -90,7 +91,7 @@ class RadioGroupItem extends AutoControlledComponent<
 > {
   elementRef = React.createRef<HTMLElement>()
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'RadioGroupItem'
 

--- a/packages/react/src/components/Reaction/Reaction.tsx
+++ b/packages/react/src/components/Reaction/Reaction.tsx
@@ -13,6 +13,7 @@ import {
   createShorthandFactory,
   ContentComponentProps,
   isFromKeyboard,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -51,7 +52,7 @@ export interface ReactionState {
 }
 
 class Reaction extends UIComponent<WithAsProp<ReactionProps>, ReactionState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-reaction'
 

--- a/packages/react/src/components/Reaction/Reaction.tsx
+++ b/packages/react/src/components/Reaction/Reaction.tsx
@@ -52,7 +52,7 @@ export interface ReactionState {
 }
 
 class Reaction extends UIComponent<WithAsProp<ReactionProps>, ReactionState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ReactionProps>
 
   static className = 'ui-reaction'
 

--- a/packages/react/src/components/Reaction/Reaction.tsx
+++ b/packages/react/src/components/Reaction/Reaction.tsx
@@ -13,7 +13,7 @@ import {
   createShorthandFactory,
   ContentComponentProps,
   isFromKeyboard,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -52,7 +52,7 @@ export interface ReactionState {
 }
 
 class Reaction extends UIComponent<WithAsProp<ReactionProps>, ReactionState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-reaction'
 

--- a/packages/react/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/react/src/components/Reaction/ReactionGroup.tsx
@@ -12,7 +12,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   createShorthandFactory,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import Reaction, { ReactionProps } from './Reaction'
@@ -31,7 +31,7 @@ export interface ReactionGroupProps
 }
 
 class ReactionGroup extends UIComponent<WithAsProp<ReactionGroupProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'ReactionGroup'
 

--- a/packages/react/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/react/src/components/Reaction/ReactionGroup.tsx
@@ -12,6 +12,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
   createShorthandFactory,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import Reaction, { ReactionProps } from './Reaction'
@@ -30,7 +31,7 @@ export interface ReactionGroupProps
 }
 
 class ReactionGroup extends UIComponent<WithAsProp<ReactionGroupProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'ReactionGroup'
 

--- a/packages/react/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/react/src/components/Reaction/ReactionGroup.tsx
@@ -31,7 +31,7 @@ export interface ReactionGroupProps
 }
 
 class ReactionGroup extends UIComponent<WithAsProp<ReactionGroupProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ReactionGroupProps>
 
   static displayName = 'ReactionGroup'
 

--- a/packages/react/src/components/Segment/Segment.tsx
+++ b/packages/react/src/components/Segment/Segment.tsx
@@ -61,7 +61,7 @@ class Segment extends UIComponent<WithAsProp<SegmentProps>, any> {
         {...unhandledProps}
         className={classes.root}
       >
-        {childrenExist(children) ? children : Box.create(content, {})}
+        {childrenExist(children) ? children : Box.create(content)}
       </ElementType>
     )
   }

--- a/packages/react/src/components/Segment/Segment.tsx
+++ b/packages/react/src/components/Segment/Segment.tsx
@@ -61,7 +61,7 @@ class Segment extends UIComponent<WithAsProp<SegmentProps>, any> {
         {...unhandledProps}
         className={classes.root}
       >
-        {childrenExist(children) ? children : Box.create(content)}
+        {childrenExist(children) ? children : Box.create(content, {})}
       </ElementType>
     )
   }

--- a/packages/react/src/components/Status/Status.tsx
+++ b/packages/react/src/components/Status/Status.tsx
@@ -11,7 +11,7 @@ import {
   UIComponentProps,
   commonPropTypes,
   SizeValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
 
@@ -33,7 +33,7 @@ export interface StatusProps extends UIComponentProps {
 }
 
 class Status extends UIComponent<WithAsProp<StatusProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-status'
 

--- a/packages/react/src/components/Status/Status.tsx
+++ b/packages/react/src/components/Status/Status.tsx
@@ -11,6 +11,7 @@ import {
   UIComponentProps,
   commonPropTypes,
   SizeValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types'
 
@@ -32,7 +33,7 @@ export interface StatusProps extends UIComponentProps {
 }
 
 class Status extends UIComponent<WithAsProp<StatusProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-status'
 

--- a/packages/react/src/components/Status/Status.tsx
+++ b/packages/react/src/components/Status/Status.tsx
@@ -33,7 +33,7 @@ export interface StatusProps extends UIComponentProps {
 }
 
 class Status extends UIComponent<WithAsProp<StatusProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<StatusProps>
 
   static className = 'ui-status'
 

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -14,6 +14,7 @@ import {
   rtlTextContainer,
   SizeValue,
   AlignValue,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -64,7 +65,7 @@ export interface TextProps
 }
 
 class Text extends UIComponent<WithAsProp<TextProps>, any> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-text'
 

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -14,7 +14,7 @@ import {
   rtlTextContainer,
   SizeValue,
   AlignValue,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -65,7 +65,7 @@ export interface TextProps
 }
 
 class Text extends UIComponent<WithAsProp<TextProps>, any> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-text'
 

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -65,7 +65,7 @@ export interface TextProps
 }
 
 class Text extends UIComponent<WithAsProp<TextProps>, any> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<TextProps>
 
   static className = 'ui-text'
 

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -78,7 +78,7 @@ export interface ToolbarSlotClassNames {
 }
 
 class Toolbar extends UIComponent<WithAsProp<ToolbarProps>, ToolbarState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarProps>
 
   static className = 'ui-toolbar'
 

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -15,7 +15,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -78,7 +78,7 @@ export interface ToolbarSlotClassNames {
 }
 
 class Toolbar extends UIComponent<WithAsProp<ToolbarProps>, ToolbarState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-toolbar'
 

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -15,6 +15,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -77,7 +78,7 @@ export interface ToolbarSlotClassNames {
 }
 
 class Toolbar extends UIComponent<WithAsProp<ToolbarProps>, ToolbarState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-toolbar'
 

--- a/packages/react/src/components/Toolbar/ToolbarCustomItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarCustomItem.tsx
@@ -10,7 +10,7 @@ import {
   childrenExist,
   commonPropTypes,
   isFromKeyboard,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 
 import { ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
@@ -64,7 +64,7 @@ class ToolbarCustomItem extends UIComponent<
 
   static className = 'ui-toolbar__customitem'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarCustomItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarCustomItem.tsx
@@ -64,7 +64,7 @@ class ToolbarCustomItem extends UIComponent<
 
   static className = 'ui-toolbar__customitem'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarCustomItemProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarCustomItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarCustomItem.tsx
@@ -10,6 +10,7 @@ import {
   childrenExist,
   commonPropTypes,
   isFromKeyboard,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 
 import { ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
@@ -63,7 +64,7 @@ class ToolbarCustomItem extends UIComponent<
 
   static className = 'ui-toolbar__customitem'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarDivider.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarDivider.tsx
@@ -24,7 +24,7 @@ export interface ToolbarDividerProps
 class ToolbarDivider extends UIComponent<WithAsProp<ToolbarDividerProps>> {
   static displayName = 'ToolbarDivider'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarDividerProps>
 
   static className = 'ui-toolbar__divider'
 

--- a/packages/react/src/components/Toolbar/ToolbarDivider.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarDivider.tsx
@@ -6,7 +6,7 @@ import {
   UIComponentProps,
   UIComponent,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
@@ -24,7 +24,7 @@ export interface ToolbarDividerProps
 class ToolbarDivider extends UIComponent<WithAsProp<ToolbarDividerProps>> {
   static displayName = 'ToolbarDivider'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-toolbar__divider'
 

--- a/packages/react/src/components/Toolbar/ToolbarDivider.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarDivider.tsx
@@ -6,6 +6,7 @@ import {
   UIComponentProps,
   UIComponent,
   commonPropTypes,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
@@ -23,7 +24,7 @@ export interface ToolbarDividerProps
 class ToolbarDivider extends UIComponent<WithAsProp<ToolbarDividerProps>> {
   static displayName = 'ToolbarDivider'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-toolbar__divider'
 

--- a/packages/react/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarItem.tsx
@@ -17,6 +17,7 @@ import {
   childrenExist,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import {
   ComponentEventHandler,
@@ -123,7 +124,7 @@ class ToolbarItem extends UIComponent<WithAsProp<ToolbarItemProps>, ToolbarItemS
     wrapper: `${ToolbarItem.className}__wrapper`,
   }
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon(),
@@ -217,7 +218,7 @@ class ToolbarItem extends UIComponent<WithAsProp<ToolbarItemProps>, ToolbarItemS
         onFocus={this.handleFocus}
         onClick={this.handleClick}
       >
-        {childrenExist(children) ? children : Icon.create(icon)}
+        {childrenExist(children) ? children : Icon.create(icon, {})}
       </ElementType>
     )
 

--- a/packages/react/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarItem.tsx
@@ -17,7 +17,7 @@ import {
   childrenExist,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import {
   ComponentEventHandler,
@@ -124,7 +124,7 @@ class ToolbarItem extends UIComponent<WithAsProp<ToolbarItemProps>, ToolbarItemS
     wrapper: `${ToolbarItem.className}__wrapper`,
   }
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon(),
@@ -218,7 +218,7 @@ class ToolbarItem extends UIComponent<WithAsProp<ToolbarItemProps>, ToolbarItemS
         onFocus={this.handleFocus}
         onClick={this.handleClick}
       >
-        {childrenExist(children) ? children : Icon.create(icon, {})}
+        {childrenExist(children) ? children : Icon.create(icon)}
       </ElementType>
     )
 

--- a/packages/react/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarItem.tsx
@@ -124,7 +124,7 @@ class ToolbarItem extends UIComponent<WithAsProp<ToolbarItemProps>, ToolbarItemS
     wrapper: `${ToolbarItem.className}__wrapper`,
   }
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarItemProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenu.tsx
@@ -12,6 +12,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -44,7 +45,7 @@ class ToolbarMenu extends UIComponent<ToolbarMenuProps> {
 
   static className = 'ui-toolbar__menu'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenu.tsx
@@ -45,7 +45,7 @@ class ToolbarMenu extends UIComponent<ToolbarMenuProps> {
 
   static className = 'ui-toolbar__menu'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarMenuProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenu.tsx
@@ -12,7 +12,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -45,7 +45,7 @@ class ToolbarMenu extends UIComponent<ToolbarMenuProps> {
 
   static className = 'ui-toolbar__menu'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -6,7 +6,7 @@ import {
   UIComponentProps,
   UIComponent,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
@@ -24,7 +24,7 @@ export interface ToolbarMenuDividerProps
 class ToolbarMenuDivider extends UIComponent<WithAsProp<ToolbarMenuDividerProps>> {
   static displayName = 'ToolbarMenuDivider'
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-toolbar__menudivider'
 

--- a/packages/react/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -6,6 +6,7 @@ import {
   UIComponentProps,
   UIComponent,
   commonPropTypes,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 import { WithAsProp, withSafeTypeForAs } from '../../types'
@@ -23,7 +24,7 @@ export interface ToolbarMenuDividerProps
 class ToolbarMenuDivider extends UIComponent<WithAsProp<ToolbarMenuDividerProps>> {
   static displayName = 'ToolbarMenuDivider'
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-toolbar__menudivider'
 

--- a/packages/react/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -24,7 +24,7 @@ export interface ToolbarMenuDividerProps
 class ToolbarMenuDivider extends UIComponent<WithAsProp<ToolbarMenuDividerProps>> {
   static displayName = 'ToolbarMenuDivider'
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarMenuDividerProps>
 
   static className = 'ui-toolbar__menudivider'
 

--- a/packages/react/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -15,6 +15,7 @@ import {
   childrenExist,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { ComponentEventHandler, ShorthandValue, WithAsProp, withSafeTypeForAs } from '../../types'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -84,7 +85,7 @@ class ToolbarMenuItem extends UIComponent<WithAsProp<ToolbarMenuItemProps>, Tool
     wrapper: `${ToolbarMenuItem.className}__wrapper`,
   }
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -85,7 +85,7 @@ class ToolbarMenuItem extends UIComponent<WithAsProp<ToolbarMenuItemProps>, Tool
     wrapper: `${ToolbarMenuItem.className}__wrapper`,
   }
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarMenuItemProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -15,7 +15,7 @@ import {
   childrenExist,
   isFromKeyboard,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { ComponentEventHandler, ShorthandValue, WithAsProp, withSafeTypeForAs } from '../../types'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -85,7 +85,7 @@ class ToolbarMenuItem extends UIComponent<WithAsProp<ToolbarMenuItemProps>, Tool
     wrapper: `${ToolbarMenuItem.className}__wrapper`,
   }
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -12,7 +12,7 @@ import {
   childrenExist,
   commonPropTypes,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -43,7 +43,7 @@ class ToolbarRadioGroup extends UIComponent<WithAsProp<ToolbarRadioGroupProps>> 
 
   static className = 'ui-toolbars' // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
 
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -12,6 +12,7 @@ import {
   childrenExist,
   commonPropTypes,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { mergeComponentVariables } from '../../lib/mergeThemes'
 
@@ -42,7 +43,7 @@ class ToolbarRadioGroup extends UIComponent<WithAsProp<ToolbarRadioGroupProps>> 
 
   static className = 'ui-toolbars' // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
 
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -43,7 +43,7 @@ class ToolbarRadioGroup extends UIComponent<WithAsProp<ToolbarRadioGroupProps>> 
 
   static className = 'ui-toolbars' // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
 
-  static create: ShorthandFactory
+  static create: ShorthandFactory<ToolbarRadioGroupProps>
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/react/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/react/src/components/Tooltip/TooltipContent.tsx
@@ -13,7 +13,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -41,7 +41,7 @@ export interface TooltipContentProps
 }
 
 class TooltipContent extends UIComponent<WithAsProp<TooltipContentProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'TooltipContent'
   static className = 'ui-tooltip__content'

--- a/packages/react/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/react/src/components/Tooltip/TooltipContent.tsx
@@ -13,6 +13,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { Accessibility } from '../../lib/accessibility/types'
 
@@ -40,7 +41,7 @@ export interface TooltipContentProps
 }
 
 class TooltipContent extends UIComponent<WithAsProp<TooltipContentProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'TooltipContent'
   static className = 'ui-tooltip__content'

--- a/packages/react/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/react/src/components/Tooltip/TooltipContent.tsx
@@ -41,7 +41,7 @@ export interface TooltipContentProps
 }
 
 class TooltipContent extends UIComponent<WithAsProp<TooltipContentProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<TooltipContentProps>
 
   static displayName = 'TooltipContent'
   static className = 'ui-tooltip__content'

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -72,7 +72,7 @@ export interface TreeState {
 }
 
 class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'Tree'
 
@@ -263,7 +263,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
           const isSubtree = hasSubtree(item)
           const isSubtreeOpen = isSubtree && this.isActiveItem(item['id'])
 
-          const renderedItem = TreeItem.create(item, {
+          const renderedItem: any = TreeItem.create(item, {
             defaultProps: {
               className: Tree.slotClassNames.item,
               open: isSubtreeOpen,
@@ -273,6 +273,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
             },
             overrideProps: this.handleTreeItemOverrides,
           })
+          console.error(JSON.stringify(renderedItem))
 
           // Only need refs of the items that spawn subtrees, when they need to be focused
           // by any of their children, using Arrow Left.

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -14,6 +14,7 @@ import {
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
   AutoControlledComponent,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import {
   ShorthandRenderFunction,

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -264,7 +264,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
           const isSubtree = hasSubtree(item)
           const isSubtreeOpen = isSubtree && this.isActiveItem(item['id'])
 
-          const renderedItem: any = TreeItem.create(item, {
+          const renderedItem = TreeItem.create(item, {
             defaultProps: {
               className: Tree.slotClassNames.item,
               open: isSubtreeOpen,
@@ -288,7 +288,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
           return [
             ...renderedItems,
             finalRenderedItem,
-            ...[isSubtreeOpen ? renderItems(item['items']) : []],
+            ...([isSubtreeOpen ? renderItems(item['items']) : []] as any),
           ]
         },
         [],

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -14,7 +14,7 @@ import {
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
   AutoControlledComponent,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import {
   ShorthandRenderFunction,
@@ -73,7 +73,7 @@ export interface TreeState {
 }
 
 class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'Tree'
 

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -73,7 +73,7 @@ export interface TreeState {
 }
 
 class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<TreeProps>
 
   static displayName = 'Tree'
 

--- a/packages/react/src/components/Tree/Tree.tsx
+++ b/packages/react/src/components/Tree/Tree.tsx
@@ -273,7 +273,6 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
             },
             overrideProps: this.handleTreeItemOverrides,
           })
-          console.error(JSON.stringify(renderedItem))
 
           // Only need refs of the items that spawn subtrees, when they need to be focused
           // by any of their children, using Arrow Left.

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -15,6 +15,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import {
   ComponentEventHandler,
@@ -88,7 +89,7 @@ export interface TreeItemState {
 }
 
 class TreeItem extends UIComponent<WithAsProp<TreeItemProps>, TreeItemState> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static displayName = 'TreeItem'
 

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -15,7 +15,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import {
   ComponentEventHandler,
@@ -89,7 +89,7 @@ export interface TreeItemState {
 }
 
 class TreeItem extends UIComponent<WithAsProp<TreeItemProps>, TreeItemState> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static displayName = 'TreeItem'
 

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -89,7 +89,7 @@ export interface TreeItemState {
 }
 
 class TreeItem extends UIComponent<WithAsProp<TreeItemProps>, TreeItemState> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<TreeItemProps>
 
   static displayName = 'TreeItem'
 

--- a/packages/react/src/components/Tree/TreeTitle.tsx
+++ b/packages/react/src/components/Tree/TreeTitle.tsx
@@ -50,7 +50,7 @@ export interface TreeTitleProps
 }
 
 class TreeTitle extends UIComponent<WithAsProp<TreeTitleProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<TreeTitleProps>
 
   static className = 'ui-tree__title'
 

--- a/packages/react/src/components/Tree/TreeTitle.tsx
+++ b/packages/react/src/components/Tree/TreeTitle.tsx
@@ -12,6 +12,7 @@ import {
   ContentComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
+  CreateShorthandFactoryResult,
 } from '../../lib'
 import { treeTitleBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -49,7 +50,7 @@ export interface TreeTitleProps
 }
 
 class TreeTitle extends UIComponent<WithAsProp<TreeTitleProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-tree__title'
 

--- a/packages/react/src/components/Tree/TreeTitle.tsx
+++ b/packages/react/src/components/Tree/TreeTitle.tsx
@@ -12,7 +12,7 @@ import {
   ContentComponentProps,
   rtlTextContainer,
   applyAccessibilityKeyHandlers,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 import { treeTitleBehavior } from '../../lib/accessibility'
 import { Accessibility } from '../../lib/accessibility/types'
@@ -50,7 +50,7 @@ export interface TreeTitleProps
 }
 
 class TreeTitle extends UIComponent<WithAsProp<TreeTitleProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-tree__title'
 

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -33,7 +33,7 @@ export interface VideoProps extends UIComponentProps {
 }
 
 class Video extends UIComponent<WithAsProp<VideoProps>> {
-  static create: ShorthandFactory
+  static create: ShorthandFactory<VideoProps>
 
   static className = 'ui-video'
 

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -7,7 +7,7 @@ import {
   UIComponent,
   UIComponentProps,
   commonPropTypes,
-  CreateShorthandFactoryResult,
+  ShorthandFactory,
 } from '../../lib'
 
 import { WithAsProp, withSafeTypeForAs } from '../../types'
@@ -33,7 +33,7 @@ export interface VideoProps extends UIComponentProps {
 }
 
 class Video extends UIComponent<WithAsProp<VideoProps>> {
-  static create: CreateShorthandFactoryResult
+  static create: ShorthandFactory
 
   static className = 'ui-video'
 

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -2,7 +2,13 @@ import { Ref } from '@stardust-ui/react-component-ref'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
-import { createShorthandFactory, UIComponent, UIComponentProps, commonPropTypes } from '../../lib'
+import {
+  createShorthandFactory,
+  UIComponent,
+  UIComponentProps,
+  commonPropTypes,
+  CreateShorthandFactoryResult,
+} from '../../lib'
 
 import { WithAsProp, withSafeTypeForAs } from '../../types'
 
@@ -27,7 +33,7 @@ export interface VideoProps extends UIComponentProps {
 }
 
 class Video extends UIComponent<WithAsProp<VideoProps>> {
-  static create: Function
+  static create: CreateShorthandFactoryResult
 
   static className = 'ui-video'
 

--- a/packages/react/src/lib/createComponent.tsx
+++ b/packages/react/src/lib/createComponent.tsx
@@ -5,7 +5,7 @@ import { ThemeContext } from '@stardust-ui/react-fela'
 
 import renderComponent, { RenderResultConfig } from './renderComponent'
 import { AccessibilityActionHandlers } from './accessibility/reactTypes'
-import { createShorthandFactory, CreateShorthandFactoryResult } from './factories'
+import { createShorthandFactory, ShorthandFactory } from './factories'
 import { ObjectOf, ProviderContextPrepared } from '../types'
 
 export interface CreateComponentConfig<P> {
@@ -21,7 +21,7 @@ export interface CreateComponentConfig<P> {
 
 export type CreateComponentReturnType<P> = React.FunctionComponent<P> & {
   className: string
-  create: CreateShorthandFactoryResult
+  create: ShorthandFactory
 }
 
 const createComponent = <P extends ObjectOf<any> = any>({

--- a/packages/react/src/lib/createComponent.tsx
+++ b/packages/react/src/lib/createComponent.tsx
@@ -5,7 +5,7 @@ import { ThemeContext } from '@stardust-ui/react-fela'
 
 import renderComponent, { RenderResultConfig } from './renderComponent'
 import { AccessibilityActionHandlers } from './accessibility/reactTypes'
-import { createShorthandFactory } from './factories'
+import { createShorthandFactory, CreateShorthandFactoryResult } from './factories'
 import { ObjectOf, ProviderContextPrepared } from '../types'
 
 export interface CreateComponentConfig<P> {
@@ -21,7 +21,7 @@ export interface CreateComponentConfig<P> {
 
 export type CreateComponentReturnType<P> = React.FunctionComponent<P> & {
   className: string
-  create: Function
+  create: CreateShorthandFactoryResult
 }
 
 const createComponent = <P extends ObjectOf<any> = any>({

--- a/packages/react/src/lib/createComponent.tsx
+++ b/packages/react/src/lib/createComponent.tsx
@@ -21,7 +21,7 @@ export interface CreateComponentConfig<P> {
 
 export type CreateComponentReturnType<P> = React.FunctionComponent<P> & {
   className: string
-  create: ShorthandFactory
+  create: ShorthandFactory<P>
 }
 
 const createComponent = <P extends ObjectOf<any> = any>({

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -10,6 +10,7 @@ import {
   ShorthandRenderer,
 } from '../types'
 import { mergeStyles } from './mergeThemes'
+import { UIComponentProps } from '.'
 
 type HTMLTag = 'iframe' | 'img' | 'input'
 type ShorthandProp = 'children' | 'src' | 'type'
@@ -91,6 +92,10 @@ type CreateShorthandFactoryConfigInner<TPropName = string> = {
   mappedArrayProp?: TPropName
 }
 export type CreateShorthandFactoryConfig = CreateShorthandFactoryConfigInner
+export type CreateShorthandFactoryResult = (
+  a: ShorthandValue<UIComponentProps>,
+  b: CreateShorthandOptions,
+) => React.ReactElement<Props> | null | undefined
 // ============================================================
 // Factory Creators
 // ============================================================
@@ -107,25 +112,20 @@ export function createShorthandFactory<TStringElement extends keyof JSX.Intrinsi
   mappedProp?: keyof PropsOf<TStringElement>
   mappedArrayProp?: keyof PropsOf<TStringElement>
   allowsJSX?: boolean
-})
+}): CreateShorthandFactoryResult
 export function createShorthandFactory<TFunctionComponent extends React.FunctionComponent>(config: {
   Component: TFunctionComponent
   mappedProp?: keyof PropsOf<TFunctionComponent>
   mappedArrayProp?: keyof PropsOf<TFunctionComponent>
   allowsJSX?: boolean
-})
+}): CreateShorthandFactoryResult
 export function createShorthandFactory<TInstance extends React.Component>(config: {
   Component: { new (...args: any[]): TInstance }
   mappedProp?: keyof PropsOf<TInstance>
   mappedArrayProp?: keyof PropsOf<TInstance>
   allowsJSX?: boolean
-})
-export function createShorthandFactory({
-  Component,
-  mappedProp,
-  mappedArrayProp,
-  allowsJSX,
-}: CreateShorthandFactoryConfigInner<any>) {
+}): CreateShorthandFactoryResult
+export function createShorthandFactory({ Component, mappedProp, mappedArrayProp, allowsJSX }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
     throw new Error('createShorthandFactory() Component must be a string or function.')
   }

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -10,7 +10,6 @@ import {
   ShorthandRenderer,
 } from '../types'
 import { mergeStyles } from './mergeThemes'
-import { UIComponentProps } from './commonPropInterfaces'
 
 type HTMLTag = 'iframe' | 'img' | 'input'
 type ShorthandProp = 'children' | 'src' | 'type'
@@ -92,8 +91,8 @@ type CreateShorthandFactoryConfigInner<TPropName = string> = {
   mappedArrayProp?: TPropName
 }
 export type CreateShorthandFactoryConfig = CreateShorthandFactoryConfigInner
-export type ShorthandFactory = (
-  value: ShorthandValue<UIComponentProps>,
+export type ShorthandFactory<P> = (
+  value: ShorthandValue<P>,
   options?: CreateShorthandOptions,
 ) => React.ReactElement | null | undefined
 // ============================================================
@@ -107,24 +106,30 @@ export type ShorthandFactory = (
  * @param {string} config.allowsJSX Indicates if factory supports React Elements
  * @returns {function} A shorthand factory function waiting for `val` and `defaultProps`.
  */
-export function createShorthandFactory<TStringElement extends keyof JSX.IntrinsicElements>(config: {
+export function createShorthandFactory<
+  TStringElement extends keyof JSX.IntrinsicElements,
+  P
+>(config: {
   Component: TStringElement
   mappedProp?: keyof PropsOf<TStringElement>
   mappedArrayProp?: keyof PropsOf<TStringElement>
   allowsJSX?: boolean
-}): ShorthandFactory
-export function createShorthandFactory<TFunctionComponent extends React.FunctionComponent>(config: {
+}): ShorthandFactory<P>
+export function createShorthandFactory<
+  TFunctionComponent extends React.FunctionComponent,
+  P
+>(config: {
   Component: TFunctionComponent
   mappedProp?: keyof PropsOf<TFunctionComponent>
   mappedArrayProp?: keyof PropsOf<TFunctionComponent>
   allowsJSX?: boolean
-}): ShorthandFactory
-export function createShorthandFactory<TInstance extends React.Component>(config: {
+}): ShorthandFactory<P>
+export function createShorthandFactory<TInstance extends React.Component, P>(config: {
   Component: { new (...args: any[]): TInstance }
   mappedProp?: keyof PropsOf<TInstance>
   mappedArrayProp?: keyof PropsOf<TInstance>
   allowsJSX?: boolean
-}): ShorthandFactory
+}): ShorthandFactory<P>
 export function createShorthandFactory({ Component, mappedProp, mappedArrayProp, allowsJSX }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
     throw new Error('createShorthandFactory() Component must be a string or function.')

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -95,7 +95,7 @@ export type CreateShorthandFactoryConfig = CreateShorthandFactoryConfigInner
 export type ShorthandFactory = (
   value: ShorthandValue<UIComponentProps>,
   options?: CreateShorthandOptions,
-) => React.ReactElement<Props> | null | undefined
+) => React.ReactElement | null | undefined
 // ============================================================
 // Factory Creators
 // ============================================================

--- a/packages/react/src/lib/factories.ts
+++ b/packages/react/src/lib/factories.ts
@@ -1,5 +1,5 @@
-import * as _ from 'lodash'
 import cx from 'classnames'
+import * as _ from 'lodash'
 import * as React from 'react'
 import {
   ShorthandValue,
@@ -10,7 +10,7 @@ import {
   ShorthandRenderer,
 } from '../types'
 import { mergeStyles } from './mergeThemes'
-import { UIComponentProps } from '.'
+import { UIComponentProps } from './commonPropInterfaces'
 
 type HTMLTag = 'iframe' | 'img' | 'input'
 type ShorthandProp = 'children' | 'src' | 'type'
@@ -92,9 +92,9 @@ type CreateShorthandFactoryConfigInner<TPropName = string> = {
   mappedArrayProp?: TPropName
 }
 export type CreateShorthandFactoryConfig = CreateShorthandFactoryConfigInner
-export type CreateShorthandFactoryResult = (
-  a: ShorthandValue<UIComponentProps>,
-  b: CreateShorthandOptions,
+export type ShorthandFactory = (
+  value: ShorthandValue<UIComponentProps>,
+  options?: CreateShorthandOptions,
 ) => React.ReactElement<Props> | null | undefined
 // ============================================================
 // Factory Creators
@@ -112,19 +112,19 @@ export function createShorthandFactory<TStringElement extends keyof JSX.Intrinsi
   mappedProp?: keyof PropsOf<TStringElement>
   mappedArrayProp?: keyof PropsOf<TStringElement>
   allowsJSX?: boolean
-}): CreateShorthandFactoryResult
+}): ShorthandFactory
 export function createShorthandFactory<TFunctionComponent extends React.FunctionComponent>(config: {
   Component: TFunctionComponent
   mappedProp?: keyof PropsOf<TFunctionComponent>
   mappedArrayProp?: keyof PropsOf<TFunctionComponent>
   allowsJSX?: boolean
-}): CreateShorthandFactoryResult
+}): ShorthandFactory
 export function createShorthandFactory<TInstance extends React.Component>(config: {
   Component: { new (...args: any[]): TInstance }
   mappedProp?: keyof PropsOf<TInstance>
   mappedArrayProp?: keyof PropsOf<TInstance>
   allowsJSX?: boolean
-}): CreateShorthandFactoryResult
+}): ShorthandFactory
 export function createShorthandFactory({ Component, mappedProp, mappedArrayProp, allowsJSX }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
     throw new Error('createShorthandFactory() Component must be a string or function.')


### PR DESCRIPTION
Fixes #1865 

The new type is
```tsx
export type ShorthandFactory = (
  value: ShorthandValue<UIComponentProps>,
  options?: CreateShorthandOptions,
) => React.ReactElement | null | undefined
```

## Won't compile
```tsx
{Avatar.create(Symbol("foo"), "FOO", "BAR")}
{Avatar.create(Symbol("foo"))}
```

## Will compile
```tsx
avatar?: ShorthandValue<AvatarProps> = ...
{Avatar.create(avatar}, {defaultProps: {...}, overrideProps: {...}}
{Avatar.create(avatar}}
```

And this will unfortunately also compile
```tsx
button?: ShorthandValue<ButtonProps> = ...
{Avatar.create(button}}
```