### PR TITLE
chore: remove dependency on @stardust/proptypes in @stardust/ref

### DIFF
--- a/packages/react-component-ref/package.json
+++ b/packages/react-component-ref/package.json
@@ -6,7 +6,6 @@
   "bugs": "https://github.com/stardust-ui/react/issues",
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@stardust-ui/react-proptypes": "^0.37.0",
     "prop-types": "^15.7.2",
     "react-is": "^16.6.3"
   },

--- a/packages/react-component-ref/src/Ref.tsx
+++ b/packages/react-component-ref/src/Ref.tsx
@@ -1,11 +1,10 @@
-import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as ReactIs from 'react-is'
 
 import RefFindNode from './RefFindNode'
 import RefForward from './RefForward'
-import { RefProps } from './types'
+import { RefProps, refPropType } from './types'
 
 const Ref: React.FunctionComponent<RefProps> = props => {
   const { children, innerRef } = props
@@ -17,9 +16,12 @@ const Ref: React.FunctionComponent<RefProps> = props => {
 }
 
 Ref.displayName = 'Ref'
-Ref.propTypes = {
-  children: PropTypes.element.isRequired,
-  innerRef: customPropTypes.ref.isRequired as PropTypes.Validator<React.Ref<any>>,
+// TODO: use Babel plugin for this
+if (process.env.NODE_ENV !== 'production') {
+  Ref.propTypes = {
+    children: PropTypes.element.isRequired,
+    innerRef: refPropType.isRequired,
+  }
 }
 
 export default Ref

--- a/packages/react-component-ref/src/RefFindNode.tsx
+++ b/packages/react-component-ref/src/RefFindNode.tsx
@@ -1,18 +1,21 @@
-import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
 import handleRef from './handleRef'
-import { RefProps } from './types'
+import { RefProps, refPropType } from './types'
 
 export default class RefFindNode extends React.Component<RefProps> {
   static displayName = 'RefFindNode'
 
-  static propTypes = {
-    children: PropTypes.element.isRequired,
-    innerRef: customPropTypes.ref.isRequired as PropTypes.Validator<React.Ref<any>>,
-  }
+  // TODO: use Babel plugin for this
+  static propTypes =
+    process.env.NODE_ENV !== 'production'
+      ? {
+          children: PropTypes.element.isRequired,
+          innerRef: refPropType.isRequired,
+        }
+      : {}
 
   prevNode: Node | null = null
 

--- a/packages/react-component-ref/src/RefForward.tsx
+++ b/packages/react-component-ref/src/RefForward.tsx
@@ -1,17 +1,20 @@
-import * as customPropTypes from '@stardust-ui/react-proptypes'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 import handleRef from './handleRef'
-import { RefProps } from './types'
+import { RefProps, refPropType } from './types'
 
 export default class RefForward extends React.Component<RefProps> {
   static displayName = 'RefForward'
 
-  static propTypes = {
-    children: PropTypes.element.isRequired,
-    innerRef: customPropTypes.ref.isRequired as PropTypes.Validator<React.Ref<any>>,
-  }
+  // TODO: use Babel plugin for this
+  static propTypes =
+    process.env.NODE_ENV !== 'production'
+      ? {
+          children: PropTypes.element.isRequired,
+          innerRef: refPropType.isRequired,
+        }
+      : {}
 
   handleRefOverride = (node: HTMLElement) => {
     const { children, innerRef } = this.props

--- a/packages/react-component-ref/src/isRefObject.ts
+++ b/packages/react-component-ref/src/isRefObject.ts
@@ -1,8 +1,6 @@
 import * as React from 'react'
 
-/**
- * Check that the passed object is a valid React ref object.
- */
+/** Checks that the passed object is a valid React ref object. */
 const isRefObject = (ref: any): ref is React.RefObject<any> =>
   // https://github.com/facebook/react/blob/v16.8.2/packages/react-reconciler/src/ReactFiberCommitWork.js#L665
   ref !== null && typeof ref === 'object' && ref.hasOwnProperty('current')

--- a/packages/react-component-ref/src/toRefObject.ts
+++ b/packages/react-component-ref/src/toRefObject.ts
@@ -5,9 +5,7 @@ const nullRefObject: React.RefObject<null> = { current: null }
 // A map of created ref objects to provide memoization.
 const refObjects = new WeakMap<Node, React.RefObject<Node>>()
 
-/**
- * Creates a React ref object from existing DOM node.
- */
+/** Creates a React ref object from existing DOM node. */
 const toRefObject = <T extends Node>(node: T): React.RefObject<T> => {
   // A "null" is not valid key for a WeakMap
   if (node === null) {

--- a/packages/react-component-ref/src/types.ts
+++ b/packages/react-component-ref/src/types.ts
@@ -1,3 +1,4 @@
+import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
 export interface RefProps {
@@ -10,3 +11,9 @@ export interface RefProps {
    */
   innerRef: React.Ref<any>
 }
+
+/** A checker that matches the React.Ref type. */
+export const refPropType = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.object,
+]) as PropTypes.Requireable<React.Ref<any>>


### PR DESCRIPTION
This PR removes dependency on `@stardust-ui/react-proptypes` in `@stardust-ui/react-component-ref` to get better bundle size for external consumers.