### PR TITLE
[WIP] fix(PortalInner): wrap children with ProviderBox

### DIFF
--- a/docs/src/examples/components/Popup/Types/PopupExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupExample.shorthand.tsx
@@ -1,6 +1,25 @@
-import * as React from 'react'
-import { Button, Popup } from '@stardust-ui/react'
+import React from 'react'
+import { Button, Popup, Dialog } from '@stardust-ui/react'
 
-const PopupExample = () => <Popup trigger={<Button icon="more" />} content="Hello from popup!" />
+const PopupExample = () => (
+  <>
+    <Popup
+      trigger={<Button icon="more" />}
+      content={{
+        content:
+          'Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! ',
+        style: { overflowY: 'scroll', height: '100px', width: '100px' },
+      }}
+    />
 
+    <Dialog
+      trigger={<Button icon="more" />}
+      content={{
+        content:
+          'Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! ',
+        style: { overflowY: 'scroll', height: '100px', width: '100px' },
+      }}
+    />
+  </>
+)
 export default PopupExample

--- a/docs/src/examples/components/Popup/Types/PopupExample.shorthand.tsx
+++ b/docs/src/examples/components/Popup/Types/PopupExample.shorthand.tsx
@@ -1,25 +1,6 @@
-import React from 'react'
-import { Button, Popup, Dialog } from '@stardust-ui/react'
+import * as React from 'react'
+import { Button, Popup } from '@stardust-ui/react'
 
-const PopupExample = () => (
-  <>
-    <Popup
-      trigger={<Button icon="more" />}
-      content={{
-        content:
-          'Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! ',
-        style: { overflowY: 'scroll', height: '100px', width: '100px' },
-      }}
-    />
+const PopupExample = () => <Popup trigger={<Button icon="more" />} content="Hello from popup!" />
 
-    <Dialog
-      trigger={<Button icon="more" />}
-      content={{
-        content:
-          'Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! Hello from popup! ',
-        style: { overflowY: 'scroll', height: '100px', width: '100px' },
-      }}
-    />
-  </>
-)
 export default PopupExample

--- a/packages/react/src/components/Portal/PortalInner.tsx
+++ b/packages/react/src/components/Portal/PortalInner.tsx
@@ -6,6 +6,7 @@ import * as ReactDOM from 'react-dom'
 import { ThemeContext } from 'react-fela'
 
 import { isBrowser, ChildrenComponentProps, commonPropTypes } from '../../lib'
+import ProviderBox from '../Provider/ProviderBox'
 
 export interface PortalInnerProps extends ChildrenComponentProps {
   /** Existing element the portal should be bound to. */
@@ -59,8 +60,9 @@ class PortalInner extends React.Component<PortalInnerProps> {
 
     const target: HTMLElement | null = isBrowser() ? this.context.target.body : null
     const container: HTMLElement | null = mountNode || target
+    const childrenWithProviderBox = <ProviderBox>{children}</ProviderBox>
 
-    return container && ReactDOM.createPortal(children, container)
+    return container && ReactDOM.createPortal(childrenWithProviderBox, container)
   }
 }
 

--- a/packages/react/test/specs/components/Popup/Popup-test.tsx
+++ b/packages/react/test/specs/components/Popup/Popup-test.tsx
@@ -217,7 +217,8 @@ describe('Popup', () => {
   describe('inline', () => {
     test('renders the content in the document body the inline prop is not provided', () => {
       mountWithProvider(<Popup trigger={<button />} content="Content" open />)
-      const contentElement = document.body.firstElementChild
+      // First child is the ProviderBox, it's first children is the PopupContent component
+      const contentElement = document.body.firstElementChild.firstElementChild
 
       expect(contentElement.classList.contains(Popup.Content.className)).toEqual(true)
     })


### PR DESCRIPTION
None of the styles of the `ProviderBox` are applied when the `PortalInner` component is rendered. Simple fix introduced for wrapping the children of the `PortalInner` component with `ProviderBox` (ensured that it works with `Popup`, `Tooltip`  and `Dialog` components).

TODO:
- [ ] add screenshot tests for `Popup`, `Dialog` and `Tooltip`
- [x] fix Popup tests