### PR TITLE
fix(Accessibility): fix order of applying unhandled props and key handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Menu` and `Submenu` to use correct indicator icon and have correct width behavior [redlines] @bcalvery ([#1831](https://github.com/stardust-ui/react/pull/1831))
+- Fix order of applying unhandled props and key handlers @jurokapsiar ([#1901](https://github.com/stardust-ui/react/pull/1901)) 
 
 <!--------------------------------[ v0.38.0 ]------------------------------- -->
 ## [v0.38.0](https://github.com/stardust-ui/react/tree/v0.38.0) (2019-09-06)

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -142,9 +142,9 @@ class Button extends UIComponent<WithAsProp<ButtonProps>> {
         onClick={this.handleClick}
         onFocus={this.handleFocus}
         {...accessibility.attributes.root}
-        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
         {...rtlTextContainer.getAttributes({ forElements: [children] })}
         {...unhandledProps}
+        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
       >
         {hasChildren && children}
         {!hasChildren && loading && this.renderLoader(variables, styles)}

--- a/packages/react/src/components/Embed/Embed.tsx
+++ b/packages/react/src/components/Embed/Embed.tsx
@@ -131,8 +131,8 @@ class Embed extends AutoControlledComponent<WithAsProp<EmbedProps>, EmbedState> 
         className={classes.root}
         onClick={this.handleClick}
         {...accessibility.attributes.root}
-        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
         {...unhandledProps}
+        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
       >
         {active ? (
           <>

--- a/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
+++ b/packages/react/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
@@ -198,8 +198,8 @@ class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemPr
           className={classes.root}
           {...accessibility.attributes.root}
           {...rtlTextContainer.getAttributes({ forElements: [children] })}
-          {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
           {...unhandledProps}
+          {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
         >
           {childrenExist(children) ? children : this.renderContent()}
         </ElementType>

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -179,12 +179,7 @@ class Slider extends AutoControlledComponent<WithAsProp<SliderProps>, SliderStat
 
     // we need 2 wrappers around the slider rail, track, input and thumb slots to achieve correct component sizes
     return (
-      <ElementType
-        className={classes.root}
-        {...accessibility.attributes.root}
-        {...restProps}
-        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
-      >
+      <ElementType className={classes.root} {...accessibility.attributes.root} {...restProps}>
         <div className={cx(Slider.slotClassNames.inputWrapper, classes.inputWrapper)}>
           <span className={cx(Slider.slotClassNames.rail, classes.rail)} />
           <span

--- a/packages/react/src/components/Tree/TreeItem.tsx
+++ b/packages/react/src/components/Tree/TreeItem.tsx
@@ -213,8 +213,8 @@ class TreeItem extends UIComponent<WithAsProp<TreeItemProps>, TreeItemState> {
         className={classes.root}
         {...accessibility.attributes.root}
         {...rtlTextContainer.getAttributes({ forElements: [children] })}
-        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
         {...unhandledProps}
+        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
       >
         {childrenExist(children) ? children : this.renderContent()}
       </ElementType>

--- a/packages/react/test/specs/commonTests/eventTarget.ts
+++ b/packages/react/test/specs/commonTests/eventTarget.ts
@@ -1,0 +1,28 @@
+import { ReactWrapper } from 'enzyme'
+
+export const EVENT_TARGET_ATTRIBUTE = 'data-simulate-event-here'
+
+export const getEventTargetComponent = (
+  wrapper: ReactWrapper,
+  listenerName: string,
+  eventTargets?: object = {},
+) => {
+  const eventTarget = eventTargets[listenerName]
+    ? wrapper
+        .find(eventTargets[listenerName])
+        .hostNodes()
+        .first()
+    : wrapper
+        .find(`[${EVENT_TARGET_ATTRIBUTE}]`)
+        .hostNodes()
+        .first()
+
+  // if (eventTarget.length === 0) {
+  //   throw new Error(
+  //     'The event prop was not delegated to the children. You probably ' +
+  //     'forgot to use `getUnhandledProps` util to spread the `unhandledProps` props.',
+  //   )
+  // }
+
+  return eventTarget
+}

--- a/packages/react/test/specs/commonTests/handlesAccessibility.tsx
+++ b/packages/react/test/specs/commonTests/handlesAccessibility.tsx
@@ -95,7 +95,6 @@ export default (
 
     const wrapper = mountWithProvider(<Component {...wrapperProps} />)
     const component = wrapper.find(Component)
-
     ;(component.instance() as UIComponent<any, any>).actionHandlers.mockAction = actionHandler
     // Force render component to apply updated key handlers
     wrapper.setProps({})

--- a/packages/react/test/specs/commonTests/handlesAccessibility.tsx
+++ b/packages/react/test/specs/commonTests/handlesAccessibility.tsx
@@ -72,41 +72,6 @@ export default (
     expect(role).toBeFalsy()
   })
 
-  test(`handles "onKeyDown" overrides`, () => {
-    const actionHandler = jest.fn()
-    const eventHandler = jest.fn()
-
-    const actionBehavior: Accessibility = () => ({
-      keyActions: {
-        root: {
-          mockAction: {
-            keyCombinations: [{ keyCode: keyboardKey.Enter }],
-          },
-        },
-      },
-    })
-
-    const wrapperProps = {
-      ...requiredProps,
-      accessibility: actionBehavior,
-      [EVENT_TARGET_ATTRIBUTE]: true,
-      onKeyDown: eventHandler,
-    }
-
-    const wrapper = mountWithProvider(<Component {...wrapperProps} />)
-    const component = wrapper.find(Component)
-    ;(component.instance() as UIComponent<any, any>).actionHandlers.mockAction = actionHandler
-    // Force render component to apply updated key handlers
-    wrapper.setProps({})
-
-    getEventTargetComponent(component, 'onKeyDown').simulate('keydown', {
-      keyCode: keyboardKey.Enter,
-    })
-
-    expect(actionHandler).toBeCalledTimes(1)
-    expect(eventHandler).toBeCalledTimes(1)
-  })
-
   if (!partSelector) {
     // temporarily disabled as we do not support overriding of attributes applied to parts
     test('gets correct role when overrides accessibility', () => {
@@ -143,6 +108,46 @@ export default (
       const rendered = mountWithProviderAndGetComponent(Component, element)
       const role = getRenderedAttribute(rendered, 'role', partSelector)
       expect(role).toBe(testRole)
+    })
+
+    test(`handles "onKeyDown" overrides`, () => {
+      const actionHandler = jest.fn()
+      const eventHandler = jest.fn()
+
+      const actionBehavior: Accessibility = () => ({
+        keyActions: {
+          root: {
+            mockAction: {
+              keyCombinations: [{ keyCode: keyboardKey.Enter }],
+            },
+          },
+        },
+      })
+
+      const wrapperProps = {
+        ...requiredProps,
+        accessibility: actionBehavior,
+        [EVENT_TARGET_ATTRIBUTE]: true,
+        onKeyDown: eventHandler,
+      }
+
+      const wrapper = mountWithProvider(<Component {...wrapperProps} />)
+      const component = wrapper.find(Component)
+      const instance = component.instance() as UIComponent<any, any>
+      if (instance.actionHandlers) {
+        instance.actionHandlers.mockAction = actionHandler
+      }
+      // Force render component to apply updated key handlers
+      wrapper.setProps({})
+
+      getEventTargetComponent(component, 'onKeyDown').simulate('keydown', {
+        keyCode: keyboardKey.Enter,
+      })
+
+      if (instance.actionHandlers) {
+        expect(actionHandler).toBeCalledTimes(1)
+      }
+      expect(eventHandler).toBeCalledTimes(1)
     })
   }
 

--- a/packages/react/test/specs/components/Embed/Embed-test.tsx
+++ b/packages/react/test/specs/components/Embed/Embed-test.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 import Embed from 'src/components/Embed/Embed'
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
 import { mountWithProviderAndGetComponent } from 'test/utils'
 
 describe('Embed', () => {
   isConformant(Embed)
+
+  describe('accessibility', () => {
+    handlesAccessibility(Embed, { defaultRootRole: 'presentation' })
+  })
 
   describe('onClick', () => {
     test('is called with (e, props) on a click', () => {


### PR DESCRIPTION
Fixes #1899 

Key handlers need to be applied after unhandled props so that onKeyDown is not overwritten but correctly respects both the key handlers from behaviors as well as onKeyDown passed by the consumer or by a wrapping component (popup) 