### PR TITLE
fix(Chat): fix handling of `onMouseEnter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Menu` and `Submenu` to use correct indicator icon and have correct width behavior [redlines] @bcalvery ([#1831](https://github.com/stardust-ui/react/pull/1831))
+- Fix handling of `onMouseEnter` prop in `ChatMessage` @layershifter ([#1903](https://github.com/stardust-ui/react/pull/1903))
 
 <!--------------------------------[ v0.38.0 ]------------------------------- -->
 ## [v0.38.0](https://github.com/stardust-ui/react/tree/v0.38.0) (2019-09-06)

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -90,6 +90,13 @@ export interface ChatMessageProps
    */
   onFocus?: ComponentEventHandler<ChatMessageProps>
 
+  /**
+   * Called after user will enter by mouse.
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onMouseEnter?: ComponentEventHandler<ChatMessageProps>
+
   /** Reaction group applied to the message. */
   reactionGroup?: ShorthandValue<ReactionGroupProps> | ShorthandCollection<ReactionProps>
 
@@ -126,6 +133,7 @@ class ChatMessage extends UIComponent<WithAsProp<ChatMessageProps>, ChatMessageS
     timestamp: customPropTypes.itemShorthand,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
+    onMouseEnter: PropTypes.func,
     reactionGroup: PropTypes.oneOfType([
       customPropTypes.collectionShorthand,
       customPropTypes.itemShorthand,
@@ -179,6 +187,11 @@ class ChatMessage extends UIComponent<WithAsProp<ChatMessageProps>, ChatMessageS
 
     this.setState({ focused: shouldPreserveFocusState })
     _.invoke(this.props, 'onBlur', e, this.props)
+  }
+
+  handleMouseEnter = (e: React.SyntheticEvent) => {
+    this.updateActionsMenuPosition()
+    _.invoke(this.props, 'onMouseEnter', e, this.props)
   }
 
   renderActionMenu(
@@ -277,7 +290,7 @@ class ChatMessage extends UIComponent<WithAsProp<ChatMessageProps>, ChatMessageS
         <ElementType
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
-          onMouseEnter={() => this.updateActionsMenuPosition()}
+          onMouseEnter={this.handleMouseEnter}
           className={className}
           {...accessibility.attributes.root}
           {...unhandledProps}

--- a/packages/react/src/components/Chat/ChatMessage.tsx
+++ b/packages/react/src/components/Chat/ChatMessage.tsx
@@ -91,7 +91,7 @@ export interface ChatMessageProps
   onFocus?: ComponentEventHandler<ChatMessageProps>
 
   /**
-   * Called after user will enter by mouse.
+   * Called after user enters by mouse.
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props.
    */

--- a/packages/react/test/specs/components/Chat/ChatMessage-test.tsx
+++ b/packages/react/test/specs/components/Chat/ChatMessage-test.tsx
@@ -1,4 +1,7 @@
+import * as React from 'react'
+
 import { handlesAccessibility, implementsShorthandProp, isConformant } from 'test/specs/commonTests'
+import { mountWithProvider } from 'test/utils'
 
 import ChatMessage from 'src/components/Chat/ChatMessage'
 import { chatMessageBehavior } from 'src/lib/accessibility'
@@ -18,6 +21,16 @@ describe('ChatMessage', () => {
   describe('accessibility', () => {
     handlesAccessibility(ChatMessage, {
       focusZoneDefinition: (chatMessageBehavior as AccessibilityDefinition).focusZone,
+    })
+  })
+
+  describe('onMouseEnter', () => {
+    it('performs position update', () => {
+      const wrapper = mountWithProvider(<ChatMessage />)
+      const update = jest.spyOn(wrapper.instance(), 'updateActionsMenuPosition')
+
+      wrapper.simulate('mouseenter')
+      expect(update).toBeCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
### 💥 Issue

Previously `onMouseEnter` was not handled properly, if you will pass custom `onMouseEnter` the position update will be never called.

