### PR TITLE
docs: remove HTML preview and improve error readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Menu` and `Submenu` to use correct indicator icon and have correct width behavior [redlines] @bcalvery ([#1831](https://github.com/stardust-ui/react/pull/1831))
 - Fix handling of `onMouseEnter` prop in `ChatMessage` @layershifter ([#1903](https://github.com/stardust-ui/react/pull/1903))
 
+### Documentation
+- Fix broken code editor in some doc site examples and improve error experience @levithomason ([#1906](https://github.com/stardust-ui/react/pull/1906))
+
 <!--------------------------------[ v0.38.0 ]------------------------------- -->
 ## [v0.38.0](https://github.com/stardust-ui/react/tree/v0.38.0) (2019-09-06)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.37...v0.38.0)

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -1,11 +1,10 @@
 import {
   CopyToClipboard,
-  CodeSnippet,
   KnobInspector,
   KnobProvider,
   LogInspector,
 } from '@stardust-ui/docs-components'
-import { Divider, Flex, Menu, Segment, Provider, ICSSInJSStyle } from '@stardust-ui/react'
+import { Flex, Menu, Segment, Provider, ICSSInJSStyle } from '@stardust-ui/react'
 import * as _ from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
@@ -28,6 +27,8 @@ import ComponentExampleKnobs from './ComponentExampleKnobs'
 import ExamplePlaceholder from '../../ExamplePlaceholder'
 import VariableResolver from 'docs/src/components/VariableResolver/VariableResolver'
 import ComponentExampleVariables from 'docs/src/components/ComponentDoc/ComponentExample/ComponentExampleVariables'
+
+const ERROR_COLOR = '#D34'
 
 export interface ComponentExampleProps
   extends RouteComponentProps<any, any>,
@@ -463,12 +464,12 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
                 <SourceRender
                   babelConfig={babelConfig}
                   source={currentCode}
-                  renderHtml={showCode}
+                  renderHtml={false}
                   resolver={importResolver}
                   wrap={this.renderElement}
                   unstable_hot
                 >
-                  {({ element, error, markup }) => (
+                  {({ element, error }) => (
                     <>
                       <Segment
                         className={`rendered-example ${this.getKebabExamplePath()}`}
@@ -491,25 +492,32 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
                       </Segment>
 
                       {showCode && (
-                        <Segment styles={{ padding: 0 }}>
-                          {showCode && this.renderSourceCode()}
+                        <div
+                          style={{
+                            boxShadow: `0 0 0 0.5em ${error ? ERROR_COLOR : 'transparent'}`,
+                          }}
+                        >
+                          {this.renderSourceCode()}
                           {error && (
-                            <Segment inverted color="red">
-                              <pre style={{ whiteSpace: 'pre-wrap' }}>{error.toString()}</pre>
-                            </Segment>
+                            <pre
+                              style={{
+                                position: 'sticky',
+                                bottom: 0,
+                                padding: '1em',
+                                // don't block viewport
+                                maxHeight: '50vh',
+                                overflowY: 'auto',
+                                color: '#fff',
+                                background: ERROR_COLOR,
+                                whiteSpace: 'pre-wrap',
+                                // above code editor text :/
+                                zIndex: 4,
+                              }}
+                            >
+                              {error.toString()}
+                            </pre>
                           )}
-                          {showCode && (
-                            <div>
-                              <Divider fitted />
-                              <CodeSnippet
-                                fitted
-                                label="Rendered HTML"
-                                mode="html"
-                                value={markup}
-                              />
-                            </div>
-                          )}
-                        </Segment>
+                        </div>
                       )}
                     </>
                   )}


### PR DESCRIPTION
### Remove Rendered HTML

Our HTML renderer is broken and causing all Portal examples to fail.  Users can just use the HTML explorer in the browser.  This was chosen as the simplest solution to our issue.  It also removes some of the crowding problem that we have in examples by only showing the JSX.

Now our examples all work:

![image](https://user-images.githubusercontent.com/5067638/64563198-9afac880-d303-11e9-9ce6-ac0657a07924.png)

### Better Error Experience

Our errors used to get buried and lost below the fold on long examples.  A red border was added around the example source code when in error state to let the user know there is an error below. Additionally, the errors are `sticky` so that they are always at the bottom of the screen.

![http://g.recordit.co/FPbNGkWZts.gif](http://g.recordit.co/FPbNGkWZts.gif)