### PR TITLE
docs: persist editor state in url

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
@@ -18,7 +18,10 @@ type ComponentControlsProps = {
   onShowRtl: (e: React.SyntheticEvent) => void
   onShowTransparent: (e: React.SyntheticEvent) => void
   onShowVariables: (e: React.SyntheticEvent) => void
+  showCode: boolean
   showRtl: boolean
+  showVariables: boolean
+  showTransparent: boolean
 }
 
 const controlsTheme: ThemeInput = {
@@ -48,7 +51,10 @@ const ComponentControls: React.FC<ComponentControlsProps> = props => {
     exampleCode,
     exampleLanguage,
     examplePath,
+    showCode,
     showRtl,
+    showVariables,
+    showTransparent,
     onCopyLink,
     onShowCode,
     onShowRtl,
@@ -69,6 +75,7 @@ const ComponentControls: React.FC<ComponentControlsProps> = props => {
             key: 'show-code',
             content: <ComponentButton iconName="code" label="Try it" />,
             onClick: onShowCode,
+            active: showCode,
           },
           {
             key: 'show-codesandbox',
@@ -84,16 +91,19 @@ const ComponentControls: React.FC<ComponentControlsProps> = props => {
             key: 'show-variables',
             content: <ComponentButton iconName="paint brush" label="Theme it" />,
             onClick: onShowVariables,
+            active: showVariables,
           },
           {
             key: 'show-transparent',
             content: <ComponentButton iconName="adjust" label="Transparent" />,
             onClick: onShowTransparent,
+            active: showTransparent,
           },
           {
             key: 'show-rtl',
             content: <ComponentButton iconName="align right" label="RTL" />,
             onClick: onShowRtl,
+            active: showRtl,
           },
           {
             key: 'maximize',

--- a/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -50,7 +50,7 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
       const { history, location } = this.props
       const at = location.pathname
       const newLocation = at.replace(this.tabRegex, 'definition')
-      history.replace(newLocation)
+      history.push(newLocation)
       return 0
     }
     return index
@@ -106,13 +106,13 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
     const at = location.pathname
     const newLocation = at.replace(this.tabRegex, this.props.tabs[newIndex].toLowerCase())
 
-    history.replace(newLocation)
+    history.push(newLocation)
     this.setState({ currentTabIndex: newIndex })
   }
 
   onPropComponentSelected = (e, props) => {
     const { history } = this.props
-    history.replace({ ...history.location, hash: props.value })
+    history.push({ ...history.location, hash: props.value })
   }
 
   render() {

--- a/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -68,7 +68,7 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
 
     if (location.hash) {
       const activePath = getFormattedHash(location.hash)
-      history.replace(`${location.pathname}#${activePath}`)
+      history.replace({ ...history.location, hash: activePath })
       this.setState({ activePath })
       if (this.props.tabs[tabIndex] === 'Props') {
         this.setState({ defaultPropComponent: activePath })
@@ -91,10 +91,10 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
 
   /* TODO: bring back the right floating menu
   handleSidebarItemClick = (e, { examplePath }) => {
-    const { history, location } = this.props
+    const { history } = this.props
     const activePath = examplePathToHash(examplePath)
 
-    history.replace(`${location.pathname}#${activePath}`)
+    history.replace({ ...history.location, hash: activePath })
     // set active hash path
     this.setState({ activePath }, scrollToAnchor)
   }
@@ -111,8 +111,8 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
   }
 
   onPropComponentSelected = (e, props) => {
-    const { history, location } = this.props
-    history.replace(`${location.pathname}#${props.value}`)
+    const { history } = this.props
+    history.replace({ ...history.location, hash: props.value })
   }
 
   render() {

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -4,11 +4,12 @@ import {
   KnobProvider,
   LogInspector,
 } from '@stardust-ui/docs-components'
-import { Flex, Menu, Segment, Provider, ICSSInJSStyle } from '@stardust-ui/react'
+import { Flex, ICSSInJSStyle, Menu, Provider, Segment } from '@stardust-ui/react'
 import * as _ from 'lodash'
 import * as React from 'react'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 import * as copyToClipboard from 'copy-to-clipboard'
+import qs from 'qs'
 import SourceRender from 'react-source-render'
 import VisibilitySensor from 'react-visibility-sensor'
 
@@ -40,7 +41,10 @@ export interface ComponentExampleProps
 }
 
 interface ComponentExampleState {
+  anchorName: string
   componentVariables: Object
+  isActive: boolean
+  isActiveHash: boolean
   usedVariables: Record<string, string[]>
   showCode: boolean
   showRtl: boolean
@@ -59,71 +63,115 @@ const childrenStyle: React.CSSProperties = {
  * Allows toggling the the raw `code` code block.
  */
 class ComponentExample extends React.Component<ComponentExampleProps, ComponentExampleState> {
-  anchorName: string
   kebabExamplePath: string
 
-  constructor(props) {
-    super(props)
+  static getClearedActiveState = () => ({
+    showCode: false,
+    showRtl: false,
+    showVariables: false,
+    showTransparent: false,
+  })
 
-    const { examplePath } = props
+  static getAnchorName = props => examplePathToHash(props.examplePath)
 
-    this.anchorName = examplePathToHash(examplePath)
-    this.state = {
-      showCode: this.isActiveHash(),
-      componentVariables: {},
-      usedVariables: {},
-      showRtl: examplePath && examplePath.endsWith('rtl'),
-      showTransparent: false,
-      showVariables: false,
-      wasEverVisible: false,
-    }
+  static isActiveHash = props => {
+    const anchorName = ComponentExample.getAnchorName(props)
+    const formattedHash = getFormattedHash(props.location.hash)
+
+    return anchorName === formattedHash
   }
 
-  componentWillReceiveProps(nextProps: ComponentExampleProps) {
-    // deactivate examples when switching from one to the next
-    if (
-      this.isActiveHash() &&
-      this.isActiveState() &&
-      this.props.location.hash !== nextProps.location.hash
-    ) {
-      this.clearActiveState()
-    }
-  }
-
-  clearActiveState = () => {
-    this.setState({
-      showCode: false,
-      showRtl: false,
-      showVariables: false,
+  static getStateFromURL = props => {
+    return qs.parse(props.location.search, {
+      ignoreQueryPrefix: true,
+      decoder: (raw, parse) => {
+        const result = parse(raw)
+        return result === 'false' ? false : result === 'true' ? true : result
+      },
     })
   }
 
-  isActiveState = () => {
-    const { showCode, showVariables } = this.state
+  static setStateToURL = (props, state) => {
+    const nextQueryState = {
+      showCode: state.showCode,
+      showRtl: state.showRtl,
+      showTransparent: state.showTransparent,
+      showVariables: state.showVariables,
+    }
 
-    return showCode || showVariables
+    const prevQueryState = ComponentExample.getStateFromURL(props)
+
+    // don't trigger re-renders if the state in the query string is the same as the state
+    // that is trying to be set
+    if (_.isEqual(prevQueryState, nextQueryState)) {
+      return
+    }
+
+    const nextQueryString = qs.stringify(nextQueryState)
+
+    props.history.replace({ ...props.history.location, search: `?${nextQueryString}` })
   }
 
-  isActiveHash = () => this.anchorName === getFormattedHash(this.props.location.hash)
+  static getDerivedStateFromProps(props, state) {
+    const anchorName = ComponentExample.getAnchorName(props)
+    const isActiveHash = ComponentExample.isActiveHash(props)
+    const isActive = !!state.showCode || !!state.showVariables
+    const nextHash = props.location.hash !== state.prevHash ? props.location.hash : state.prevHash
+
+    const nextState = {
+      anchorName,
+      isActive,
+      isActiveHash,
+      prevHash: nextHash,
+    }
+
+    // deactivate examples when switching from one to the next
+    if (!isActiveHash && state.prevHash !== nextHash) {
+      Object.assign(nextState, ComponentExample.getClearedActiveState())
+    }
+
+    return nextState
+  }
+
+  componentDidUpdate(
+    prevProps: Readonly<ComponentExampleProps>,
+    prevState: Readonly<ComponentExampleState>,
+    snapshot?: any,
+  ): void {
+    if (this.state.isActiveHash) {
+      ComponentExample.setStateToURL(this.props, this.state)
+    }
+  }
+
+  constructor(props) {
+    super(props)
+    const isActiveHash = ComponentExample.isActiveHash(props)
+
+    this.state = {
+      componentVariables: {},
+      usedVariables: {},
+      showCode: isActiveHash,
+      showRtl: false,
+      showTransparent: false,
+      showVariables: false,
+      wasEverVisible: false,
+      ...(isActiveHash && ComponentExample.getStateFromURL(props)),
+      ...(/\.rtl$/.test(props.examplePath) && { showRtl: true }),
+    }
+  }
 
   updateHash = () => {
-    if (this.isActiveState()) this.setHashAndScroll()
-    else if (this.isActiveHash()) this.removeHash()
+    const { isActive } = this.state
+
+    if (isActive) this.setHashAndScroll()
   }
 
   setHashAndScroll = () => {
-    const { history, location } = this.props
+    const { anchorName } = this.state
+    const { history } = this.props
 
-    history.replace(`${location.pathname}#${this.anchorName}`)
+    history.replace({ ...history.location, hash: anchorName })
     scrollToAnchor()
-  }
-
-  removeHash = () => {
-    const { history, location } = this.props
-
-    history.replace(location.pathname)
-
-    this.clearActiveState()
   }
 
   handleDirectLinkClick = () => {
@@ -410,6 +458,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       title,
     } = this.props
     const {
+      anchorName,
       componentVariables,
       usedVariables,
       showCode,
@@ -429,7 +478,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
           <Flex.Item>
             <KnobProvider>
               {/* Ensure anchor links don't occlude card shadow effect */}
-              <div id={this.anchorName} style={{ position: 'relative', bottom: '1rem' }} />
+              <div id={anchorName} style={{ position: 'relative', bottom: '1rem' }} />
 
               <ExamplePlaceholder visible={wasEverVisible}>
                 <Segment styles={{ borderBottom: '1px solid #ddd' }}>
@@ -438,7 +487,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
                     <Flex.Item push>
                       <ComponentControls
-                        anchorName={this.anchorName}
+                        anchorName={anchorName}
                         exampleCode={currentCode}
                         exampleLanguage={currentCodeLanguage}
                         examplePath={currentCodePath}
@@ -447,7 +496,10 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
                         onShowRtl={this.handleShowRtlClick}
                         onShowVariables={this.handleShowVariablesClick}
                         onShowTransparent={this.handleShowTransparentClick}
+                        showCode={showCode}
                         showRtl={showRtl}
+                        showVariables={showVariables}
+                        showTransparent={showTransparent}
                       />
                     </Flex.Item>
                   </Flex>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "@stardust-ui/internal-tooling": "^0.38.0",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "qs": "^6.8.0"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11728,6 +11728,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
+  integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
+
 qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
### URLs

Doc site URLs now include the state of the editor controls.  Here's an exploded view of the button url with the default state when opened:

```
/components/button/definition

?showCode=true & showRtl=false & showTransparent=false & showVariables=false

#types-button
```

This is leading to shareable playground URLs.

### Editor Menu

I also fixed editor menu's to show the menu item as active when the option is on.  The styles are still ugly, another PR...

![image](https://user-images.githubusercontent.com/5067638/64658093-09ff1c80-d3eb-11e9-8f7a-357f139e6778.png)
