### PR TITLE
chore(tests): remove useless auto-controlled tests

### DIFF
--- a/packages/react/test/specs/components/Input/Input-test.tsx
+++ b/packages/react/test/specs/components/Input/Input-test.tsx
@@ -69,25 +69,6 @@ describe('Input', () => {
     })
   })
 
-  describe('auto-controlled', () => {
-    it('sets input value from user when the value prop is not set (non-controlled mode)', () => {
-      const inputComp = mount(<Input />)
-      const domNode = getInputDomNode(inputComp)
-      setUserInputValue(inputComp, testValue)
-
-      expect(domNode.value).toEqual(testValue)
-    })
-
-    it('cannot set input value from user when the value prop is already set (controlled mode)', () => {
-      const controlledInputValue = 'controlled input value'
-      const inputComp = mount(<Input value={controlledInputValue} />)
-      const domNode = getInputDomNode(inputComp)
-      setUserInputValue(inputComp, testValue)
-
-      expect(domNode.value).toEqual(controlledInputValue)
-    })
-  })
-
   describe('clearable', () => {
     it('calls onChange on Icon click with an `empty` value', () => {
       const onChange = jest.fn()

--- a/packages/react/test/specs/components/Slider/Slider-test.tsx
+++ b/packages/react/test/specs/components/Slider/Slider-test.tsx
@@ -1,16 +1,5 @@
-import * as React from 'react'
-import { ReactWrapper } from 'enzyme'
-
-import { mountWithProvider as mount } from 'test/utils'
 import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
 import Slider from 'src/components/Slider/Slider'
-
-const getInputDomNode = (sliderComp: ReactWrapper): HTMLInputElement =>
-  sliderComp.find('input').getDOMNode() as HTMLInputElement
-
-const setUserInputValue = (sliderComp: ReactWrapper, value: string) => {
-  sliderComp.find('input').simulate('change', { target: { value } })
-}
 
 describe('Slider', () => {
   isConformant(Slider, {
@@ -20,24 +9,6 @@ describe('Slider', () => {
       onKeyPress: 'input',
       onKeyUp: 'input',
     },
-  })
-
-  describe('auto-controlled', () => {
-    it('sets slider value from user when the value prop is not set (non-controlled mode)', () => {
-      const sliderComp = mount(<Slider />)
-      const domNode = getInputDomNode(sliderComp)
-      setUserInputValue(sliderComp, '30')
-
-      expect(domNode.value).toEqual('30')
-    })
-
-    it('cannot set input value from user when the value prop is already set (controlled mode)', () => {
-      const sliderComp = mount(<Slider value={'80'} />)
-      const domNode = getInputDomNode(sliderComp)
-      setUserInputValue(sliderComp, '30')
-
-      expect(domNode.value).toEqual('80')
-    })
   })
 
   describe('accessibility', () => {


### PR DESCRIPTION
These tests are redundant, as that functionality is already tested by `AutoControlledComponent` tests