### PR TITLE
fix(FocusTrapZone): Do not force focus inside focus trap zone on outside focus

### DIFF
--- a/packages/react/src/lib/accessibility/FocusZone/CHANGELOG.md
+++ b/packages/react/src/lib/accessibility/FocusZone/CHANGELOG.md
@@ -68,6 +68,7 @@ This is a list of changes made to the Stardust copy of FocusTrapZone in comparis
 
 ### BREAKING CHANGES
 - Allow using `firstFocusableSelector` for all type of selectors, not only class names @sophieH29 ([#1732](https://github.com/stardust-ui/react/pull/1732))
+- Do not force focus inside focus trap zone on outside focus @sophieH29 ([#1930](https://github.com/stardust-ui/react/pull/1930))
 
 ### Fixes
 - Do not focus trigger on outside click @sophieH29 ([#627](https://github.com/stardust-ui/react/pull/627))

--- a/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
+++ b/packages/react/src/lib/accessibility/FocusZone/FocusTrapZone.tsx
@@ -62,7 +62,7 @@ export default class FocusTrapZone extends React.Component<FocusTrapZoneProps, {
   static defaultProps: FocusTrapZoneProps = {
     as: 'div',
     isClickableOutsideFocusTrap: true,
-    forceFocusInsideTrapOnOutsideFocus: true,
+    forceFocusInsideTrapOnOutsideFocus: false,
   }
 
   componentDidMount(): void {


### PR DESCRIPTION
Popup in Menu scenario was broken due to a recent focus trap zone update to the Fabric latest version.

For now, switching it back to Stardust default behavior, we will investigate later how to align.

Repro: https://codesandbox.io/s/stardust-ui-example-yjnqv