### PR TITLE
docs(Tree): remove renderTreeTitle prop from exclusive example

### DIFF
--- a/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeExclusiveExample.shorthand.tsx
+++ b/docs/src/examples/components/HierarchicalTree/Types/HierarchicalTreeExclusiveExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Icon, HierarchicalTree } from '@stardust-ui/react'
+import { HierarchicalTree } from '@stardust-ui/react'
 
 const items = [
   {
@@ -40,15 +40,6 @@ const items = [
   },
 ]
 
-const titleRenderer = (Component, { content, open, hasSubtree, ...restProps }) => (
-  <Component open={open} hasSubtree={hasSubtree} {...restProps}>
-    {hasSubtree && <Icon name={open ? 'arrow-down' : 'arrow-right'} />}
-    <span>{content}</span>
-  </Component>
-)
-
-const TreeExclusiveExample = () => (
-  <HierarchicalTree items={items} renderItemTitle={titleRenderer} exclusive />
-)
+const TreeExclusiveExample = () => <HierarchicalTree items={items} exclusive />
 
 export default TreeExclusiveExample

--- a/docs/src/examples/components/Tree/Types/TreeExclusiveExample.shorthand.tsx
+++ b/docs/src/examples/components/Tree/Types/TreeExclusiveExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Icon, Tree } from '@stardust-ui/react'
+import { Tree } from '@stardust-ui/react'
 
 const items = [
   {
@@ -40,13 +40,6 @@ const items = [
   },
 ]
 
-const titleRenderer = (Component, { content, open, hasSubtree, ...restProps }) => (
-  <Component open={open} hasSubtree={hasSubtree} {...restProps}>
-    {hasSubtree && <Icon name={open ? 'triangle-down' : 'triangle-right'} />}
-    <span>{content}</span>
-  </Component>
-)
-
-const TreeExclusiveExample = () => <Tree items={items} renderItemTitle={titleRenderer} exclusive />
+const TreeExclusiveExample = () => <Tree items={items} exclusive />
 
 export default TreeExclusiveExample


### PR DESCRIPTION
There is no need for `renderItemTitle` in the `exclusive` example and it will make the example that actually illustrates `renderItemTitle` useless.