### PR TITLE
docs(ComponentExample): temporary enable HTML rendering

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -501,7 +501,10 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
               <SourceRender
                 babelConfig={babelConfig}
                 source={currentCode}
-                renderHtml={false}
+                // Temporary workaround for:
+                // https://github.com/stardust-ui/react/issues/1952
+                // renderHtml={false}
+                renderHtml
                 resolver={importResolver}
                 unstable_hot
               >

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -504,7 +504,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
                 // Temporary workaround for:
                 // https://github.com/stardust-ui/react/issues/1952
                 // renderHtml={false}
-                renderHtml
+                renderHtml={showCode}
                 resolver={importResolver}
                 unstable_hot
               >


### PR DESCRIPTION
A temporary workaround for #1952.

As we discovered the issue is happens due different handling of errors in `react-source-render`. Now errors are handled by [React error boundaries](https://reactjs.org/docs/error-boundaries.html) and they cause tree remount.