### PR TITLE
fix(Popper): fix comparison for `scrollParent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix comparison for `scrollParent` in `unstable_Popper` @layershifter ([#1959](https://github.com/stardust-ui/react/pull/1959))
+
 <!--------------------------------[ v0.39.0 ]------------------------------- -->
 ## [v0.39.0](https://github.com/stardust-ui/react/tree/v0.39.0) (2019-09-23)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.38.1...v0.39.0)

--- a/packages/react/src/lib/positioner/Popper.tsx
+++ b/packages/react/src/lib/positioner/Popper.tsx
@@ -78,7 +78,8 @@ const Popper: React.FunctionComponent<PopperProps> = props => {
     }
 
     const pointerTargetRefElement = pointerTargetRef && pointerTargetRef.current
-    const popperHasScrollableParent = getScrollParent(contentRef.current) !== document.body
+    const scrollParentElement = getScrollParent(contentRef.current)
+    const popperHasScrollableParent = scrollParentElement !== scrollParentElement.ownerDocument.body
 
     const modifiers: PopperJS.Modifiers = _.merge(
       { preventOverflow: { padding: 0 } },


### PR DESCRIPTION
Fixes #1924 

```tsx
const popperHasScrollableParent = getScrollParent(contentRef.current) !== document.body
```

The previous check was always false positive when `Popper` was rendered in another document. This PR fixes it.