### PR TITLE
fix(mixed): avoid usages of global `document` and `window`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix comparison for `scrollParent` in `unstable_Popper` @layershifter ([#1959](https://github.com/stardust-ui/react/pull/1959))
 - Updating `Button` styles for Teams dark & high contrast themes to match design @notandrew ([#1933](https://github.com/stardust-ui/react/pull/1933))
 - Update Office brand icons in Teams theme with latest version @notandrew ([#1954](https://github.com/stardust-ui/react/pull/1954))
+- Avoid usages of global `document` and `window` in components @layershifter ([#1970](https://github.com/stardust-ui/react/pull/1970))
 
 ### Features
 - Add experimental runtime accessibility attributes validation (the initial step validates the Button component only) @mshoho ([#1911](https://github.com/stardust-ui/react/pull/1911))

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -6,6 +6,16 @@
       "rules": {
         "react/prop-types": "off"
       }
+    },
+    {
+      "files": "src/**/*.{ts,tsx}",
+      "globals": {
+        "document": "off",
+        "window": "off"
+      },
+      "rules": {
+        "no-undef": "error"
+      }
     }
   ],
   "root": true

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -807,11 +807,13 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     state: DownshiftState<ShorthandValue<DropdownItemProps>>,
     changes: StateChangeOptions<ShorthandValue<DropdownItemProps>>,
   ) => {
+    const activeElement: Element = this.context.target.activeElement
+
     switch (changes.type) {
       case Downshift.stateChangeTypes.blurButton:
         // Downshift closes the list by default on trigger blur. It does not support the case when dropdown is
         // single selection and focuses list on trigger click/up/down/space/enter. Treating that here.
-        if (state.isOpen && document.activeElement === this.listRef.current) {
+        if (state.isOpen && activeElement === this.listRef.current) {
           return {} // won't change state in this case.
         }
       default:

--- a/packages/react/src/components/Loader/Loader.tsx
+++ b/packages/react/src/components/Loader/Loader.tsx
@@ -102,7 +102,8 @@ class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
     const { delay } = this.props
 
     if (delay > 0) {
-      this.delayTimer = window.setTimeout(() => {
+      // @ts-ignore We have a collision between types from DOM and @types/node
+      this.delayTimer = setTimeout(() => {
         this.setState({ visible: true })
       }, delay)
     }

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -273,7 +273,9 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     const lastContentRef = getRefs().pop()
     const isLastOpenedPopup: boolean =
       lastContentRef && lastContentRef.current === this.popupDomElement
-    const bodyHasFocus: boolean = document.activeElement === document.body
+
+    const activeDocument = this.props.mountDocument || this.context.target
+    const bodyHasFocus: boolean = activeDocument.activeElement === activeDocument.body
 
     if (keyCode === keyboardKey.Escape && bodyHasFocus && isLastOpenedPopup) {
       this.close(e, () => _.invoke(this.triggerFocusableDomElement, 'focus'))

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -179,16 +179,17 @@ class Toolbar extends UIComponent<WithAsProp<ToolbarProps>, ToolbarState> {
 
   componentWillUnmount() {
     if (this.animationFrameId !== undefined) {
-      window.cancelAnimationFrame(this.animationFrameId)
+      cancelAnimationFrame(this.animationFrameId)
       this.animationFrameId = undefined
     }
   }
 
   afterComponentRendered() {
     if (this.animationFrameId !== undefined) {
-      window.cancelAnimationFrame(this.animationFrameId)
+      cancelAnimationFrame(this.animationFrameId)
     }
-    this.animationFrameId = window.requestAnimationFrame(() => {
+
+    this.animationFrameId = requestAnimationFrame(() => {
       this.animationFrameId = undefined
       const { onReduceItems } = this.props
       if (_.isNil(onReduceItems) || !this.hiddenToolbarRef.current || this.state.stable) {

--- a/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/react/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -100,7 +100,7 @@ class ToolbarRadioGroup extends UIComponent<WithAsProp<ToolbarRadioGroupProps>> 
       nextItemToFocus.focus()
     }
 
-    if (document.activeElement === nextItemToFocus) {
+    if (this.context.target.activeElement === nextItemToFocus) {
       event.stopPropagation()
     }
     event.preventDefault()

--- a/packages/react/src/lib/accessibility/FocusZone/focusUtilities.ts
+++ b/packages/react/src/lib/accessibility/FocusZone/focusUtilities.ts
@@ -427,6 +427,7 @@ export function focusAsync(element: HTMLElement | { focus: () => void } | undefi
  */
 export function getWindow(rootElement?: Element | null): Window | undefined {
   return (
+    // eslint-disable-next-line no-undef
     (rootElement && rootElement.ownerDocument && rootElement.ownerDocument.defaultView) || window
   )
 }
@@ -437,6 +438,7 @@ export function getWindow(rootElement?: Element | null): Window | undefined {
  * @public
  */
 export function getDocument(rootElement?: Element | null): Document | undefined {
+  // eslint-disable-next-line no-undef
   return (rootElement && rootElement.ownerDocument) || document
 }
 

--- a/packages/react/src/lib/debug/debugApi.ts
+++ b/packages/react/src/lib/debug/debugApi.ts
@@ -25,6 +25,7 @@ const getFunctionComponentDebugData = component => {
 }
 
 const debugApi = (inputComponent?) => {
+  // eslint-disable-next-line no-undef
   const component = inputComponent || (window as any).$r
 
   if (!component) {
@@ -64,6 +65,7 @@ const isDebugEnabled = () => {
   let enabled = false
   try {
     const isProduction = process.env.NODE_ENV === 'production'
+    // eslint-disable-next-line no-undef
     const isEnabledBrowserOverride = !!window.localStorage.stardustDebug
 
     if (isEnabledBrowserOverride) {

--- a/packages/react/src/lib/debug/index.ts
+++ b/packages/react/src/lib/debug/index.ts
@@ -6,6 +6,7 @@ import debugApi from './debugApi'
 
 // expose debug API as $stardust object
 if (typeof window !== 'undefined') {
+  // eslint-disable-next-line no-undef
   ;(window as any).$stardust = debugApi
 }
 

--- a/packages/react/src/lib/doesNodeContainClick.tsx
+++ b/packages/react/src/lib/doesNodeContainClick.tsx
@@ -10,7 +10,12 @@ import * as _ from 'lodash'
  * @param {Document} target A target document.
  * @returns {boolean}
  */
-const doesNodeContainClick = (node: HTMLElement, e: MouseEvent, target: Document = document) => {
+const doesNodeContainClick = (
+  node: HTMLElement,
+  e: MouseEvent,
+  // eslint-disable-next-line no-undef
+  target: Document = document,
+) => {
   if (_.some([e, node], _.isNil)) return false
 
   // if there is an e.target and it is in the document, use a simple node.contains() check

--- a/packages/react/src/lib/felaRenderer.tsx
+++ b/packages/react/src/lib/felaRenderer.tsx
@@ -15,6 +15,7 @@ import felaSanitizeCss from './felaSanitizeCssPlugin'
 let felaDevMode = false
 
 try {
+  // eslint-disable-next-line no-undef
   felaDevMode = !!window.localStorage.felaDevMode
 } catch {}
 

--- a/packages/react/src/lib/fontSizeUtility.ts
+++ b/packages/react/src/lib/fontSizeUtility.ts
@@ -7,7 +7,8 @@ let _documentRemSize: number | null = null
 
 const getDocumentRemSize = (): number => {
   return isBrowser()
-    ? getFontSizeValue(getComputedStyle(document.documentElement).fontSize) ||
+    ? // eslint-disable-next-line no-undef
+      getFontSizeValue(getComputedStyle(document.documentElement).fontSize) ||
         DEFAULT_REM_SIZE_IN_PX
     : DEFAULT_REM_SIZE_IN_PX
 }

--- a/packages/react/src/lib/isBrowser.tsx
+++ b/packages/react/src/lib/isBrowser.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable no-undef */
 const hasDocument = typeof document === 'object' && document !== null
 const hasWindow = typeof window === 'object' && window !== null && window.self === window
+/* eslint-enable no-undef */
 
 const isBrowser = () => hasDocument && hasWindow
 

--- a/packages/react/src/lib/mergeProviderContexts.ts
+++ b/packages/react/src/lib/mergeProviderContexts.ts
@@ -8,12 +8,14 @@ const registeredRenderers = new WeakMap<Document, Renderer>()
 export const mergeRenderers = (
   current: Renderer,
   next?: Renderer,
-  target: Document = document,
+  target: Document = document, // eslint-disable-line no-undef
 ): Renderer => {
   if (next) {
     return next
   }
 
+  // A valid comparison, default renderer will be used
+  // eslint-disable-next-line no-undef
   if (target === document) {
     return felaRenderer
   }
@@ -50,7 +52,7 @@ const mergeProviderContexts = (
     rtl: false,
     disableAnimations: false,
     originalThemes: [],
-    target: document,
+    target: document, // eslint-disable-line no-undef
   } as ProviderContextPrepared
 
   return contexts.reduce<ProviderContextPrepared>(

--- a/packages/react/src/lib/positioner/getScrollParent.ts
+++ b/packages/react/src/lib/positioner/getScrollParent.ts
@@ -28,6 +28,7 @@ const getStyleComputedProperty = (node: Node): Partial<CSSStyleDeclaration> => {
 const getScrollParent = (node: Node): Node => {
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
   const parentNode = node && getParentNode(node)
+  // eslint-disable-next-line
   if (!parentNode) return document.body
 
   switch (parentNode.nodeName) {


### PR DESCRIPTION
Fixes #1964.

This PR removes remaining usages of `document` and `window` globals in components. Also forces ESLint to catch such issues.