### PR TITLE
fix(whatInput): use proper `document` to set `data-whatinput` attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix comparison for `scrollParent` in `unstable_Popper` @layershifter ([#1959](https://github.com/stardust-ui/react/pull/1959))
 - Updating `Button` styles for Teams dark & high contrast themes to match design @notandrew ([#1933](https://github.com/stardust-ui/react/pull/1933))
 - Update Office brand icons in Teams theme with latest version @notandrew ([#1954](https://github.com/stardust-ui/react/pull/1954))
+- Fix setting `data-whatinput` attribute in child windows ([#1971](https://github.com/stardust-ui/react/pull/1971))
 
 ### Features
 - Add experimental runtime accessibility attributes validation (the initial step validates the Button component only) @mshoho ([#1911](https://github.com/stardust-ui/react/pull/1911))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix comparison for `scrollParent` in `unstable_Popper` @layershifter ([#1959](https://github.com/stardust-ui/react/pull/1959))
 - Updating `Button` styles for Teams dark & high contrast themes to match design @notandrew ([#1933](https://github.com/stardust-ui/react/pull/1933))
 - Update Office brand icons in Teams theme with latest version @notandrew ([#1954](https://github.com/stardust-ui/react/pull/1954))
-- Fix setting `data-whatinput` attribute in child windows ([#1971](https://github.com/stardust-ui/react/pull/1971))
+- Fix setting `data-whatinput` attribute in child windows @layershifter ([#1972](https://github.com/stardust-ui/react/pull/1972))
 
 ### Features
 - Add experimental runtime accessibility attributes validation (the initial step validates the Button component only) @mshoho ([#1911](https://github.com/stardust-ui/react/pull/1911))

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
@@ -1,0 +1,5 @@
+const config: ScreenerTestsConfig = {
+  steps: [builder => builder.focus('iframe').snapshot('Focuses button in iframe')],
+}
+
+export default config

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
@@ -1,5 +1,0 @@
-const config: ScreenerTestsConfig = {
-  steps: [builder => builder.focus('iframe').snapshot('Focuses button in iframe')],
-}
-
-export default config

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
@@ -1,0 +1,7 @@
+const config: ScreenerTestsConfig = {
+  steps: [
+    (builder, keys) => builder.keys('body', keys.tab).snapshot('Focuses attachment in iframe'),
+  ],
+}
+
+export default config

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.steps.ts
@@ -1,7 +1,0 @@
-const config: ScreenerTestsConfig = {
-  steps: [
-    (builder, keys) => builder.keys('body', keys.tab).snapshot('Focuses attachment in iframe'),
-  ],
-}
-
-export default config

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
@@ -36,7 +36,7 @@ const ProviderExampleTargetFrame = () => (
     {externalDocument => (
       <Provider theme={themes.teams} target={externalDocument}>
         <Attachment actionable header="Document.docx" />
-        <Button content="Hello world!" />
+        <Button autoFocus content="Hello world!" />
       </Provider>
     )}
   </PortalFrame>

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
@@ -1,22 +1,18 @@
-import { Attachment, Button, Provider, Ref, themes } from '@stardust-ui/react'
+import { Attachment, Button, Provider, themes } from '@stardust-ui/react'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
 type PortalFrameProps = {
   children: (externalDocument: Document) => React.ReactElement
-  onMount: () => void
 }
 
-const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children, onMount }) => {
+const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children }) => {
   const frameRef = React.useRef<HTMLIFrameElement>(null)
   const [mounted, setMounted] = React.useState<boolean>(false)
 
   React.useEffect(() => {
     setMounted(true)
   }, [])
-  React.useEffect(() => {
-    if (mounted) onMount()
-  }, [mounted])
 
   return (
     <>
@@ -34,21 +30,15 @@ const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children, onMo
   )
 }
 
-const ProviderExampleTargetFrame = () => {
-  const buttonRef = React.useRef<HTMLButtonElement>()
-
-  return (
-    <PortalFrame onMount={() => buttonRef.current.focus()}>
-      {externalDocument => (
-        <Provider theme={themes.teams} target={externalDocument}>
-          <Attachment actionable header="Document.docx" />
-          <Ref innerRef={buttonRef}>
-            <Button content="Hello world!" />
-          </Ref>
-        </Provider>
-      )}
-    </PortalFrame>
-  )
-}
+const ProviderExampleTargetFrame = () => (
+  <PortalFrame>
+    {externalDocument => (
+      <Provider theme={themes.teams} target={externalDocument}>
+        <Attachment actionable header="Document.docx" />
+        <Button content="Hello world!" />
+      </Provider>
+    )}
+  </PortalFrame>
+)
 
 export default ProviderExampleTargetFrame

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { Attachment, Button, Provider, themes } from '@stardust-ui/react'
+
+type PortalWindowProps = {
+  children: (externalDocument: Document) => React.ReactElement
+  onClose?: () => void
+}
+
+const PortalFrame: React.FunctionComponent<PortalWindowProps> = ({ children }) => {
+  const frameRef = React.useRef<HTMLIFrameElement>(null)
+  const [mounted, setMounted] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return (
+    <>
+      <iframe
+        ref={frameRef}
+        style={{ height: 300, width: 600, border: 0, padding: 20 }}
+        title="An example of nested Provider in iframe"
+      />
+      {mounted &&
+        ReactDOM.createPortal(
+          children(frameRef.current.contentDocument),
+          frameRef.current.contentDocument.body,
+        )}
+    </>
+  )
+}
+
+const ProviderExampleTargetFrame = () => (
+  <PortalFrame>
+    {externalDocument => (
+      <Provider theme={themes.teams} target={externalDocument}>
+        <Attachment actionable header="Document.docx" />
+        <Button content="Hello world!" />
+      </Provider>
+    )}
+  </PortalFrame>
+)
+
+export default ProviderExampleTargetFrame

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
@@ -1,18 +1,22 @@
-import { Attachment, Button, Provider, themes } from '@stardust-ui/react'
+import { Attachment, Button, Provider, Ref, themes } from '@stardust-ui/react'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
 type PortalFrameProps = {
   children: (externalDocument: Document) => React.ReactElement
+  onMount: () => void
 }
 
-const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children }) => {
+const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children, onMount }) => {
   const frameRef = React.useRef<HTMLIFrameElement>(null)
   const [mounted, setMounted] = React.useState<boolean>(false)
 
   React.useEffect(() => {
     setMounted(true)
   }, [])
+  React.useEffect(() => {
+    if (mounted) onMount()
+  }, [mounted])
 
   return (
     <>
@@ -30,15 +34,21 @@ const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children }) =>
   )
 }
 
-const ProviderExampleTargetFrame = () => (
-  <PortalFrame>
-    {externalDocument => (
-      <Provider theme={themes.teams} target={externalDocument}>
-        <Attachment actionable header="Document.docx" />
-        <Button autoFocus content="Hello world!" />
-      </Provider>
-    )}
-  </PortalFrame>
-)
+const ProviderExampleTargetFrame = () => {
+  const buttonRef = React.useRef<HTMLButtonElement>()
+
+  return (
+    <PortalFrame onMount={() => buttonRef.current.focus()}>
+      {externalDocument => (
+        <Provider theme={themes.teams} target={externalDocument}>
+          <Attachment actionable header="Document.docx" />
+          <Ref innerRef={buttonRef}>
+            <Button content="Hello world!" />
+          </Ref>
+        </Provider>
+      )}
+    </PortalFrame>
+  )
+}
 
 export default ProviderExampleTargetFrame

--- a/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
+++ b/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
@@ -1,13 +1,12 @@
+import { Attachment, Button, Provider, themes } from '@stardust-ui/react'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { Attachment, Button, Provider, themes } from '@stardust-ui/react'
 
-type PortalWindowProps = {
+type PortalFrameProps = {
   children: (externalDocument: Document) => React.ReactElement
-  onClose?: () => void
 }
 
-const PortalFrame: React.FunctionComponent<PortalWindowProps> = ({ children }) => {
+const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children }) => {
   const frameRef = React.useRef<HTMLIFrameElement>(null)
   const [mounted, setMounted] = React.useState<boolean>(false)
 

--- a/docs/src/examples/components/Provider/Usage/index.tsx
+++ b/docs/src/examples/components/Provider/Usage/index.tsx
@@ -10,7 +10,14 @@ const Usage = () => (
       description="A Provider allows to define target document to apply styles."
       examplePath="components/Provider/Usage/ProviderExampleTarget"
     />
-    <ComponentExample examplePath="components/Provider/Usage/ProviderExampleTargetFrame" />
+    <ComponentExample
+      description={
+        <>
+          <code>iframe</code> can be also used as <code>target</code>.
+        </>
+      }
+      examplePath="components/Provider/Usage/ProviderExampleTargetFrame"
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/components/Provider/Usage/index.tsx
+++ b/docs/src/examples/components/Provider/Usage/index.tsx
@@ -10,6 +10,7 @@ const Usage = () => (
       description="A Provider allows to define target document to apply styles."
       examplePath="components/Provider/Usage/ProviderExampleTarget"
     />
+    <ComponentExample examplePath="components/Provider/Usage/ProviderExampleTargetFrame" />
   </ExampleSection>
 )
 

--- a/packages/react/src/lib/whatInput.ts
+++ b/packages/react/src/lib/whatInput.ts
@@ -7,13 +7,6 @@ import isBrowser from './isBrowser'
  * variables
  */
 
-// cache document.documentElement
-
-const docElem = isBrowser() ? document.documentElement : null
-
-// currently focused dom element
-let currentElement = null
-
 // last used input type
 let currentInput = 'initial'
 
@@ -83,7 +76,7 @@ const setUp = () => {
   inputMap[detectWheel()] = 'mouse'
 
   addListeners(window)
-  doUpdate()
+  doUpdate(window.document)
 }
 
 /*
@@ -117,10 +110,6 @@ const addListeners = (eventTarget: Window) => {
   // keyboard events
   eventTarget.addEventListener('keydown', eventBuffer, true)
   eventTarget.addEventListener('keyup', eventBuffer, true)
-
-  // focus events
-  eventTarget.addEventListener('focusin', setElement)
-  eventTarget.addEventListener('focusout', clearElement)
 }
 
 // checks conditions before updating new input
@@ -145,37 +134,14 @@ const setInput = event => {
         window.sessionStorage.setItem('what-input', currentInput)
       } catch (e) {}
 
-      doUpdate()
+      doUpdate(event.view.document)
     }
   }
 }
 
 // updates the doc and `inputTypes` array with new input
-const doUpdate = () => {
-  docElem.setAttribute(`data-whatinput`, currentInput)
-}
-
-const setElement = event => {
-  if (!event.target.nodeName) {
-    // If nodeName is undefined, clear the element
-    // This can happen if click inside an <svg> element.
-    clearElement()
-    return
-  }
-
-  currentElement = event.target.nodeName.toLowerCase()
-  docElem.setAttribute('data-whatelement', currentElement)
-
-  if (event.target.classList && event.target.classList.length) {
-    docElem.setAttribute('data-whatclasses', event.target.classList.toString().replace(' ', ','))
-  }
-}
-
-const clearElement = () => {
-  currentElement = null
-
-  docElem.removeAttribute('data-whatelement')
-  docElem.removeAttribute('data-whatclasses')
+const doUpdate = (target: Document) => {
+  target.documentElement.setAttribute(`data-whatinput`, currentInput)
 }
 
 // buffers events that frequently also fire mouse events
@@ -253,7 +219,7 @@ export const setUpWhatInput = (target: Document) => {
     target[whatInputInitialized] = true
 
     addListeners(targetWindow)
-    doUpdate()
+    doUpdate(target)
   }
 }
 


### PR DESCRIPTION
Fixes #1971.

***

This PR fixes our fork of `what-input` to properly set `data-whatinput` attribute as our `:focus-visible` implementation dependents on it.