### PR TITLE
fix(Alert): correctly handle RTL if shorthand API is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Correctly handle RTL in `Alert` component @miroslavstastny ([#2018](https://github.com/stardust-ui/react/pull/2018))
+
 <!--------------------------------[ v0.40.0 ]------------------------------- -->
 ## [v0.40.0](https://github.com/stardust-ui/react/tree/v0.40.0) (2019-10-09)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.39.0...v0.40.0)

--- a/docs/src/examples/components/Alert/Rtl/AlertExampleChildren.rtl.tsx
+++ b/docs/src/examples/components/Alert/Rtl/AlertExampleChildren.rtl.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react'
+import { Alert } from '@stardust-ui/react'
+
+const AlertExampleChildrenRtl = () => <Alert>مرحبا العالم</Alert>
+
+export default AlertExampleChildrenRtl

--- a/docs/src/examples/components/Alert/Rtl/AlertExampleDismissAction.rtl.tsx
+++ b/docs/src/examples/components/Alert/Rtl/AlertExampleDismissAction.rtl.tsx
@@ -12,6 +12,7 @@ const AlertExampleDismissActionRtl = () => (
         content: 'عالم',
       },
     ]}
+    icon="exclamation-triangle"
     content="مرحبا العالم"
   />
 )

--- a/docs/src/examples/components/Alert/Rtl/AlertExampleDismissAction.rtl.tsx
+++ b/docs/src/examples/components/Alert/Rtl/AlertExampleDismissAction.rtl.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { Alert } from '@stardust-ui/react'
+
+const AlertExampleDismissActionRtl = () => (
+  <Alert
+    actions={[
+      {
+        content: 'مرحبا',
+        primary: true,
+      },
+      {
+        content: 'عالم',
+      },
+    ]}
+    content="مرحبا العالم"
+  />
+)
+
+export default AlertExampleDismissActionRtl

--- a/docs/src/examples/components/Alert/Rtl/index.tsx
+++ b/docs/src/examples/components/Alert/Rtl/index.tsx
@@ -6,6 +6,8 @@ import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
 const Rtl = () => (
   <NonPublicSection title="Rtl">
     <ComponentExample examplePath="components/Alert/Rtl/AlertExample.rtl" />
+    <ComponentExample examplePath="components/Alert/Rtl/AlertExampleChildren.rtl" />
+    <ComponentExample examplePath="components/Alert/Rtl/AlertExampleDismissAction.rtl" />
   </NonPublicSection>
 )
 

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -239,14 +239,14 @@ class Alert extends AutoControlledComponent<WithAsProp<AlertProps>, AlertState> 
 
   renderComponent(config: RenderResultConfig<AlertProps>) {
     const { accessibility, classes, ElementType, unhandledProps } = config
-    const { children, content } = this.props
+    const { children } = this.props
 
     return (
       <ElementType
         className={classes.root}
         onFocus={this.handleFocus}
         {...accessibility.attributes.root}
-        {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
+        {...rtlTextContainer.getAttributes({ forElements: [children] })}
         {...unhandledProps}
       >
         {childrenExist(children) ? children : this.renderContent(config)}


### PR DESCRIPTION
Fixes #2017
Set dir="auto" on `Alert` only if Children API is used.
If shorthand API is used, content is wrapped by its own `Text` component, no need to set `dir` on parent container.