### PR TITLE
docs(Dialog): Fix closing of dialog in header action example

### DIFF
--- a/docs/src/examples/components/Dialog/Content/DialogExampleHeaderAction.shorthand.tsx
+++ b/docs/src/examples/components/Dialog/Content/DialogExampleHeaderAction.shorthand.tsx
@@ -9,6 +9,7 @@ const DialogExampleHeaderAction: React.FC = () => {
       open={open}
       onOpen={() => setOpen(true)}
       onCancel={() => setOpen(false)}
+      onConfirm={() => setOpen(false)}
       confirmButton="Confirm"
       content="Are you sure you want to confirm this action?"
       header="Action confirmation"

--- a/docs/src/examples/components/Dialog/Content/DialogExampleHeaderAction.shorthand.tsx
+++ b/docs/src/examples/components/Dialog/Content/DialogExampleHeaderAction.shorthand.tsx
@@ -7,7 +7,8 @@ const DialogExampleHeaderAction: React.FC = () => {
   return (
     <Dialog
       open={open}
-      onOpen={(e, { open }) => setOpen(open)}
+      onOpen={() => setOpen(true)}
+      onCancel={() => setOpen(false)}
       confirmButton="Confirm"
       content="Are you sure you want to confirm this action?"
       header="Action confirmation"


### PR DESCRIPTION
Use proper callbacks to allow outside click and Esc to close the dialog.