### PR TITLE
chore: update Screener triggers

### DIFF
--- a/.github/workflows/screener.yml
+++ b/.github/workflows/screener.yml
@@ -1,5 +1,10 @@
 name: Screener
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/build/screener/screener.config.js
+++ b/build/screener/screener.config.js
@@ -40,7 +40,10 @@ module.exports = {
     // failureExitCode: 0,
   }),
   ...(process.env.GITHUB_REF && {
-    branch: process.env.GITHUB_REF,
+    // GITHUB_REF can be:
+    // - refs/heads/feature-branch-1
+    // - refs/pull/2040/merge
+    branch: process.env.GITHUB_REF.split('/')[2],
     commit: process.env.GITHUB_SHA,
   }),
 }

--- a/build/screener/screener.config.js
+++ b/build/screener/screener.config.js
@@ -38,11 +38,9 @@ module.exports = {
     baseBranch: 'master',
     // Disable exit code to fail in Github Actions
     // failureExitCode: 0,
-  }),
-  ...(process.env.GITHUB_REF && {
     // GITHUB_REF can be:
-    // - refs/heads/feature-branch-1
-    // - refs/pull/2040/merge
+    // - refs/heads/feature-branch-1 for "push"
+    // - refs/pull/2040/merge for "pull_request"
     branch: process.env.GITHUB_REF.split('/')[2],
     commit: process.env.GITHUB_SHA,
   }),


### PR DESCRIPTION
This PR:
- corrects naming of branches/PRs
- enables running Screener for `master` branch to accept screenshots