### PR TITLE
fix(Doc): Do not break editor content when editing code which contains error

### DIFF
--- a/docs/src/components/Editor/Editor.tsx
+++ b/docs/src/components/Editor/Editor.tsx
@@ -53,7 +53,7 @@ export interface EditorProps extends AceEditorProps {
 export const EDITOR_BACKGROUND_COLOR = '#2D2D2D'
 export const EDITOR_GUTTER_COLOR = '#272727'
 
-class Editor extends React.Component<EditorProps> {
+class Editor extends React.PureComponent<EditorProps> {
   editorRef = React.createRef<any>()
   name = `docs-editor-${_.uniqueId()}`
 


### PR DESCRIPTION
Rerender `Editor` only if props change.