### PR TITLE
docs(Toolbar): Label toolbars examples, adding best practices

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.tsx
@@ -22,6 +22,7 @@ type ComponentControlsProps = {
   showRtl: boolean
   showVariables: boolean
   showTransparent: boolean
+  toolbarAriaLabel?: string
 }
 
 const controlsTheme: ThemeInput = {
@@ -60,6 +61,7 @@ const ComponentControls: React.FC<ComponentControlsProps> = props => {
     onShowRtl,
     onShowTransparent,
     onShowVariables,
+    toolbarAriaLabel,
     ...rest
   } = props
 
@@ -70,6 +72,7 @@ const ComponentControls: React.FC<ComponentControlsProps> = props => {
         fluid
         pills
         accessibility={menuAsToolbarBehavior}
+        aria-label={toolbarAriaLabel || null}
         items={[
           {
             key: 'show-code',

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -38,6 +38,7 @@ export interface ComponentExampleProps
   title: React.ReactNode
   description?: React.ReactNode
   examplePath: string
+  toolbarAriaLabel?: string
 }
 
 interface ComponentExampleState {
@@ -436,6 +437,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       onError,
       title,
       wasCodeChanged,
+      toolbarAriaLabel,
     } = this.props
     const {
       anchorName,
@@ -475,6 +477,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
                 <Flex.Item push>
                   <ComponentControls
+                    toolbarAriaLabel={toolbarAriaLabel}
                     anchorName={anchorName}
                     exampleCode={currentCode}
                     exampleLanguage={currentCodeLanguage}

--- a/docs/src/examples/components/Toolbar/BestPractices/ToolbarBestPractices.tsx
+++ b/docs/src/examples/components/Toolbar/BestPractices/ToolbarBestPractices.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { Text } from '@stardust-ui/react'
+import { link } from '../../../../utils/helpers'
+import ComponentBestPractices from 'docs/src/components/ComponentBestPractices'
+
+const doList = [
+  <Text>
+    Label each toolbar when the application contains more than one toolbar (using `aria-label` or
+    `aria-labelledby` props). Refer to{' '}
+    {link('toolbar(role)', 'https://www.w3.org/WAI/PF/aria/roles#toolbar')} for details.
+  </Text>,
+]
+
+const ToolbarBestPractices: React.FunctionComponent<{}> = () => {
+  return <ComponentBestPractices doList={doList} />
+}
+
+export default ToolbarBestPractices

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand.tsx
@@ -3,6 +3,7 @@ import { Button, Text, Toolbar } from '@stardust-ui/react'
 
 const ToolbarExampleCustomContentShorthand = () => (
   <Toolbar
+    aria-labelledby="toolbar-can-contain-custom-content"
     items={[
       { key: 'bold', icon: 'bold' },
       {

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand.tsx
@@ -3,7 +3,7 @@ import { Button, Text, Toolbar } from '@stardust-ui/react'
 
 const ToolbarExampleCustomContentShorthand = () => (
   <Toolbar
-    aria-labelledby="toolbar-can-contain-custom-content"
+    aria-label="Toolbar can contain custom content"
     items={[
       { key: 'bold', icon: 'bold' },
       {

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenu.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenu.shorthand.tsx
@@ -15,7 +15,7 @@ const ToolbarExampleMenuShorthand = () => {
 
   return (
     <Toolbar
-      aria-labelledby="toolbar-can-contain-a-menu"
+      aria-label="Toolbar can contain a menu"
       items={[
         {
           key: 'more',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenu.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenu.shorthand.tsx
@@ -15,6 +15,7 @@ const ToolbarExampleMenuShorthand = () => {
 
   return (
     <Toolbar
+      aria-labelledby="toolbar-can-contain-a-menu"
       items={[
         {
           key: 'more',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuItemToggle.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuItemToggle.shorthand.tsx
@@ -16,6 +16,7 @@ const ToolbarExampleMenuItemToggle = () => {
 
   return (
     <Toolbar
+      aria-labelledby="toolbar-can-contain-toggle-items-in-a-menu"
       items={[
         {
           key: 'more',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuItemToggle.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuItemToggle.shorthand.tsx
@@ -16,7 +16,7 @@ const ToolbarExampleMenuItemToggle = () => {
 
   return (
     <Toolbar
-      aria-labelledby="toolbar-can-contain-toggle-items-in-a-menu"
+      aria-label="Toolbar can contain toggle items in a menu"
       items={[
         {
           key: 'more',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuRadioGroup.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuRadioGroup.shorthand.tsx
@@ -7,6 +7,7 @@ const ToolbarExampleMenuRadioGroup = () => {
 
   return (
     <Toolbar
+      aria-labelledby="toolbar-can-contain-a-radio-group-in-a-menu"
       items={[
         {
           key: 'more',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuRadioGroup.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuRadioGroup.shorthand.tsx
@@ -7,7 +7,7 @@ const ToolbarExampleMenuRadioGroup = () => {
 
   return (
     <Toolbar
-      aria-labelledby="toolbar-can-contain-a-radio-group-in-a-menu"
+      aria-label="Toolbar can contain a radio group in a menu"
       items={[
         {
           key: 'more',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleOverflow.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleOverflow.shorthand.tsx
@@ -18,6 +18,7 @@ const ToolbarExampleOverflow = () => {
 
   return (
     <Toolbar
+      aria-labelledby="toolbar-overflow-menu"
       items={toolbarItems}
       overflow
       overflowOpen={overflowOpen}

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleOverflow.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleOverflow.shorthand.tsx
@@ -18,7 +18,7 @@ const ToolbarExampleOverflow = () => {
 
   return (
     <Toolbar
-      aria-labelledby="toolbar-overflow-menu"
+      aria-label="Toolbar overflow menu"
       items={toolbarItems}
       overflow
       overflowOpen={overflowOpen}

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExamplePopup.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExamplePopup.shorthand.tsx
@@ -31,6 +31,7 @@ const ToolbarExamplePopupShorthand = () => {
   const [fontColorActive, setFontColorActive] = React.useState(false)
   return (
     <Toolbar
+      aria-labelledby="toolbar-can-contain-a-popup"
       items={[
         {
           key: 'highlight',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExamplePopup.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExamplePopup.shorthand.tsx
@@ -31,7 +31,7 @@ const ToolbarExamplePopupShorthand = () => {
   const [fontColorActive, setFontColorActive] = React.useState(false)
   return (
     <Toolbar
-      aria-labelledby="toolbar-can-contain-a-popup"
+      aria-label="Toolbar can contain a popup"
       items={[
         {
           key: 'highlight',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleRadioGroup.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleRadioGroup.shorthand.tsx
@@ -7,7 +7,7 @@ const ToolbarExampleRadioGroupShorthand = () => {
   const [toDoListActive, setToDoListActive] = React.useState(false)
   return (
     <Toolbar
-      aria-labelledby="toolbar-can-contain-a-radio-group"
+      aria-label="Toolbar can contain a radio group"
       items={[
         {
           key: 'radiogroup',

--- a/docs/src/examples/components/Toolbar/Content/ToolbarExampleRadioGroup.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Content/ToolbarExampleRadioGroup.shorthand.tsx
@@ -7,6 +7,7 @@ const ToolbarExampleRadioGroupShorthand = () => {
   const [toDoListActive, setToDoListActive] = React.useState(false)
   return (
     <Toolbar
+      aria-labelledby="toolbar-can-contain-a-radio-group"
       items={[
         {
           key: 'radiogroup',

--- a/docs/src/examples/components/Toolbar/Content/index.tsx
+++ b/docs/src/examples/components/Toolbar/Content/index.tsx
@@ -9,6 +9,7 @@ const Content = () => (
   <ExampleSection title="Content">
     <ComponentExample
       title="Toolbar can contain a popup"
+      toolbarAriaLabel="Example Toolbar can contain a popup"
       description={
         <>
           Toolbar item can open a popup. See <Link to="/components/popup">Popup</Link> component for
@@ -19,26 +20,31 @@ const Content = () => (
     />
     <ComponentExample
       title="Toolbar can contain a radio group"
+      toolbarAriaLabel="Example Toolbar can contain a radio group"
       description="Toolbar items can be grouped into radio group. Up/Down arrow keys can be used to cycle between radio items. Only one of the radio items can be selected at a time, should be implemented additionally."
       examplePath="components/Toolbar/Content/ToolbarExampleRadioGroup"
     />
     <ComponentExample
       title="Toolbar can contain a menu"
+      toolbarAriaLabel="Example Toolbar can contain a menu"
       description="Toolbar item can open a menu."
       examplePath="components/Toolbar/Content/ToolbarExampleMenu"
     />
     <ComponentExample
       title="Toolbar can contain toggle items in a menu"
+      toolbarAriaLabel="Example Toolbar can contain toggle items in a menu"
       description="Toolbar item can open a menu which can contain toggle items."
       examplePath="components/Toolbar/Content/ToolbarExampleMenuItemToggle"
     />
     <ComponentExample
       title="Toolbar can contain a radio group in a menu"
+      toolbarAriaLabel="Example Toolbar can contain a radio group in a menu"
       description="Toolbar item can open a menu which can contain radio groups."
       examplePath="components/Toolbar/Content/ToolbarExampleMenuRadioGroup"
     />
     <ComponentExample
       title="Toolbar can contain custom content"
+      toolbarAriaLabel="Example Toolbar can contain custom content"
       description="Toolbar item can contain custom content."
       examplePath="components/Toolbar/Content/ToolbarExampleCustomContent"
     >
@@ -53,6 +59,7 @@ const Content = () => (
     </ComponentExample>
     <ComponentExample
       title="Toolbar overflow menu"
+      toolbarAriaLabel="Example Toolbar overflow menu"
       description="Toolbar can rearrange its items based on its wrapping container width."
       examplePath="components/Toolbar/Content/ToolbarExampleOverflow"
     />

--- a/docs/src/examples/components/Toolbar/Types/ToolbarExampleEditor.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Types/ToolbarExampleEditor.shorthand.tsx
@@ -73,6 +73,7 @@ const ToolbarExampleShorthand = () => {
   return (
     <>
       <Toolbar
+        aria-labelledby="text-editor-toolbar"
         items={[
           {
             key: 'bold',

--- a/docs/src/examples/components/Toolbar/Types/ToolbarExampleEditor.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Types/ToolbarExampleEditor.shorthand.tsx
@@ -73,7 +73,7 @@ const ToolbarExampleShorthand = () => {
   return (
     <>
       <Toolbar
-        aria-labelledby="text-editor-toolbar"
+        aria-label="Text editor"
         items={[
           {
             key: 'bold',

--- a/docs/src/examples/components/Toolbar/Types/index.tsx
+++ b/docs/src/examples/components/Toolbar/Types/index.tsx
@@ -6,6 +6,7 @@ const Types = () => (
   <ExampleSection title="Types">
     <ComponentExample
       title="Text editor toolbar"
+      toolbarAriaLabel="Example Text editor"
       description="A Toolbar use case for a text editor."
       examplePath="components/Toolbar/Types/ToolbarExampleEditor"
     />

--- a/docs/src/examples/components/Toolbar/Usage/ToolbarExampleActionPopupInMenu.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/ToolbarExampleActionPopupInMenu.shorthand.tsx
@@ -30,6 +30,7 @@ const ToolbarExampleActionPopupInMenu = () => {
   const [menuOpen, setMenuOpen] = React.useState(false)
   return (
     <Toolbar
+      aria-labelledby="popup-with-an-action-in-menu"
       items={[
         {
           icon: 'more',

--- a/docs/src/examples/components/Toolbar/Usage/ToolbarExampleActionPopupInMenu.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/ToolbarExampleActionPopupInMenu.shorthand.tsx
@@ -30,7 +30,7 @@ const ToolbarExampleActionPopupInMenu = () => {
   const [menuOpen, setMenuOpen] = React.useState(false)
   return (
     <Toolbar
-      aria-labelledby="popup-with-an-action-in-menu"
+      aria-label="Popup with an action in menu"
       items={[
         {
           icon: 'more',

--- a/docs/src/examples/components/Toolbar/Usage/ToolbarExamplePopupInMenu.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/ToolbarExamplePopupInMenu.shorthand.tsx
@@ -7,7 +7,7 @@ const ToolbarExamplePopupInMenu = () => {
 
   return (
     <Toolbar
-      aria-labelledby="popup-in-menu"
+      aria-label="Popup in menu"
       items={[
         {
           key: 'menu1',

--- a/docs/src/examples/components/Toolbar/Usage/ToolbarExamplePopupInMenu.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/ToolbarExamplePopupInMenu.shorthand.tsx
@@ -7,6 +7,7 @@ const ToolbarExamplePopupInMenu = () => {
 
   return (
     <Toolbar
+      aria-labelledby="popup-in-menu"
       items={[
         {
           key: 'menu1',

--- a/docs/src/examples/components/Toolbar/Usage/ToolbarExampleWithTooltip.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/ToolbarExampleWithTooltip.shorthand.tsx
@@ -19,7 +19,7 @@ const ToolbarExampleShorthand = () => {
 
   return (
     <Toolbar
-      aria-labelledby="with-tooltips"
+      aria-label="With tooltips"
       items={[
         {
           key: 'bold',

--- a/docs/src/examples/components/Toolbar/Usage/ToolbarExampleWithTooltip.shorthand.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/ToolbarExampleWithTooltip.shorthand.tsx
@@ -19,6 +19,7 @@ const ToolbarExampleShorthand = () => {
 
   return (
     <Toolbar
+      aria-labelledby="with-tooltips"
       items={[
         {
           key: 'bold',

--- a/docs/src/examples/components/Toolbar/Usage/index.tsx
+++ b/docs/src/examples/components/Toolbar/Usage/index.tsx
@@ -7,6 +7,7 @@ const Usage = () => (
   <ExampleSection title="Usage">
     <ComponentExample
       title="With tooltips"
+      toolbarAriaLabel="Example With tooltips"
       description={
         <>
           {'The items inside the Toolbar, as actionable elements, should be rendered with '}
@@ -17,11 +18,13 @@ const Usage = () => (
     />
     <ComponentExample
       title="Popup in Menu"
+      toolbarAriaLabel="Example Popup in Menu"
       description="Menus can contain items that show a Popup"
       examplePath="components/Toolbar/Usage/ToolbarExamplePopupInMenu"
     />
     <ComponentExample
       title="Popup with an action, in Menu"
+      toolbarAriaLabel="Example Popup with an action, in Menu"
       description="Popup action can lead to closing of the menu"
       examplePath="components/Toolbar/Usage/ToolbarExampleActionPopupInMenu"
     />


### PR DESCRIPTION
JAWS doesn't narrate some of our toolbars. 
The same issue appear when using toolbars on other pages. 

Issue is that if there is more than one toolbars on the page, then each toolbar need be labelled. 