### PR TITLE
fix(docs): Fix overflow in Editor Toolbar prototype opened in Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))
 
+### Documentation
+- Editor Toolbar prototype: Fix overflow menu overflowing in Portal window @miroslavstastny ([#2053](https://github.com/stardust-ui/react/pull/2053))
+
 <!--------------------------------[ v0.40.1 ]------------------------------- -->
 ## [v0.40.1](https://github.com/stardust-ui/react/tree/v0.40.1) (2019-10-18)
 [Compare changes](https://github.com/stardust-ui/react/compare/v0.40.0...v0.40.1)

--- a/docs/src/prototypes/EditorToolbar/PortalWindow.tsx
+++ b/docs/src/prototypes/EditorToolbar/PortalWindow.tsx
@@ -18,7 +18,14 @@ const PortalWindow: React.FunctionComponent<PortalWindowProps> = ({ children, on
     externalWindow.current.document.documentElement.style.fontSize = getComputedStyle(
       document.documentElement,
     ).fontSize
+    externalWindow.current.document.documentElement.style.height = '100%'
+    externalWindow.current.document.documentElement.style.width = '100%'
+    externalWindow.current.document.body.style.height = '100%'
+    externalWindow.current.document.body.style.width = '100%'
+
     externalContainer.current = externalWindow.current.document.createElement('div')
+    externalContainer.current.style.height = 'inherit'
+    externalContainer.current.style.width = 'inherit'
 
     externalWindow.current.document.body.appendChild(externalContainer.current)
     if (onClose) externalWindow.current.onbeforeunload = onClose

--- a/docs/src/prototypes/EditorToolbar/index.tsx
+++ b/docs/src/prototypes/EditorToolbar/index.tsx
@@ -39,7 +39,12 @@ const EditorToolbarInWindowPrototype = () => {
       {open && (
         <PortalWindow onClose={() => setOpen(false)}>
           {externalDocument => (
-            <Provider rtl={rtl} theme={themes.teams} target={externalDocument}>
+            <Provider
+              rtl={rtl}
+              theme={themes.teams}
+              styles={{ overflow: 'hidden', height: 'inherit', width: 'inherit' }}
+              target={externalDocument}
+            >
               <EditorToolbar {...state} dispatch={dispatch} />
             </Provider>
           )}


### PR DESCRIPTION
Fix `PortalWindow` styles in order for `Popper` positioning to work correctly.

### Before
![image](https://user-images.githubusercontent.com/9615899/67380419-94aa6e00-f58a-11e9-8905-6ca7eb17c285.png)

### After
![image](https://user-images.githubusercontent.com/9615899/67380856-3df16400-f58b-11e9-9cd8-0c01e96451a0.png)
