### PR TITLE
fix(Debug): Check that owner exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
-- Show debug panel correctly for components with no owner @miroslavstastny ([2055](https://github.com/stardust-ui/react/pull/2055))
+- Show debug panel correctly for components with no owner @miroslavstastny ([#2055](https://github.com/stardust-ui/react/pull/2055))
 
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
-- Show debug panel correctly for components with no owner. @miroslavstastny ([2055](https://github.com/stardust-ui/react/pull/2055))
+- Show debug panel correctly for components with no owner @miroslavstastny ([2055](https://github.com/stardust-ui/react/pull/2055))
 
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Show debug panel correctly for components with no owner. @miroslavstastny ([2055](https://github.com/stardust-ui/react/pull/2055))
+
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))
 

--- a/packages/react/src/components/Debug/DebugComponentViewer.tsx
+++ b/packages/react/src/components/Debug/DebugComponentViewer.tsx
@@ -23,14 +23,16 @@ const style: React.CSSProperties = {
 const DebugComponentViewer: React.FC<DebugComponentViewerProps> = props => {
   const { fiberNav, onFiberChanged, onFiberSelected } = props
 
-  const ownerNav = fiberNav.owner
+  const ownerNav = fiberNav.owner || ({ jsxString: 'unknown' } as FiberNavigator)
 
   const parentNavs = []
-  let parentNav = fiberNav.parent
+  if (fiberNav.owner) {
+    let parentNav = fiberNav.parent
 
-  while (parentNav && !parentNav.isEqual(ownerNav)) {
-    if (parentNav.stardustDebug) parentNavs.unshift(parentNav)
-    parentNav = parentNav.parent
+    while (parentNav && !parentNav.isEqual(ownerNav)) {
+      if (parentNav.stardustDebug) parentNavs.unshift(parentNav)
+      parentNav = parentNav.parent
+    }
   }
 
   const component = fiberNav.name && <DebugLine>{fiberNav.jsxString}</DebugLine>


### PR DESCRIPTION
When showing a debug panel, check that debug owner exists.

Debug owner is the component which rendered the debugged component. There are cases where the debug owner is not in the React tree. Consider the following example:
```jsx
const icon = <Icon name="call" />
const ButtonExample = () => <Button icon={() => icon} content="Click here" />
```
If that is rendered as an example in DocSite using `ComponentExample`, debug owner is not found.