### PR TITLE
fix(FocusZone): Fixing a core keydown disconnect issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Show debug panel correctly for components with no owner @miroslavstastny ([#2055](https://github.com/stardust-ui/react/pull/2055))
 - Correctly handle empty key actions in RTL @miroslavstastny ([#2060](https://github.com/stardust-ui/react/pull/2060))
 - Accessibility improvements for `tree` and `splitButton` @kolaps33 ([#2032](https://github.com/stardust-ui/react/pull/2032))
+- Fixing a core keydown disconnect issue @dzearing ([#2056](https://github.com/stardust-ui/react/pull/2056))
 
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))

--- a/packages/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/react-bindings/src/FocusZone/FocusZone.tsx
@@ -196,7 +196,7 @@ export default class FocusZone extends React.Component<FocusZoneProps> implement
       _outerZones.delete(this)
     }
 
-    if (this.windowElement) {
+    if (this.windowElement && _outerZones.size === 0) {
       this.windowElement.removeEventListener('keydown', this._onKeyDownCapture, true)
     }
 


### PR DESCRIPTION
When you have multiple outer zones on the page, the first one hooks up a global keydown handler to manage tab presses. This is only hooked up on the first outer zone instance.

When that instance is unmounted, the event handler goes away. In normal cases, first in last out would never hit a bug. But when you have first in first out scenarios, you are left with focuszones on the page that dont get tabindex fixes on hitting tab.

This fix makes sure that the global event handler is only disconnected on the last outer zone unmount.