### PR TITLE
fix(Accessibility): filter out key actions with no key combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Show debug panel correctly for components with no owner @miroslavstastny ([#2055](https://github.com/stardust-ui/react/pull/2055))
+- Correctly handle empty key actions in RTL @miroslavstastny ([#2060](https://github.com/stardust-ui/react/pull/2060))
 
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))

--- a/packages/react/src/lib/getKeyDownHandlers.ts
+++ b/packages/react/src/lib/getKeyDownHandlers.ts
@@ -28,7 +28,10 @@ const getKeyDownHandlers = (
   if (!componentActionHandlers || !behaviorKeyActions) return keyHandlers
 
   for (const componentPart in behaviorKeyActions) {
-    const componentPartKeyAction = _.pickBy(behaviorKeyActions[componentPart], 'keyCombinations')
+    const componentPartKeyAction = _.pickBy(
+      behaviorKeyActions[componentPart],
+      actions => !_.isEmpty(actions.keyCombinations),
+    )
     const handledActions = _.intersection(
       _.keys(componentPartKeyAction),
       _.keys(componentActionHandlers),

--- a/packages/react/src/lib/getKeyDownHandlers.ts
+++ b/packages/react/src/lib/getKeyDownHandlers.ts
@@ -28,7 +28,7 @@ const getKeyDownHandlers = (
   if (!componentActionHandlers || !behaviorKeyActions) return keyHandlers
 
   for (const componentPart in behaviorKeyActions) {
-    const componentPartKeyAction = behaviorKeyActions[componentPart]
+    const componentPartKeyAction = _.pickBy(behaviorKeyActions[componentPart], 'keyCombinations')
     const handledActions = _.intersection(
       _.keys(componentPartKeyAction),
       _.keys(componentActionHandlers),

--- a/packages/react/test/specs/lib/getKeyDownHandlers-test.ts
+++ b/packages/react/test/specs/lib/getKeyDownHandlers-test.ts
@@ -34,6 +34,7 @@ describe('getKeyDownHandlers', () => {
       expect(keyHandlers.hasOwnProperty(partElementName)).toBeTruthy()
       expect(keyHandlers[partElementName].hasOwnProperty('onKeyDown')).toBeTruthy()
     })
+
     test('for few component elements', () => {
       const actions = {
         testAction: () => {},
@@ -54,6 +55,7 @@ describe('getKeyDownHandlers', () => {
       expect(keyHandlers[partElementName].hasOwnProperty('onKeyDown')).toBeTruthy()
       expect(keyHandlers[anotherPartName].hasOwnProperty('onKeyDown')).toBeTruthy()
     })
+
     test('when there is 1 common action and few others that are not common', () => {
       const actions = {
         uncommonAction: () => {},
@@ -71,6 +73,7 @@ describe('getKeyDownHandlers', () => {
       expect(keyHandlers.hasOwnProperty(partElementName)).toBeTruthy()
       expect(keyHandlers[partElementName].hasOwnProperty('onKeyDown')).toBeTruthy()
     })
+
     test('and action should be invoked if keydown event has keycode mapped to that action', () => {
       const actions = {
         testAction: jest.fn(),
@@ -92,6 +95,24 @@ describe('getKeyDownHandlers', () => {
       expect(actions.testAction).toHaveBeenCalled()
       expect(actions.otherAction).toHaveBeenCalled()
       expect(actions.anotherTestAction).not.toHaveBeenCalled()
+    })
+
+    test('should ignore actions with no keyCombinations', () => {
+      const actions = {
+        testAction: jest.fn(),
+        otherAction: jest.fn(),
+      }
+
+      actionsDefinition[partElementName].otherAction = {
+        keyCombinations: false,
+      }
+
+      const keyHandlers = getKeyDownHandlers(actions, actionsDefinition)
+
+      keyHandlers[partElementName] &&
+        keyHandlers[partElementName]['onKeyDown'](eventArg(testKeyCode))
+      expect(actions.testAction).toHaveBeenCalled()
+      expect(actions.otherAction).not.toHaveBeenCalled()
     })
 
     describe('with respect of RTL', () => {
@@ -132,6 +153,28 @@ describe('getKeyDownHandlers', () => {
         expect(actions.actionOnLeftArrow).not.toHaveBeenCalled()
         expect(actions.actionOnRightArrow).toHaveBeenCalled()
       })
+
+      test('should ignore actions with no keyCombinations', () => {
+        const actions = {
+          actionOnRightArrow: jest.fn(),
+          otherAction: jest.fn(),
+        }
+
+        actionsDefinition[partElementName].actionOnRightArrow = {
+          keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
+        }
+
+        actionsDefinition[partElementName].otherAction = {
+          keyCombinations: false,
+        }
+
+        const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, true)
+
+        keyHandlers[partElementName] &&
+          keyHandlers[partElementName]['onKeyDown'](eventArg(keyboardKey.ArrowLeft))
+        expect(actions.actionOnRightArrow).toHaveBeenCalled()
+        expect(actions.otherAction).not.toHaveBeenCalled()
+      })
     })
   })
 
@@ -142,17 +185,35 @@ describe('getKeyDownHandlers', () => {
       const keyHandlers = getKeyDownHandlers(actions, actionsDefinition)
       expect(keyHandlers.hasOwnProperty(partElementName)).toBeFalsy()
     })
-    test("when acessibility's actionsDefinition is null", () => {
+
+    test("when accessibility's actionsDefinition is null", () => {
       const actions = { otherAction: () => {} }
       const keyHandlers = getKeyDownHandlers(actions, null)
 
       expect(keyHandlers.hasOwnProperty(partElementName)).toBeFalsy()
     })
+
     test('there are not common actions and actions definition', () => {
       const actions = { otherAction: () => {} }
       const keyHandlers = getKeyDownHandlers(actions, actionsDefinition)
 
       expect(keyHandlers.hasOwnProperty(partElementName)).toBeFalsy()
+    })
+
+    test('when action definition has no keyCombinations', () => {
+      const actions = {
+        testAction: () => {},
+        otherAction: () => {},
+      }
+
+      actionsDefinition.anotherPart = {
+        otherAction: {
+          keyCombinations: false,
+        },
+      }
+
+      const keyHandlers = getKeyDownHandlers(actions, actionsDefinition)
+      expect(keyHandlers.hasOwnProperty('anotherPart')).toBeFalsy()
     })
   })
 })

--- a/packages/react/test/specs/lib/getKeyDownHandlers-test.ts
+++ b/packages/react/test/specs/lib/getKeyDownHandlers-test.ts
@@ -100,11 +100,19 @@ describe('getKeyDownHandlers', () => {
     test('should ignore actions with no keyCombinations', () => {
       const actions = {
         testAction: jest.fn(),
-        otherAction: jest.fn(),
+        actionFalse: jest.fn(),
+        actionNull: jest.fn(),
+        actionEmpty: jest.fn(),
       }
 
-      actionsDefinition[partElementName].otherAction = {
+      actionsDefinition[partElementName].actionFalse = {
         keyCombinations: false,
+      }
+      actionsDefinition[partElementName].actionNull = {
+        keyCombinations: null,
+      }
+      actionsDefinition[partElementName].actionEmpty = {
+        keyCombinations: [],
       }
 
       const keyHandlers = getKeyDownHandlers(actions, actionsDefinition)
@@ -112,7 +120,9 @@ describe('getKeyDownHandlers', () => {
       keyHandlers[partElementName] &&
         keyHandlers[partElementName]['onKeyDown'](eventArg(testKeyCode))
       expect(actions.testAction).toHaveBeenCalled()
-      expect(actions.otherAction).not.toHaveBeenCalled()
+      expect(actions.actionFalse).not.toHaveBeenCalled()
+      expect(actions.actionNull).not.toHaveBeenCalled()
+      expect(actions.actionEmpty).not.toHaveBeenCalled()
     })
 
     describe('with respect of RTL', () => {
@@ -157,15 +167,23 @@ describe('getKeyDownHandlers', () => {
       test('should ignore actions with no keyCombinations', () => {
         const actions = {
           actionOnRightArrow: jest.fn(),
-          otherAction: jest.fn(),
+          actionFalse: jest.fn(),
+          actionNull: jest.fn(),
+          actionEmpty: jest.fn(),
         }
 
         actionsDefinition[partElementName].actionOnRightArrow = {
           keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
         }
 
-        actionsDefinition[partElementName].otherAction = {
+        actionsDefinition[partElementName].actionFalse = {
           keyCombinations: false,
+        }
+        actionsDefinition[partElementName].actionNull = {
+          keyCombinations: null,
+        }
+        actionsDefinition[partElementName].actionEmpty = {
+          keyCombinations: [],
         }
 
         const keyHandlers = getKeyDownHandlers(actions, actionsDefinition, true)
@@ -173,7 +191,9 @@ describe('getKeyDownHandlers', () => {
         keyHandlers[partElementName] &&
           keyHandlers[partElementName]['onKeyDown'](eventArg(keyboardKey.ArrowLeft))
         expect(actions.actionOnRightArrow).toHaveBeenCalled()
-        expect(actions.otherAction).not.toHaveBeenCalled()
+        expect(actions.actionFalse).not.toHaveBeenCalled()
+        expect(actions.actionNull).not.toHaveBeenCalled()
+        expect(actions.actionEmpty).not.toHaveBeenCalled()
       })
     })
   })
@@ -203,12 +223,20 @@ describe('getKeyDownHandlers', () => {
     test('when action definition has no keyCombinations', () => {
       const actions = {
         testAction: () => {},
-        otherAction: () => {},
+        actionFalse: () => {},
+        actionNull: () => {},
+        actionEmpty: () => {},
       }
 
       actionsDefinition.anotherPart = {
-        otherAction: {
+        actionFalse: {
           keyCombinations: false,
+        },
+        actionNull: {
+          keyCombinations: null,
+        },
+        actionEmpty: {
+          keyCombinations: [],
         },
       }
 


### PR DESCRIPTION
Fixes #2058.
Ignore keyActions with empty keyCombinations. Fixes exception in RTL.