### PR TITLE
feat(Teams theme): add foregroundHover2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add `menu` prop on `ToolbarMenuItem` component @mnajdova ([#1984](https://github.com/stardust-ui/react/pull/1984))
 - Add `unstable_overflow` to `ChatMessage` to provide more flexible position in overflow containers @layershifter ([#2050](https://github.com/stardust-ui/react/pull/2050))
+- Add `foregroundHover2` to Teams theme @miroslavstastny ([#2071](https://github.com/stardust-ui/react/pull/2071))
 
 ### Documentation
 - Editor Toolbar prototype: Fix overflow menu overflowing in Portal window @miroslavstastny ([#2053](https://github.com/stardust-ui/react/pull/2053))

--- a/packages/react/src/themes/teams-dark/colors.ts
+++ b/packages/react/src/themes/teams-dark/colors.ts
@@ -27,6 +27,7 @@ export const colorScheme: ColorSchemeMapping = {
 
     foregroundHover: colors.white,
     foregroundHover1: colors.white,
+    foregroundHover2: colors.white,
 
     backgroundHover: colors.grey[550],
     backgroundHover1: colors.grey[550],

--- a/packages/react/src/themes/teams-high-contrast/colors.ts
+++ b/packages/react/src/themes/teams-high-contrast/colors.ts
@@ -68,6 +68,7 @@ export const colorScheme: ColorSchemeMapping = {
 
     foregroundHover: colors.black,
     foregroundHover1: colors.black,
+    foregroundHover2: accessibleCyan,
 
     backgroundHover: accessibleYellow,
     backgroundHover1: accessibleYellow,

--- a/packages/react/src/themes/teams/colors.ts
+++ b/packages/react/src/themes/teams/colors.ts
@@ -239,6 +239,7 @@ export const colorScheme: ColorSchemeMapping<ColorScheme, TeamsColorNames> = {
 
     foregroundHover: colors.grey[750],
     foregroundHover1: colors.white,
+    foregroundHover2: colors.white,
 
     backgroundHover: colors.grey[100],
     backgroundHover1: colors.grey[150],


### PR DESCRIPTION
Add `foregroundHover2` with the following mapping:
Teams -> white
Teams dark -> white
Teams HC -> accessible cyan