### PR TITLE
perf: add filter to chart

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentPerfExample/ComponentPerfChart.tsx
+++ b/docs/src/components/ComponentDoc/ComponentPerfExample/ComponentPerfChart.tsx
@@ -1,40 +1,135 @@
-import { Box, Flex, Text } from '@stardust-ui/react'
+import * as _ from 'lodash'
+import { Box, Flex, RadioGroup, Text } from '@stardust-ui/react'
 import { PerfChart, usePerfData } from 'docs/src/components/ComponentDoc/PerfChart'
 import * as React from 'react'
+import { PerfData, PerfSample } from 'docs/src/components/ComponentDoc/PerfChart/PerfDataContext'
+
+enum FILTER_BY {
+  CI_BUILD = 'ci build',
+  RELEASE = 'release',
+  DAY = 'day',
+  MONTH = 'month',
+}
 
 export const ComponentPerfChart = ({ perfTestName }) => {
   const { loading, error, data } = usePerfData(perfTestName)
 
+  const [filterBy, setFilterBy] = React.useState(FILTER_BY.CI_BUILD)
+
+  let filteredData: PerfData = data
+
+  switch (filterBy) {
+    case FILTER_BY.CI_BUILD:
+      filteredData = data
+      break
+
+    case FILTER_BY.RELEASE:
+      filteredData = data.filter(entry => entry.tag)
+
+      if (!data[0].tag) {
+        const unreleased = { ...data[0], tag: 'UNRELEASED' }
+        filteredData.unshift(unreleased)
+      }
+      break
+
+    case FILTER_BY.DAY:
+      filteredData = []
+      _.forEachRight(data, (sample: PerfSample, i, arr) => {
+        const prevSample = arr[i - 1]
+
+        if (!prevSample) {
+          filteredData.push(sample)
+          return
+        }
+
+        const lastDate = new Date(prevSample.ts)
+        const nextDate = new Date(sample.ts)
+
+        if (
+          lastDate.getDate() !== nextDate.getDate() ||
+          lastDate.getMonth() !== nextDate.getMonth() ||
+          lastDate.getFullYear() !== nextDate.getFullYear()
+        ) {
+          filteredData.push(sample)
+        }
+      })
+      break
+
+    case FILTER_BY.MONTH:
+      filteredData = []
+
+      _.forEachRight(data, (sample: PerfSample, i, arr) => {
+        const prevSample = arr[i - 1]
+
+        if (!prevSample) {
+          filteredData.push(sample)
+          return
+        }
+
+        const lastDate = new Date(prevSample.ts)
+        const nextDate = new Date(sample.ts)
+
+        if (
+          lastDate.getMonth() !== nextDate.getMonth() ||
+          lastDate.getFullYear() !== nextDate.getFullYear()
+        ) {
+          filteredData.push(sample)
+        }
+      })
+      break
+
+    default:
+      break
+  }
+
+  const handleFilterChange = React.useCallback((e, props) => {
+    setFilterBy(props.value)
+  }, [])
+
   return (
-    <Box
-      styles={{
-        '::before': {
-          paddingTop: '50%',
-          content: '""',
-          display: 'block',
-        },
-        position: 'relative',
-      }}
-    >
-      <Flex
-        hAlign="center"
-        vAlign="center"
+    <div>
+      <RadioGroup
+        defaultCheckedValue={FILTER_BY.CI_BUILD}
+        checkedValueChanged={handleFilterChange}
+        items={[
+          { label: FILTER_BY.CI_BUILD, value: FILTER_BY.CI_BUILD },
+          { label: FILTER_BY.RELEASE, value: FILTER_BY.RELEASE },
+          { label: FILTER_BY.DAY, value: FILTER_BY.DAY },
+          { label: FILTER_BY.MONTH, value: FILTER_BY.MONTH },
+        ]}
+      />
+
+      <Box
         styles={{
-          position: 'absolute',
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0,
+          '::before': {
+            paddingTop: '50%',
+            content: '""',
+            display: 'block',
+          },
+          overflow: 'hidden',
+          position: 'relative',
         }}
       >
-        {loading ? (
-          <Text content="Loading..." />
-        ) : error ? (
-          <Text error content={`Error: ${error.message}`} />
-        ) : (
-          <PerfChart perfData={data} />
-        )}
-      </Flex>
-    </Box>
+        <Flex
+          hAlign="center"
+          vAlign="center"
+          styles={{
+            position: 'absolute',
+            top: '1rem',
+            bottom: 0,
+            left: 0,
+            right: 0,
+          }}
+        >
+          {loading ? (
+            <Text content="Loading..." />
+          ) : error ? (
+            <Text error content={`Error: ${error.message}`} />
+          ) : (
+            <PerfChart perfData={filteredData} />
+          )}
+        </Flex>
+      </Box>
+    </div>
   )
 }

--- a/docs/src/components/ComponentDoc/PerfChart/PerfChart.tsx
+++ b/docs/src/components/ComponentDoc/PerfChart/PerfChart.tsx
@@ -14,13 +14,24 @@ import PerfChartTooltip from './PerfChartTooltip'
 import { PerfData } from './PerfDataContext'
 import { curveBundle } from 'd3-shape'
 
+export type PerfChartProps = { perfData: PerfData }
+
+const sampleToXAxis = sample => {
+  return new Date(sample.ts).getTime()
+}
+
+const formatXAxis = val => {
+  const date = new Date(val)
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+}
+
 /**
  * Draws a performance chart for all items in perfData.performance.
  * Shows tooltip with details for selected build on mouse hover.
  * x-axis is a build number
  * y-axis is a render time
  */
-const PerfChart: React.FC<{ perfData: PerfData }> = ({ perfData }) => {
+const PerfChart: React.FC<PerfChartProps> = ({ perfData }) => {
   const availableCharts: string[] = perfData
     .reduce(
       (acc, next) => {
@@ -42,9 +53,9 @@ const PerfChart: React.FC<{ perfData: PerfData }> = ({ perfData }) => {
       <LineSeries
         {...props}
         key={chartName + key}
-        data={perfData.map(entry => ({
-          x: entry.build,
-          y: _.get(entry, `performance.${chartName}.actualTime.${data}`, 0),
+        data={perfData.map(sample => ({
+          x: sampleToXAxis(sample),
+          y: _.get(sample, `performance.${chartName}.actualTime.${data}`, 0),
         }))}
         {...(index === 0 && {
           onNearestX: (d: { x: number }) => {
@@ -67,17 +78,18 @@ const PerfChart: React.FC<{ perfData: PerfData }> = ({ perfData }) => {
         style={{ position: 'absolute', top: 0, right: 0, background: 'white' }}
       />
       <YAxis title="ms" />
-      <XAxis title="version / build" />
+      <XAxis tickFormat={formatXAxis} tickLabelAngle={-30} />
 
       <HorizontalGridLines />
 
       {/* git tags */}
       {perfData
-        .filter(entry => entry.tag)
-        .map(entry => {
-          const data = [{ x: entry.build, y: 0 }, { x: entry.build, y: 1000 }]
+        .filter(sample => sample.tag)
+        .map(sample => {
+          const data = [{ x: sampleToXAxis(sample), y: 0 }, { x: sampleToXAxis(sample), y: 1000 }]
           return (
             <DecorativeAxis
+              key={sample.build}
               style={{
                 ticks: { display: 'none' },
                 text: { display: 'none' },
@@ -93,11 +105,11 @@ const PerfChart: React.FC<{ perfData: PerfData }> = ({ perfData }) => {
       <LabelSeries
         allowOffsetToBeReversed
         data={perfData
-          .filter(entry => entry.tag)
-          .map(entry => ({
-            x: entry.build,
+          .filter(sample => sample.tag)
+          .map(sample => ({
+            x: sampleToXAxis(sample),
             y: 0,
-            label: entry.tag,
+            label: sample.tag,
             style: {
               fontSize: 10,
               fill: tagColor,
@@ -118,7 +130,6 @@ const PerfChart: React.FC<{ perfData: PerfData }> = ({ perfData }) => {
       {lineSeries('curve-median', 'median', {
         stroke: medColor,
         strokeWidth: '2px',
-        curve: curveBundle.beta(1),
       })}
 
       {lineSeries('curve-min', 'min', {
@@ -129,7 +140,10 @@ const PerfChart: React.FC<{ perfData: PerfData }> = ({ perfData }) => {
       })}
 
       {nearestX && (
-        <PerfChartTooltip x={nearestX} data={perfData.find(entry => entry.build === nearestX)} />
+        <PerfChartTooltip
+          x={nearestX}
+          data={perfData.find(sample => sampleToXAxis(sample) === nearestX)}
+        />
       )}
     </FlexibleXYPlot>
   )


### PR DESCRIPTION
Our perf charts now:

- show date on the X axis
- show 250 samples, instead of 50
- filter by `ci build` (perf times measured for each build on CI)
- filter by `release` (per released version of the library, including "unreleased")
- filter by `day` (first build of the day)
- filter by `month` (first build of the month)

![http://g.recordit.co/9ev17QA0Gt.gif](http://g.recordit.co/9ev17QA0Gt.gif)