### PR TITLE
fix(whatInput): cleanup previously added event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### BREAKING CHANGES
 - Control Tree `activeItemIds` through `expanded` TreeItem prop @silviuavram ([#2061](https://github.com/stardust-ui/react/pull/2061))
-
-### BREAKING CHANGES
 - Rename all @stardust-ui scope to @fluentui ([#2117](https://github.com/microsoft/fluent-ui-react/pull/2117))
 
 ### Fixes
@@ -34,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Accessibility `splitButton` & `menuButton` - screen reader fixes @kolaps33 ([#2090](https://github.com/microsoft/fluent-ui-react/pull/2090))
 - Accessibility `menuButton` add aria-controls attribute based on `open` prop @kolaps33 ([#2107](https://github.com/microsoft/fluent-ui-react/pull/2107))
 - Fix the 500 color variant for `steelLight` in category color scheme @natashamayurshah ([#2089](https://github.com/microsoft/fluent-ui-react/pull/2089))
+- Trigger `whatInput` cleanup when last `Provider` with custom `target` gets removed @silviuavram ([#2127](https://github.com/microsoft/fluent-ui-react/pull/2127))
 
 ### Features
 - Add `Table` component base implementation @pompomon ([#2099](https://github.com/microsoft/fluent-ui-react/pull/2099))

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 // @ts-ignore
 import { RendererProvider, ThemeProvider, ThemeContext } from 'react-fela'
 
-import { ChildrenComponentProps, setUpWhatInput } from '../../lib'
+import { ChildrenComponentProps, setUpWhatInput, tryCleanupWhatInput } from '../../lib'
 
 import {
   ThemePrepared,
@@ -145,6 +145,12 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
     this.renderFontFaces(this.outgoingContext.renderer)
     if (this.props.target) {
       setUpWhatInput(this.props.target)
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.target) {
+      tryCleanupWhatInput(this.props.target)
     }
   }
 

--- a/packages/react/src/lib/whatInput.ts
+++ b/packages/react/src/lib/whatInput.ts
@@ -214,8 +214,9 @@ export const setUpWhatInput = (target: Document) => {
     'addEventListener' in targetWindow &&
     Array.prototype.indexOf
   ) {
-    if (target[whatInputInitialized]) {
-      target[whatInputInitialized] = target[whatInputInitialized] + 1
+    const initializedTimes = target[whatInputInitialized]
+    if (typeof initializedTimes === 'number' && initializedTimes > 0) {
+      target[whatInputInitialized] = initializedTimes + 1
       return
     }
     target[whatInputInitialized] = 1

--- a/packages/react/src/lib/whatInput.ts
+++ b/packages/react/src/lib/whatInput.ts
@@ -96,7 +96,7 @@ const addListeners = (eventTarget: Window) => {
   if (eventTarget.PointerEvent) {
     eventTarget.addEventListener('pointerdown', setInput)
     // @ts-ignore
-  } else if (window.MSPointerEvent) {
+  } else if (eventTarget.MSPointerEvent) {
     eventTarget.addEventListener('MSPointerDown', setInput)
   } else {
     // mouse events
@@ -256,7 +256,6 @@ export const tryCleanupWhatInput = (target: Document) => {
   if (isBrowser() && targetWindow && 'removeEventListener' in targetWindow) {
     if (target[whatInputInitialized] === 1) {
       delete target[whatInputInitialized]
-      console.log('clean--')
       cleanupWhatInput(targetWindow)
     } else {
       target[whatInputInitialized] = target[whatInputInitialized] - 1

--- a/packages/react/src/lib/whatInput.ts
+++ b/packages/react/src/lib/whatInput.ts
@@ -96,7 +96,7 @@ const addListeners = (eventTarget: Window) => {
   if (eventTarget.PointerEvent) {
     eventTarget.addEventListener('pointerdown', setInput)
     // @ts-ignore
-  } else if (eventTarget.MSPointerEvent) {
+  } else if (window.MSPointerEvent) {
     eventTarget.addEventListener('MSPointerDown', setInput)
   } else {
     // mouse events

--- a/packages/react/src/lib/whatInput.ts
+++ b/packages/react/src/lib/whatInput.ts
@@ -30,6 +30,8 @@ const ignoreMap = [
   91, // Windows key / left Apple cmd
   93, // Windows menu / right Apple cmd
 ]
+// used to count how many Providers needed to initialize whatinput.
+const whatInputInitialized = 'whatInputInitialized'
 
 // mapping of events to input types
 const inputMap = {
@@ -87,7 +89,7 @@ const addListeners = (eventTarget: Window) => {
   // `pointermove`, `MSPointerMove`, `mousemove` and mouse wheel event binding
   // can only demonstrate potential, but not actual, interaction
   // and are treated separately
-  const options = supportsPassive ? { passive: true, useCapture: true } : true
+  const options = supportsPassive ? { passive: true, capture: true } : true
 
   // pointer events (mouse, pen, touch)
   // @ts-ignore
@@ -212,14 +214,52 @@ export const setUpWhatInput = (target: Document) => {
     'addEventListener' in targetWindow &&
     Array.prototype.indexOf
   ) {
-    const whatInputInitialized = 'whatInputInitialized'
-    if (target[whatInputInitialized] === true) {
+    if (target[whatInputInitialized]) {
+      target[whatInputInitialized] = target[whatInputInitialized] + 1
       return
     }
-    target[whatInputInitialized] = true
+    target[whatInputInitialized] = 1
 
     addListeners(targetWindow)
     doUpdate(target)
+  }
+}
+
+function cleanupWhatInput(eventTarget: Window) {
+  const options = supportsPassive ? { capture: true } : true
+
+  // @ts-ignore
+  if (eventTarget.PointerEvent) {
+    eventTarget.removeEventListener('pointerdown', setInput)
+    // @ts-ignore
+  } else if (window.MSPointerEvent) {
+    eventTarget.removeEventListener('MSPointerDown', setInput)
+  } else {
+    // mouse events
+    eventTarget.removeEventListener('mousedown', setInput, true)
+
+    // touch events
+    if ('ontouchstart' in eventTarget) {
+      eventTarget.removeEventListener('touchstart', eventBuffer, options)
+      eventTarget.removeEventListener('touchend', setInput, true)
+    }
+  }
+
+  // keyboard events
+  eventTarget.removeEventListener('keydown', eventBuffer, true)
+  eventTarget.removeEventListener('keyup', eventBuffer, true)
+}
+
+export const tryCleanupWhatInput = (target: Document) => {
+  const targetWindow = target.defaultView
+  if (isBrowser() && targetWindow && 'removeEventListener' in targetWindow) {
+    if (target[whatInputInitialized] === 1) {
+      delete target[whatInputInitialized]
+      console.log('clean--')
+      cleanupWhatInput(targetWindow)
+    } else {
+      target[whatInputInitialized] = target[whatInputInitialized] - 1
+    }
   }
 }
 

--- a/packages/react/test/specs/components/Provider/Provider-test.tsx
+++ b/packages/react/test/specs/components/Provider/Provider-test.tsx
@@ -232,4 +232,58 @@ describe('Provider', () => {
 
     expect(renderStatic).toHaveBeenCalled()
   })
+
+  describe('target', () => {
+    test('performs whatinput init on first Provider mount', () => {
+      const addEventListener = jest.fn()
+      const setAttribute = jest.fn()
+      const externalDocument: any = {
+        defaultView: {
+          addEventListener,
+          removeEventListener: jest.fn(),
+          ontouchstart: jest.fn(),
+        },
+        documentElement: {
+          setAttribute,
+        },
+      }
+
+      mount(
+        <Provider id="first-provider" target={externalDocument}>
+          <Provider id="second-provider" target={externalDocument}>
+            <div />
+          </Provider>
+        </Provider>,
+      )
+
+      expect(addEventListener).toHaveBeenCalledTimes(5)
+      expect(setAttribute).toHaveBeenCalledTimes(1)
+    })
+
+    test('performs whatinput cleanup on last Provider unmount', () => {
+      const removeEventListener = jest.fn()
+      const setAttribute = jest.fn()
+      const externalDocument: any = {
+        defaultView: {
+          addEventListener: jest.fn(),
+          removeEventListener,
+          ontouchstart: jest.fn(),
+        },
+        documentElement: {
+          setAttribute,
+        },
+      }
+
+      const wrapper = mount(
+        <Provider id="first-provider" target={externalDocument}>
+          <Provider id="second-provider" target={externalDocument}>
+            <div />
+          </Provider>
+        </Provider>,
+      )
+      wrapper.unmount()
+
+      expect(removeEventListener).toHaveBeenCalledTimes(5)
+    })
+  })
 })

--- a/packages/react/test/specs/components/Provider/Provider-test.tsx
+++ b/packages/react/test/specs/components/Provider/Provider-test.tsx
@@ -256,8 +256,9 @@ describe('Provider', () => {
         </Provider>,
       )
 
+      // mousedown + touchstart + touchend + keyup + keydown
       expect(addEventListener).toHaveBeenCalledTimes(5)
-      expect(setAttribute).toHaveBeenCalledTimes(1)
+      expect(setAttribute).toHaveBeenCalledWith('data-whatinput', expect.any(String))
     })
 
     test('performs whatinput cleanup on last Provider unmount', () => {
@@ -283,6 +284,7 @@ describe('Provider', () => {
       )
       wrapper.unmount()
 
+      // mousedown + touchstart + touchend + keyup + keydown
       expect(removeEventListener).toHaveBeenCalledTimes(5)
     })
   })


### PR DESCRIPTION
Fixes https://github.com/microsoft/fluent-ui-react/issues/2109

Counting on `target[whatInputInitialized]` the number of Providers requesting to setup the custom-target whatInput.

To cleanup, in Provider `componentWillUnmount` we will attempt to remove listeners. If there are still Providers running (`target[whatInputInitialized] > 1`) then we will decrement that value. If it's the last one, then we perform cleanup.

Extra:
- in `whatInput.ts` I changed `useCapture` with `capture` (line 92). According to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) that is the correct property if we pass the information inside the `options` object params.

To Do:
- add test to check cleanup is performed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2127)