### PR TITLE
fix(Dropdown): prevent unnecessary re-renders in DropdowItem

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -745,7 +745,15 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                 key: (item as any).header,
               }),
           }),
-          overrideProps: this.handleItemOverrides(item, index, getItemProps, selected),
+          overrideProps: {
+            getItemProps,
+            item,
+            index,
+            // for single selection the selected item should have aria-selected, instead of the highlighted
+            ...(!this.props.multiple && {
+              'aria-selected': selected,
+            }),
+          },
           render: renderItem,
         })
       }),
@@ -851,29 +859,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
   isSelectedItemActive = (index: number): boolean => {
     return index === this.state.activeSelectedIndex
   }
-
-  handleItemOverrides = (
-    item: ShorthandValue<DropdownItemProps>,
-    index: number,
-    getItemProps: (options: GetItemPropsOptions<ShorthandValue<DropdownItemProps>>) => any,
-    selected: boolean,
-  ) => (predefinedProps: DropdownItemProps) => ({
-    accessibilityItemProps: {
-      ...getItemProps({
-        item,
-        index,
-        onClick: e => {
-          e.stopPropagation()
-          e.nativeEvent.stopImmediatePropagation()
-          _.invoke(predefinedProps, 'onClick', e, predefinedProps)
-        },
-      }),
-      // for single selection the selected item should have aria-selected, instead of the highlighted
-      ...(!this.props.multiple && {
-        'aria-selected': selected,
-      }),
-    },
-  })
 
   handleSelectedItemOverrides = (item: ShorthandValue<DropdownItemProps>, rtl: boolean) => (
     predefinedProps: DropdownSelectedItemProps,

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -88,6 +88,10 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
     selected: PropTypes.bool,
   }
 
+  shouldComponentUpdate(nextProps: DropdownItemProps) {
+    return !_.isEqual(this.props, nextProps)
+  }
+
   handleClick = e => {
     _.invoke(this.props, 'onClick', e, this.props)
   }
@@ -101,7 +105,10 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
       selected,
       checkable,
       checkableIndicator,
-    } = this.props
+      getItemProps,
+      item,
+      index,
+    } = this.props as any
     return (
       <ListItem
         className={DropdownItem.className}
@@ -140,10 +147,21 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
         }
         truncateContent
         truncateHeader
+        {...getItemProps({
+          item,
+          index,
+          onClick: this.handleItemClick,
+        })}
         {...accessibilityItemProps}
         {...unhandledProps}
       />
     )
+  }
+
+  handleItemClick = e => {
+    e.stopPropagation()
+    e.nativeEvent.stopImmediatePropagation()
+    _.invoke(this.props, 'onClick', e, this.props)
   }
 }
 

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -16,6 +16,7 @@ import ListItem from '../List/ListItem'
 import Icon, { IconProps } from '../Icon/Icon'
 import Image, { ImageProps } from '../Image/Image'
 import Box, { BoxProps } from '../Box/Box'
+import { GetItemPropsOptions } from 'downshift'
 
 export interface DropdownItemSlotClassNames {
   content: string
@@ -40,11 +41,20 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
   /** A slot for a checkable indicator. */
   checkableIndicator?: ShorthandValue<IconProps>
 
+  /** Getter prop callback from Downshift. */
+  getItemProps: (options: GetItemPropsOptions<ShorthandValue<DropdownItemProps>>) => any
+
   /** Item's header. */
   header?: ShorthandValue<BoxProps>
 
   /** Item's image. */
   image?: ShorthandValue<ImageProps>
+
+  /** Index of item in the list. */
+  index: number
+
+  /** Item's shorthand that will be passed to getItemProps for referencing. */
+  item: ShorthandValue<DropdownItemProps>
 
   /** Indicated whether the item has been set active by keyboard. */
   isFromKeyboard?: boolean
@@ -76,13 +86,15 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
       children: false,
       content: false,
     }),
-    accessibilityItemProps: PropTypes.object,
     active: PropTypes.bool,
     content: customPropTypes.itemShorthand,
     checkable: PropTypes.bool,
     checkableIndicator: customPropTypes.itemShorthandWithoutJSX,
+    getItemProps: PropTypes.func,
     header: customPropTypes.itemShorthand,
     image: customPropTypes.itemShorthandWithoutJSX,
+    index: PropTypes.number,
+    item: customPropTypes.itemShorthand,
     onClick: PropTypes.func,
     isFromKeyboard: PropTypes.bool,
     selected: PropTypes.bool,
@@ -108,7 +120,7 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
       getItemProps,
       item,
       index,
-    } = this.props as any
+    } = this.props
     return (
       <ListItem
         className={DropdownItem.className}

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -29,9 +29,6 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
   /** A dropdown item can be active. */
   active?: boolean
 
-  /** Item's accessibility props. */
-  accessibilityItemProps?: any
-
   /** Item's content. */
   content?: ShorthandValue<BoxProps>
 
@@ -42,7 +39,7 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
   checkableIndicator?: ShorthandValue<IconProps>
 
   /** Getter prop callback from Downshift. */
-  getItemProps: (options: GetItemPropsOptions<ShorthandValue<DropdownItemProps>>) => any
+  getItemProps?: (options: GetItemPropsOptions<ShorthandValue<DropdownItemProps>>) => any
 
   /** Item's header. */
   header?: ShorthandValue<BoxProps>
@@ -51,10 +48,10 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
   image?: ShorthandValue<ImageProps>
 
   /** Index of item in the list. */
-  index: number
+  index?: number
 
   /** Item's shorthand that will be passed to getItemProps for referencing. */
-  item: ShorthandValue<DropdownItemProps>
+  item?: ShorthandValue<DropdownItemProps>
 
   /** Indicated whether the item has been set active by keyboard. */
   isFromKeyboard?: boolean
@@ -113,7 +110,6 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
       content,
       header,
       image,
-      accessibilityItemProps,
       selected,
       checkable,
       checkableIndicator,
@@ -164,7 +160,6 @@ class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
           index,
           onClick: this.handleItemClick,
         })}
-        {...accessibilityItemProps}
         {...unhandledProps}
       />
     )


### PR DESCRIPTION
Breaking Changes🔥

We will not call `getItemProps` in `Dropdown`, we are passing the callback and its required params to `DropdownItem`. Unnecessary re-renders were triggered because that function returns an object, which is new every time.

Also doing a deep comparison between props in `DropdownItem` to make it act as a pure component, as we don't want it re-rendering when `Downshift` (parent component re-renders). The pure comparison is killing a bit the performance, but for now it is way faster than it was before while maintaining the same behavior. Maybe we can improve here as well, as without that deep compare the performance is fast.

Had to change prop types in `DropdownItem` to match the current implementation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2131)