### PR TITLE
adds a built artifact to ignore for eslinting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,7 @@
 coverage/
 dist/
 node_modules/
-lib/
-!src/**/lib/
-!test/**/lib/
-!src/lib/
-!test/lib/
+
+# packages that have lib as the output
+packages/digest/lib
+packages/perf-test/lib

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,8 @@
 coverage/
 dist/
 node_modules/
-packages/digest/lib/
+lib/
+!src/**/lib/
+!test/**/lib/
+!src/lib/
+!test/lib/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage/
 dist/
 node_modules/
+packages/digest/lib/

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,7 @@ stats/
 .vscode/
 temp/
 *.api.json
-lib/
-!src/**/lib/
-!test/**/lib/
-!src/lib/
-!test/lib/
+
+# packages that have lib as the output
+packages/digest/lib
+packages/perf-test/lib

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ stats/
 .vscode/
 temp/
 *.api.json
+lib/
+!src/**/lib/
+!test/**/lib/
+!src/lib/
+!test/lib/

--- a/.nowignore
+++ b/.nowignore
@@ -13,6 +13,11 @@ node_modules
 packages/**/dist
 packages/**/test
 perf/dist
+lib/
+!src/**/lib/
+!test/**/lib/
+!src/lib/
+!test/lib/
 
 .editorconfig
 .gitignore

--- a/.nowignore
+++ b/.nowignore
@@ -13,11 +13,9 @@ node_modules
 packages/**/dist
 packages/**/test
 perf/dist
-lib/
-!src/**/lib/
-!test/**/lib/
-!src/lib/
-!test/lib/
+
+packages/digest/lib
+packages/perf-test/lib
 
 .editorconfig
 .gitignore

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,12 @@
 coverage/
 dist/
 stats/
+lib/
+!src/**/lib/
+!test/**/lib/
+!src/lib/
+!test/lib/
+
 
 package.json
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,12 +6,10 @@
 coverage/
 dist/
 stats/
-lib/
-!src/**/lib/
-!test/**/lib/
-!src/lib/
-!test/lib/
 
+# packages that have lib as the output
+packages/digest/lib
+packages/perf-test/lib
 
 package.json
 

--- a/packages/digest/.gitignore
+++ b/packages/digest/.gitignore
@@ -1,3 +1,0 @@
-# TODO: this should be elevated to root
-# typescript
-lib/


### PR DESCRIPTION
When we added the @fluentui/digest package, we ended up producing artifacts in the /lib directory (we had some different conventions from other repos). This was okay in CI build in the past because of the fact that we linted the code before building. But in a local dev environment, we often build before AND after linting. This make sure that eslint ignores the built files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2149)