### PR TITLE
Rename lib=>utils in stats webpack config

### DIFF
--- a/build/webpack.config.stats.ts
+++ b/build/webpack.config.stats.ts
@@ -75,8 +75,8 @@ export default [
   // entire package
   makeConfig('index', 'bundle-stardust-ui-react'),
 
-  // lib (core)
-  makeConfig('lib/index', 'bundle-stardust-ui-core'),
+  // utils (core)
+  makeConfig('utils/index', 'bundle-stardust-ui-core'),
 
   // individual components
   ...fs


### PR DESCRIPTION
Missed one rename in #2153 which broke the stats calculations in master.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2162)