### PR TITLE
perf: run flamegrill in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
           name: Circular Dependencies Tests
           command: yarn test:circulars
       - run:
+          name: Flamegrill
+          command: yarn perf:test
+      - run:
           name: Bundle Statistics (master only)
           command: |
             if [ $CIRCLE_BRANCH == 'master' ]; then

--- a/.github/test-a-feature.md
+++ b/.github/test-a-feature.md
@@ -265,11 +265,10 @@ Finding the right number of `iterations` is a balancing act between having a fas
 
 Run test and watch:
 ```
-cd packages/perf-test
-yarn just perf-test
+yarn perf:test
 ```
 
-After running `perf-test`, results can be viewed in the `packages/perf-test/dist` folder with the main entry file being `packages/perf-test/dist/perfCounts.html`.
+After running `perf:test`, results can be viewed in the `packages/perf-test/dist` folder with the main entry file being `packages/perf-test/dist/perfCounts.html`.
 
 There are more detailed commands as well (these must be run from `packages/perf-test` directory):
 

--- a/build/gulp/tasks/stats.ts
+++ b/build/gulp/tasks/stats.ts
@@ -143,6 +143,34 @@ function readSummaryPerfStats() {
     .value()
 }
 
+function readPerfTestStats() {
+  return require(paths.packageDist('perf-test', 'perfCounts.json'))
+}
+
+// 1. iterate over all perf-test results
+// 2. the ones which have filename are docsite perf examples
+//    -> use camelCase name (docsite perf examples convention)
+//    -> and merge yarn perf (summaryPerf) and yarn perf:test (perfTest) data
+// 3. the others are perf-test only examples -> store
+function mergePerfStats(summaryPerfStats, perfTestStats) {
+  return _.transform(
+    perfTestStats,
+    (result, value, key: string) => {
+      const perfTest = _.pick(value, ['profile.metrics', 'analysis', 'extended'])
+      if (value['extended'].filename) {
+        const docsiteFilename = _.camelCase(value['extended'].filename)
+        result[docsiteFilename] = {
+          ...summaryPerfStats[docsiteFilename],
+          perfTest,
+        }
+      } else {
+        result[key.replace(/\./g, '_')] = { perfTest } // mongodb does not allow dots in keys
+      }
+    },
+    {},
+  )
+}
+
 function readCurrentBundleStats() {
   return _.mapKeys(require(currentStatsFilePath), (value, key) => _.camelCase(key)) // mongodb does not allow dots in keys
 }
@@ -158,6 +186,9 @@ task('stats:save', async () => {
   )
   const bundleStats = readCurrentBundleStats()
   const perfStats = readSummaryPerfStats()
+  const perfTestStats = readPerfTestStats()
+
+  const mergedPerfStats = mergePerfStats(perfStats, perfTestStats)
 
   const prUrl =
     process.env.CIRCLE_PULL_REQUEST ||
@@ -170,7 +201,7 @@ task('stats:save', async () => {
     build: process.env.BUILD_BUILDID || process.env.CIRCLE_BUILD_NUM,
     ...commandLineArgs, // allow command line overwrites
     bundleSize: bundleStats,
-    performance: perfStats,
+    performance: mergedPerfStats,
     ts: new Date(),
   }
 

--- a/build/gulp/tasks/stats.ts
+++ b/build/gulp/tasks/stats.ts
@@ -143,28 +143,28 @@ function readSummaryPerfStats() {
     .value()
 }
 
-function readPerfTestStats() {
+function readFlamegrillStats() {
   return require(paths.packageDist('perf-test', 'perfCounts.json'))
 }
 
 // 1. iterate over all perf-test results
 // 2. the ones which have filename are docsite perf examples
 //    -> use camelCase name (docsite perf examples convention)
-//    -> and merge yarn perf (summaryPerf) and yarn perf:test (perfTest) data
+//    -> and merge yarn perf (summaryPerf) and yarn perf:test (flamegrill) data
 // 3. the others are perf-test only examples -> store
 function mergePerfStats(summaryPerfStats, perfTestStats) {
   return _.transform(
     perfTestStats,
     (result, value, key: string) => {
-      const perfTest = _.pick(value, ['profile.metrics', 'analysis', 'extended'])
+      const flamegrill = _.pick(value, ['profile.metrics', 'analysis', 'extended'])
       if (value['extended'].filename) {
         const docsiteFilename = _.camelCase(value['extended'].filename)
         result[docsiteFilename] = {
           ...summaryPerfStats[docsiteFilename],
-          perfTest,
+          flamegrill,
         }
       } else {
-        result[key.replace(/\./g, '_')] = { perfTest } // mongodb does not allow dots in keys
+        result[key.replace(/\./g, '_')] = { flamegrill } // mongodb does not allow dots in keys
       }
     },
     {},
@@ -186,9 +186,9 @@ task('stats:save', async () => {
   )
   const bundleStats = readCurrentBundleStats()
   const perfStats = readSummaryPerfStats()
-  const perfTestStats = readPerfTestStats()
+  const flamegrillStats = readFlamegrillStats()
 
-  const mergedPerfStats = mergePerfStats(perfStats, perfTestStats)
+  const mergedPerfStats = mergePerfStats(perfStats, flamegrillStats)
 
   const prUrl =
     process.env.CIRCLE_PULL_REQUEST ||

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "now-build": "cross-env NOW=true yarn predeploy:docs",
     "perf": "cross-env PERF=true gulp perf --times=100",
     "perf:debug": "cross-env PERF=true gulp perf:debug --debug",
+    "perf:test": "yarn lerna run --stream --scope @fluentui/perf-test perf:test",
     "prettier": "prettier --list-different \"**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx}\"",
     "precommit": "lint-staged",

--- a/packages/perf-test/package.json
+++ b/packages/perf-test/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "just-scripts build",
     "clean": "just-scripts clean",
-    "test": "just-scripts test"
+    "test": "just-scripts test",
+    "perf:test": "just-scripts perf-test"
   },
   "devDependencies": {
     "@fluentui/digest": "^0.41.1",

--- a/packages/perf-test/tasks/perf-test.ts
+++ b/packages/perf-test/tasks/perf-test.ts
@@ -109,7 +109,6 @@ export default async function getPerfRegressions() {
   const status = 'success'
 
   console.log(`Perf evaluation status: ${status}`)
-  // console.log(`Writing comment to file:\n${comment}`)
 
   // Write results to file
   fs.writeFileSync(path.join(outDir, 'perfCounts.html'), comment)

--- a/packages/perf-test/tasks/perf-test.ts
+++ b/packages/perf-test/tasks/perf-test.ts
@@ -248,8 +248,6 @@ function createScenarioTable(stories, testResults: ExtendedCookResults, showAll:
             )
           : ''
 
-        console.log('MX', testResult, tpi)
-
         return `<tr>
             <td>${testResult.extended.kind}</td>
             <td>${testResult.extended.story}</td>

--- a/packages/perf-test/tasks/perf-test.ts
+++ b/packages/perf-test/tasks/perf-test.ts
@@ -12,6 +12,7 @@ type ExtendedCookResult = CookResult & {
     iterations: number
     tpi?: number
     fabricTpi?: number
+    filename?: number
   }
 }
 type ExtendedCookResults = Record<string, ExtendedCookResult>
@@ -99,9 +100,7 @@ export default async function getPerfRegressions() {
   const extendedCookResults = extendCookResults(stories, scenarioResults)
   fs.writeFileSync(
     path.join(outDir, 'perfCounts.json'),
-    JSON.stringify(extendedCookResults),
-    null,
-    2,
+    JSON.stringify(extendedCookResults, null, 2),
   )
 
   const comment = createReport(stories, extendedCookResults)
@@ -137,7 +136,7 @@ function extendCookResults(stories, testResults: CookResults): ExtendedCookResul
         iterations,
         tpi,
         fabricTpi,
-        docsite: stories[kind][story].docsite,
+        filename: stories[kind][story].filename,
       },
     }
   })


### PR DESCRIPTION
Flamegrill integration was added in ##2133.
This PR integrates Flamegrill into PR pipeline.

1. Add yarn command to be able to run flamegrill:
```shell
yarn perf:test
```
2. Run flamegrill in CircleCI (all builds)
3. Save flamegrill results to DB (master build only).

Requires #2164.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2163)