### PR TITLE
chore: capture heap snapshots with Fluent IDs

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,14 +1,11 @@
-name: Screener
+name: Perf
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - master
 
 jobs:
   test:
-    name: Test visuals on Screener
+    name: Create a heap snapshot from perf tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -25,7 +22,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install
-      - run: yarn test:visual
+      - run: yarn perf:memory
         env:
           CI: true
-          SCREENER_API_KEY: ${{secrets.SCREENER_API_KEY}}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: perf.heapsnapshot
+          path: perf/dist/result.heapsnapshot

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,9 +9,6 @@ jobs:
     runs-on: circleci/node:10-browsers
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -22,7 +22,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install
-      - run: yarn perf:memory
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+      - name: Test
+        uses: ianwalter/puppeteer@v2.0.0
+        with:
+          args: yarn perf:memory
         env:
           CI: true
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Create a heap snapshot from perf tests
-    runs-on: ubuntu-latest
+    runs-on: circleci/node:10-browsers
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -22,12 +22,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
-      - name: Test
-        uses: ianwalter/puppeteer@v2.0.0
-        with:
-          args: yarn perf:memory
+      - run: yarn perf:memory
         env:
           CI: true
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,6 +32,8 @@ jobs:
         uses: ianwalter/puppeteer@v2.0.0
         with:
           args: yarn perf:memory
+        env:
+          CI: true
       - name: Save heap snapshot
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -12,8 +12,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 10
-      - name: Get yarn cache
-        id: yarn-cache
+      - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
@@ -21,11 +20,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn install
-      - run: yarn perf:memory
-        uses: docker://circleci/node:10-browsers
-        env:
-          CI: true
+      - uses: ianwalter/puppeteer@v2.0.0
+        with:
+          args: yarn
+      - uses: ianwalter/puppeteer@v2.0.0
+        with:
+          args: yarn perf:memory
       - uses: actions/upload-artifact@v1
         with:
           name: perf.heapsnapshot

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -25,9 +25,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies
-        uses: ianwalter/puppeteer@v2.0.0
-        with:
-          args: yarn
+        run: yarn install
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Run perf tests
         uses: ianwalter/puppeteer@v2.0.0
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,25 +8,32 @@ jobs:
     name: Create a heap snapshot from perf tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Checkout from Git
+        uses: actions/checkout@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: 10
-      - id: yarn-cache
+      - name: Set Yarn cache directory
+        id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - name: Get Yarn cache
+        uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - uses: ianwalter/puppeteer@v2.0.0
+      - name: Install dependencies
+        uses: ianwalter/puppeteer@v2.0.0
         with:
           args: yarn
-      - uses: ianwalter/puppeteer@v2.0.0
+      - name: Run perf tests
+        uses: ianwalter/puppeteer@v2.0.0
         with:
           args: yarn perf:memory
-      - uses: actions/upload-artifact@v1
+      - name: Save heap snapshot
+        uses: actions/upload-artifact@v1
         with:
           name: perf.heapsnapshot
           path: perf/dist/result.heapsnapshot

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,6 +24,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Get node_modules cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-
       - name: Install dependencies
         run: yarn install
         env:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,9 +6,12 @@ on:
 jobs:
   test:
     name: Create a heap snapshot from perf tests
-    runs-on: circleci/node:10-browsers
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -20,6 +23,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install
       - run: yarn perf:memory
+        uses: docker://circleci/node:10-browsers
         env:
           CI: true
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/screener.yml
+++ b/.github/workflows/screener.yml
@@ -25,6 +25,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Get node_modules cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-
       - name: Install dependencies
         run: yarn install
         env:

--- a/.github/workflows/screener.yml
+++ b/.github/workflows/screener.yml
@@ -15,16 +15,20 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 10
-      - name: Get yarn cache
+      - name: Set Yarn cache directory
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - name: Get Yarn cache
+        uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn install
+      - name: Install dependencies
+        run: yarn install
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - run: yarn test:visual
         env:
           CI: true

--- a/build/gulp/tasks/perf.ts
+++ b/build/gulp/tasks/perf.ts
@@ -118,7 +118,13 @@ task('perf:build', cb => {
 })
 
 task('perf:run-memory', async () => {
-  const browser = await puppeteer.launch(safeLaunchOptions())
+  const browser = await puppeteer.launch(
+    safeLaunchOptions(
+      process.env.CI && {
+        executablePath: 'google-chrome-unstable',
+      },
+    ),
+  )
   const context = await browser.createIncognitoBrowserContext()
   const page = await context.newPage()
 

--- a/build/puppeteer.config.ts
+++ b/build/puppeteer.config.ts
@@ -2,6 +2,7 @@ import { LaunchOptions } from 'puppeteer'
 
 /** Common set of args to be passed to Chromium. */
 const chromiumArgs: LaunchOptions['args'] = [
+  '--js-flags=--expose-gc', // exposes "gc()" function
   // Workaround for newPage hang in CircleCI: https://github.com/GoogleChrome/puppeteer/issues/1409#issuecomment-453845568
   process.env.CI && '--single-process',
 ].filter(Boolean)

--- a/build/puppeteer.config.ts
+++ b/build/puppeteer.config.ts
@@ -5,6 +5,7 @@ const chromiumArgs: LaunchOptions['args'] = [
   '--js-flags=--expose-gc', // exposes "gc()" function
   // Workaround for newPage hang in CircleCI: https://github.com/GoogleChrome/puppeteer/issues/1409#issuecomment-453845568
   process.env.CI && '--single-process',
+  process.env.CI && '--no-sandbox',
 ].filter(Boolean)
 
 export const safeLaunchOptions = (launchOptions?: LaunchOptions) => {

--- a/build/webpack.config.perf.ts
+++ b/build/webpack.config.perf.ts
@@ -10,7 +10,7 @@ const { paths } = config
 const webpackConfig: any = {
   name: 'client',
   target: 'web',
-  mode: 'development',
+  mode: argv.memory ? 'production' : 'development',
   entry: {
     app: paths.perfSrc('index'),
   },
@@ -20,7 +20,7 @@ const webpackConfig: any = {
     pathinfo: true,
     publicPath: config.compiler_public_path,
   },
-  devtool: config.compiler_devtool,
+  ...(!argv.memory && { devtool: config.compiler_devtool }),
   node: {
     fs: 'empty',
     module: 'empty',
@@ -68,6 +68,8 @@ const webpackConfig: any = {
   },
   optimization: {
     nodeEnv: !!argv.debug ? 'development' : 'production',
+    // We don't want to run Terser on perf tests
+    minimize: false,
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "now-build": "cross-env NOW=true yarn predeploy:docs",
     "perf": "cross-env PERF=true gulp perf --times=100",
     "perf:debug": "cross-env PERF=true gulp perf:debug --debug",
+    "perf:memory": "cross-env PERF=true gulp perf:memory --memory",
     "prettier": "prettier --list-different \"**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx}\"",
     "precommit": "lint-staged",

--- a/packages/react/src/themes/createTheme.ts
+++ b/packages/react/src/themes/createTheme.ts
@@ -1,6 +1,7 @@
 import { ThemeInput, ThemePrepared } from './types'
+import withMemoryId from '../utils/withMemoryId'
 import withDebugId from '../utils/withDebugId'
 
 export const createTheme = <T = ThemeInput | ThemePrepared>(themeInput: T, debugId): T => {
-  return withDebugId(themeInput, debugId)
+  return withMemoryId(withDebugId(themeInput, debugId))
 }

--- a/packages/react/src/utils/felaRenderer.tsx
+++ b/packages/react/src/utils/felaRenderer.tsx
@@ -11,6 +11,7 @@ import felaExpandCssShorthandsPlugin from './felaExpandCssShorthandsPlugin'
 import felaFocusVisibleEnhancer from './felaFocusVisibleEnhancer'
 import felaInvokeKeyframesPlugin from './felaInvokeKeyframesPlugin'
 import felaSanitizeCss from './felaSanitizeCssPlugin'
+import withMemoryId from './withMemoryId'
 
 let felaDevMode = false
 
@@ -77,6 +78,6 @@ const rendererConfig = {
   ],
 }
 
-export const createRenderer = (): Renderer => createFelaRenderer(rendererConfig)
+export const createRenderer = (): Renderer => withMemoryId(createFelaRenderer(rendererConfig))
 
 export const felaRenderer = createRenderer()

--- a/packages/react/src/utils/mergeProviderContexts.ts
+++ b/packages/react/src/utils/mergeProviderContexts.ts
@@ -2,6 +2,7 @@ import { ProviderContextPrepared, ProviderContextInput } from '../types'
 import { Renderer } from '../themes/types'
 import { createRenderer, felaRenderer } from './felaRenderer'
 import mergeThemes from './mergeThemes'
+import withMemoryId from './withMemoryId'
 
 const registeredRenderers = new WeakMap<Document, Renderer>()
 
@@ -55,7 +56,7 @@ const mergeProviderContexts = (
     disableAnimations: false,
     target: document, // eslint-disable-line no-undef
     telemetry: undefined,
-    _internal_resolvedComponentVariables: {},
+    _internal_resolvedComponentVariables: withMemoryId({}),
     renderer: undefined,
   }
 

--- a/packages/react/src/utils/withMemoryId.ts
+++ b/packages/react/src/utils/withMemoryId.ts
@@ -1,0 +1,11 @@
+/* tslint:disable */
+
+function withMemoryId<T>(target: T): T {
+  let Prototype: Function // eslint-disable-line
+  eval(`Prototype = function FluentMemoryRecord () {}`) // eslint-disable-line
+
+  // @ts-ignore
+  return Object.setPrototypeOf(target, new Prototype())
+}
+
+export default withMemoryId

--- a/yarn.lock
+++ b/yarn.lock
@@ -6899,6 +6899,11 @@ chownr@^1.0.1, chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
+chrome-heap-snapshot-parser@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/chrome-heap-snapshot-parser/-/chrome-heap-snapshot-parser-1.0.0-rc.2.tgz#0d61936875055f64eaa18bb1fcb1fc75274396d2"
+  integrity sha512-sir6w6qsqCgJk6Y8ZmwhZ/9eoRntwbFxH7FYi5AcrM60hh2fDKSymqOuZ+J7OQI68v/Z9XYmG1dKjPBxx3i2VQ==
+
 chrome-trace-event@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6899,11 +6899,6 @@ chownr@^1.0.1, chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-chrome-heap-snapshot-parser@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/chrome-heap-snapshot-parser/-/chrome-heap-snapshot-parser-1.0.0-rc.2.tgz#0d61936875055f64eaa18bb1fcb1fc75274396d2"
-  integrity sha512-sir6w6qsqCgJk6Y8ZmwhZ/9eoRntwbFxH7FYi5AcrM60hh2fDKSymqOuZ+J7OQI68v/Z9XYmG1dKjPBxx3i2VQ==
-
 chrome-trace-event@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"


### PR DESCRIPTION
## Prototype

The general idea behind is try to make objects in memory discoverable so we will be able to automate their capture and measurements.

I don't see any other options than take heap snapshots:
- [`Performance.memory`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory) is vendor API and there is no useful information 😭 
- Puppeteer provides [queryObjects()](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#executioncontextqueryobjectsprototypehandle) API, but there is nothing that allows to count memory 😭 _x 2_

### Proposal

#### Mark places that create heavy objects

Used [`Object.setPrototypeOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) so they can be easy discovered in snapshots.

![image](https://user-images.githubusercontent.com/14183168/70708331-86e7ae00-1cda-11ea-95a9-ff4d6f34d759.png)

#### Automate recording of heap snaphots

A newly created workflow (see `perf.yml`) runs performance tests, calls GC and captures a snapshot. Also it stores created snapshot as an artifact.

![image](https://user-images.githubusercontent.com/14183168/70708476-e219a080-1cda-11ea-8df3-021c05377f4c.png)

#### Possible next steps ⏭ 

`.heapsnapshot` is a JSON file and can be parsed, so we can use it in automation. I checked [`chrome-heap-snapshot-parser`](https://github.com/julianburr/chrome-heap-snapshot-parser), it needs some polishes but can be used as a source of ideas.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2166)