### PR TITLE
chore(Perf): Rename dropdown perf example to align with the rest

### DIFF
--- a/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
+++ b/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
@@ -8,8 +8,10 @@ const inputItems = _.times(300, (i: number) => ({
   header: `header: ${i}`,
 }))
 
-const DropdownPerf = () => (
+const DropdownManyItemsPerf = () => (
   <Dropdown defaultOpen items={inputItems} placeholder="Select your hero" />
 )
 
-export default DropdownPerf
+DropdownManyItemsPerf.filename = 'DropdownManyItemsPerf.perf.tsx'
+
+export default DropdownManyItemsPerf

--- a/docs/src/examples/components/Dropdown/Performance/index.tsx
+++ b/docs/src/examples/components/Dropdown/Performance/index.tsx
@@ -8,7 +8,7 @@ const Performance = () => (
     <ComponentPerfExample
       title="Default"
       description="A default test."
-      examplePath="components/Dropdown/Performance/Dropdown.perf"
+      examplePath="components/Dropdown/Performance/DropdownManyItems.perf"
     />
   </NonPublicSection>
 )


### PR DESCRIPTION
Rename dropdown perf example which was missed in #2164 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2171)