### PR TITLE
chore(Perf): Skip undef values in perf charts

### DIFF
--- a/docs/src/components/ComponentDoc/PerfChart/PerfChart.tsx
+++ b/docs/src/components/ComponentDoc/PerfChart/PerfChart.tsx
@@ -51,15 +51,18 @@ const PerfChart: React.FC<PerfChartProps> = ({ perfData, withExtremes }) => {
       <LineSeries
         {...props}
         key={chartName + key}
-        data={perfData.map(sample => ({
-          x: sampleToXAxis(sample),
-          y: _.get(sample, `performance.${chartName}.${data}`, 0),
-        }))}
-        {...(index === 0 && {
-          onNearestX: (d: { x: number }) => {
-            setNearestX(d.x)
-          },
-        })}
+        data={_.filter(
+          perfData.map(sample => {
+            const y = _.get(sample, `performance.${chartName}.${data}`)
+            if (_.isUndefined(y)) {
+              return undefined
+            }
+            return {
+              x: sampleToXAxis(sample),
+              y,
+            }
+          }),
+        )}
       />
     ))
 
@@ -148,6 +151,18 @@ const PerfChart: React.FC<PerfChartProps> = ({ perfData, withExtremes }) => {
         stroke: tpiColor,
         strokeWidth: '2px',
       })}
+
+      <LineSeries
+        opacity={0}
+        key="vertical-axis-hack"
+        data={perfData.map(sample => ({
+          x: sampleToXAxis(sample),
+          y: 0,
+        }))}
+        onNearestX={(d: { x: number }) => {
+          setNearestX(d.x)
+        }}
+      />
 
       {nearestX && (
         <PerfChartTooltip


### PR DESCRIPTION
Skip undefined values in perf charts. Previously those were charted as 0 which might be confusing.

Also now there is only one `onNearestX` handler registered as expected.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluent-ui-react/pull/2177)