### PR TITLE
docs: fix Fluent UI casing

### DIFF
--- a/docs/src/views/Performance.tsx
+++ b/docs/src/views/Performance.tsx
@@ -7,7 +7,7 @@ import ExampleSnippet from '../components/ExampleSnippet'
 export default () => (
   <DocPage title="Performance">
     <p>
-      In general, to make your application that is using FluentUi performant, it is important to
+      In general, to make your application that is using Fluent UI performant, it is important to
       follow all{' '}
       {link(
         'React performance best practices',

--- a/packages/react-theming/readme.org
+++ b/packages/react-theming/readme.org
@@ -26,7 +26,7 @@ enough flexibility.
 - When overriding major details of an existing component. (Explained
   later in "Overriding (tokens|slots) with a new component".)
 ** What's in a theme?
-A FluentUi theme contains several major sections. At at high level, it
+A Fluent UI theme contains several major sections. At at high level, it
 contains detail about colors, types, effects, spacing, and animation.
 Furthermore, a theme has the ability to override major details about
 each and every component's look and feel as well as behavior.
@@ -36,7 +36,7 @@ TODO: document theme
 ** Basic usage
 Components created with ~compose~ should act and feel like ordinary,
 run-of-the-mill components. For instance, using a ~Button~ provided by
-FluentUi is nearly the same as a native ~button~:
+Fluent UI is nearly the same as a native ~button~:
 #+begin_src
 <Button onClick={() => alert('Hello, World!')}>Hi</Button>
 #+end_src


### PR DESCRIPTION
It seems we had a couple straggling lower case "i" spellings.  This PR isn't relevant to end users so I'm not adding a CHANGELOG entry.