### PR TITLE
fix(Popup): fix click outside when trigger is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix `toggle` changing width during animation in Teams theme @mnajdova ([#2189](https://github.com/microsoft/fluent-ui-react/pull/2189))
 - Fix `Popup` positioning in multiple cases @layershifter ([#2187](https://github.com/microsoft/fluent-ui-react/pull/2187))
+- Fix click outside in `Popup` when `trigger` is not defined @layershifter ([#2202](https://github.com/microsoft/fluent-ui-react/pull/2202))
 
 <!--------------------------------[ v0.42.0 ]------------------------------- -->
 ## [v0.42.0](https://github.com/microsoft/fluent-ui-react/tree/v0.42.0) (2019-12-12)

--- a/e2e/tests/popupWithoutTrigger-example.tsx
+++ b/e2e/tests/popupWithoutTrigger-example.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { Popup, Button } from '@fluentui/react'
+
+export const selectors = {
+  popupContent: Popup.slotClassNames.content,
+  button: Button.className,
+}
+
+const PopupWithoutTriggerExample = () => {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <Popup
+        open={open}
+        content={{ content: 'Test Content' }}
+        onOpenChange={(e, data) => setOpen(data.open)}
+      />
+      <Button content="Test button" onClick={() => setOpen(!open)} />
+    </>
+  )
+}
+
+export default PopupWithoutTriggerExample

--- a/e2e/tests/popupWithoutTrigger-example.tsx
+++ b/e2e/tests/popupWithoutTrigger-example.tsx
@@ -13,8 +13,14 @@ const PopupWithoutTriggerExample = () => {
     <>
       <Popup
         open={open}
-        content={{ content: 'Test Content' }}
-        onOpenChange={(e, data) => setOpen(data.open)}
+        content={{
+          content: 'Test Content',
+          styles: { margin: '20px' }, // puppeteer performs a click on 0x0 in boxes, so button and popup content should not collide
+        }}
+        onOpenChange={(e, data) => {
+          e.stopPropagation()
+          setOpen(data.open)
+        }}
       />
       <Button content="Test button" onClick={() => setOpen(!open)} />
     </>

--- a/e2e/tests/popupWithoutTrigger-test.ts
+++ b/e2e/tests/popupWithoutTrigger-test.ts
@@ -1,0 +1,23 @@
+import { selectors } from './popupWithoutTrigger-example'
+
+const button = `.${selectors.button}`
+const popupContent = `.${selectors.popupContent}`
+
+describe('Popup without `trigger`', () => {
+  beforeEach(async () => {
+    await e2e.gotoTestCase(__filename, button)
+  })
+
+  it('Popup can be opened on button click', async () => {
+    await e2e.clickOn(button)
+    expect(await e2e.exists(popupContent)).toBe(true)
+  })
+
+  it('Popup can be closed on click outside', async () => {
+    await e2e.clickOn(button)
+    expect(await e2e.exists(popupContent)).toBe(true)
+
+    await e2e.clickOn('body')
+    expect(await e2e.exists(popupContent)).toBe(false)
+  })
+})

--- a/e2e/tests/popupWithoutTrigger-test.ts
+++ b/e2e/tests/popupWithoutTrigger-test.ts
@@ -13,11 +13,27 @@ describe('Popup without `trigger`', () => {
     expect(await e2e.exists(popupContent)).toBe(true)
   })
 
+  it('Popup can be closed on button click', async () => {
+    await e2e.clickOn(button)
+    expect(await e2e.exists(popupContent)).toBe(true)
+
+    await e2e.clickOn(button)
+    expect(await e2e.exists(popupContent)).toBe(false)
+  })
+
   it('Popup can be closed on click outside', async () => {
     await e2e.clickOn(button)
     expect(await e2e.exists(popupContent)).toBe(true)
 
     await e2e.clickOn('body')
     expect(await e2e.exists(popupContent)).toBe(false)
+  })
+
+  it('Popup stays open on click inside', async () => {
+    await e2e.clickOn(button)
+    expect(await e2e.exists(popupContent)).toBe(true)
+
+    await e2e.clickOn(popupContent)
+    expect(await e2e.exists(popupContent)).toBe(true)
   })
 })

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -296,11 +296,11 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
 
   isOutsidePopupElementAndOutsideTriggerElement(refs: NodeRef[], e) {
     const isOutsidePopupElement = this.isOutsidePopupElement(refs, e)
-    const isOutsideTriggerElement =
+    const isInsideTriggerElement =
       this.triggerRef.current &&
-      !doesNodeContainClick(this.triggerRef.current, e, this.context.target)
+      doesNodeContainClick(this.triggerRef.current, e, this.context.target)
 
-    return isOutsidePopupElement && isOutsideTriggerElement
+    return isOutsidePopupElement && !isInsideTriggerElement
   }
 
   isOutsidePopupElement(refs: NodeRef[], e) {
@@ -624,9 +624,10 @@ export default class Popup extends AutoControlledComponent<PopupProps, PopupStat
     const activeDocument = mountDocument || this.context.target
     const activeElement = activeDocument.activeElement
 
-    this.triggerFocusableDomElement = this.triggerRef.current.contains(activeElement)
-      ? activeElement
-      : this.triggerRef.current
+    this.triggerFocusableDomElement =
+      this.triggerRef.current && this.triggerRef.current.contains(activeElement)
+        ? activeElement
+        : this.triggerRef.current
   }
 
   updateContextPosition(nativeEvent: MouseEvent) {


### PR DESCRIPTION
This PR fixes a cases when clicks outside of `Popup` were not properly handled in controlled mode without `trigger` prop.