### PR TITLE
prototype(chat pane): accessibility fix attachment in chat

### DIFF
--- a/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -1,7 +1,6 @@
 import {
   Attachment,
   Popup,
-  Button,
   Menu,
   AvatarProps,
   ChatMessageProps,
@@ -124,22 +123,17 @@ function createMessageContentWithAttachments(content: string, messageId: string)
     }
   }
 
-  const actionPopup = (
-    <Popup
-      trapFocus
-      trigger={
-        <Button
-          aria-label="More attachment options"
-          iconOnly
-          circular
-          icon="ellipsis horizontal"
-          onClick={e => e.stopPropagation()}
-          onKeyDown={stopPropagationOnKeys([keyboardKey.Enter, keyboardKey.Spacebar])}
-        />
-      }
-      content={{ content: contextMenu }}
-    />
-  )
+  const action = {
+    'aria-label': 'More attachment options',
+    iconOnly: true,
+    circular: true,
+    icon: 'ellipsis horizontal',
+    onClick: e => e.stopPropagation(),
+    onKeyDown: stopPropagationOnKeys([keyboardKey.Enter, keyboardKey.Spacebar]),
+    children: (Component, props) => (
+      <Popup content={{ content: contextMenu }} trapFocus trigger={<Component {...props} />} />
+    ),
+  }
 
   return (
     <>
@@ -153,7 +147,7 @@ function createMessageContentWithAttachments(content: string, messageId: string)
             icon="file word outline"
             aria-label={`File attachment ${fileName}. Press tab for more options Press Enter to open the file`}
             header={fileName}
-            action={actionPopup}
+            action={action}
             data-is-focusable={true}
             styles={{
               ...(index === 1 ? { marginLeft: '15px' } : {}),


### PR DESCRIPTION
There was the bug in attachment for chat prototype, that we had "button" trigger element for popup in another "button" element.

Issue was that "action" slot was not replaced by trigger button but was inserted into slot. And it cause "button" in another "button". 

Issue coming from the change done in the PR:
https://github.com/microsoft/fluent-ui-react/pull/1513

