### PR TITLE
RFC: drop `content` prop

### DIFF
--- a/packages/react/src/components/Header/Header.tsx
+++ b/packages/react/src/components/Header/Header.tsx
@@ -8,8 +8,6 @@ import {
   createShorthandFactory,
   UIComponent,
   UIComponentProps,
-  ChildrenComponentProps,
-  ContentComponentProps,
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
@@ -24,11 +22,7 @@ export interface HeaderSlotClassNames {
   description: string
 }
 
-export interface HeaderProps
-  extends UIComponentProps,
-    ChildrenComponentProps,
-    ContentComponentProps,
-    ColorComponentProps {
+export interface HeaderProps extends UIComponentProps, ColorComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
    */
@@ -66,22 +60,21 @@ class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
   static Description = HeaderDescription
 
   renderComponent({ accessibility, ElementType, classes, variables: v, unhandledProps }) {
-    const { children, description, content } = this.props
+    const { children, description } = this.props
 
     const hasChildren = childrenExist(children)
-    const contentElement = childrenExist(children) ? children : content
 
     return (
       <ElementType
         {...rtlTextContainer.getAttributes({
-          forElements: [children, content],
+          forElements: [children],
           condition: !description,
         })}
         {...accessibility.attributes.root}
         {...unhandledProps}
         className={classes.root}
       >
-        {rtlTextContainer.createFor({ element: contentElement, condition: !!description })}
+        {rtlTextContainer.createFor({ element: children, condition: !!description })}
         {!hasChildren &&
           HeaderDescription.create(description, {
             defaultProps: () => ({
@@ -96,7 +89,7 @@ class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
   }
 }
 
-Header.create = createShorthandFactory({ Component: Header, mappedProp: 'content' })
+Header.create = createShorthandFactory({ Component: Header, mappedProp: 'children' })
 
 /**
  * A Header organises the content by declaring a content's topic.

--- a/packages/react/src/components/Header/HeaderDescription.tsx
+++ b/packages/react/src/components/Header/HeaderDescription.tsx
@@ -2,12 +2,9 @@ import { Accessibility } from '@fluentui/accessibility'
 import * as React from 'react'
 
 import {
-  childrenExist,
   createShorthandFactory,
   UIComponent,
   UIComponentProps,
-  ChildrenComponentProps,
-  ContentComponentProps,
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
@@ -16,11 +13,7 @@ import {
 
 import { WithAsProp, withSafeTypeForAs } from '../../types'
 
-export interface HeaderDescriptionProps
-  extends UIComponentProps,
-    ChildrenComponentProps,
-    ContentComponentProps,
-    ColorComponentProps {
+export interface HeaderDescriptionProps extends UIComponentProps, ColorComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
    */
@@ -43,15 +36,16 @@ class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, 
   }
 
   renderComponent({ accessibility, ElementType, classes, unhandledProps }) {
-    const { children, content } = this.props
+    const { children } = this.props
+
     return (
       <ElementType
-        {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
+        {...rtlTextContainer.getAttributes({ forElements: [children] })}
         {...accessibility.attributes.root}
         {...unhandledProps}
         className={classes.root}
       >
-        {childrenExist(children) ? children : content}
+        {children}
       </ElementType>
     )
   }
@@ -59,7 +53,7 @@ class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, 
 
 HeaderDescription.create = createShorthandFactory({
   Component: HeaderDescription,
-  mappedProp: 'content',
+  mappedProp: 'children',
 })
 
 /**

--- a/packages/react/src/utils/commonPropTypes.ts
+++ b/packages/react/src/utils/commonPropTypes.ts
@@ -20,7 +20,6 @@ export const createCommon = (config: CreateCommonConfig = {}) => {
     children = 'node',
     className = true,
     color = false,
-    content = 'node',
     styled = true,
   } = config
   return {
@@ -41,10 +40,6 @@ export const createCommon = (config: CreateCommonConfig = {}) => {
     }),
     ...(color && {
       color: PropTypes.string,
-    }),
-    ...(content && {
-      content:
-        content === 'shorthand' ? customPropTypes.itemShorthand : customPropTypes.nodeContent,
     }),
     ...(styled && {
       styles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),


### PR DESCRIPTION
# RFC: Remove `content` as part of factories/slots

API with having `content` & `children` comes from SUIR and the goal was to create a separation between concepts: use only Children or Shorthand API 💡 

![image](https://user-images.githubusercontent.com/14183168/71726329-0dedf900-2e37-11ea-94d9-0d384fb75ce6.png)

```tsx
<Button>Foo</Button> // shows Foo
<Button icon="book">Foo</Button> // do not show icon 💣 
<Button content="Foo" /> // style are different, but it's another issue
```

In the reality it creates more confusion than something useful, i.e. not everyone on consumer side understand how it works properly.

***

Sometimes `content` is a slot, sometimes it is a `ReactNode`, so you will never know what is correct way:

```tsx
<Popup content={{ content: 'Foo' }} /> // works 👍 
<Header content={{ content: 'Foo' }} /> // throws 💣 
```

***

Another one is that of our components do not implement that idea properly, i.e. `content` & `children` will be rendered. During my API experiments and prototyping I found that `content` is useless at 🤔 

```tsx
<Popup content={{ content: 'Foo' }} /> // what is difference between `content` & `children`?
<Popup content={{ children: 'Foo' }} /> // what is preferred?
```

The best way to avoid confusion is to drop it for cases like `Header` and keep it for Popup. In this case:
- 👍 no more confusion, if `content` exists is always slot
- 👍 no more `content={{ content }}`, it will be `content={{ children }}` which is more clear