### PR TITLE
chore(Perf): Add renderComponent times to perf charts

### DIFF
--- a/build/gulp/tasks/perf.ts
+++ b/build/gulp/tasks/perf.ts
@@ -77,35 +77,32 @@ const sumByExample = (measures: ProfilerMeasureCycle[]): PerExamplePerfMeasures 
 
   return _.mapValues(perExampleMeasures, (profilerMeasures: ProfilerMeasure[]) => ({
     actualTime: reduceMeasures(profilerMeasures, 'actualTime'),
+    renderComponentTime: reduceMeasures(profilerMeasures, 'renderComponentTime'),
+    componentCount: reduceMeasures(profilerMeasures, 'componentCount'),
   }))
 }
 
-type NumberPropertyNames<T> = { [K in keyof T]: T[K] extends number ? K : never }[keyof T]
+const createMarkdownTable = (perExamplePerfMeasures: PerExamplePerfMeasures) => {
+  const fieldsMapping = {
+    min: 'actualTime.min',
+    avg: 'actualTime.avg',
+    median: 'actualTime.median',
+    max: 'actualTime.max',
+    'renderComponent.min': 'renderComponentTime.min',
+    'renderComponent.avg': 'renderComponentTime.avg',
+    'renderComponent.median': 'renderComponentTime.median',
+    'renderComponent.max': 'renderComponentTime.max',
+    components: 'componentCount.median',
+  }
 
-const createMarkdownTable = (
-  perExamplePerfMeasures: PerExamplePerfMeasures,
-  metricName: MeasuredValues = 'actualTime',
-  fields: NumberPropertyNames<ReducedMeasures>[] = ['min', 'avg', 'median', 'max'],
-) => {
-  const exampleMeasures = _.mapValues(
-    perExamplePerfMeasures,
-    exampleMeasure => exampleMeasure[metricName],
-  )
-
-  const fieldLabels: string[] = _.map(fields, _.startCase)
-  const fieldValues = _.mapValues(exampleMeasures, exampleMeasure =>
-    _.flatMap(fields, field => exampleMeasure[field]),
-  )
+  const fieldLabels = _.keys(fieldsMapping)
+  const fieldValues = _.map(perExamplePerfMeasures, (value, exampleName) => {
+    return [exampleName, ..._.map(_.values(fieldsMapping), measure => _.get(value, measure))]
+  })
 
   return markdownTable([
     ['Example', ...fieldLabels],
-    ..._.sortBy(
-      _.map(exampleMeasures, (exampleMeasure, exampleName) => [
-        exampleName,
-        ...fieldValues[exampleName],
-      ]),
-      row => -row[fields.indexOf('median')],
-    ),
+    ..._.sortBy(fieldValues, row => -row[fieldLabels.indexOf('median') + 1]), // +1 is for exampleName
   ])
 }
 
@@ -155,6 +152,12 @@ task('perf:run', async () => {
   log(colors.green('Results are written to "%s"'), resultsFile)
   console.log('\n# Measures\n')
   console.log(createMarkdownTable(perExamplePerfMeasures))
+})
+
+task('perf:log', cb => {
+  const perExamplePerfMeasures = JSON.parse(fs.readFileSync(paths.perfDist('result.json'), 'utf-8'))
+  console.log(createMarkdownTable(perExamplePerfMeasures))
+  cb()
 })
 
 task('perf:serve', cb => {

--- a/build/gulp/tasks/perf.ts
+++ b/build/gulp/tasks/perf.ts
@@ -154,12 +154,6 @@ task('perf:run', async () => {
   console.log(createMarkdownTable(perExamplePerfMeasures))
 })
 
-task('perf:log', cb => {
-  const perExamplePerfMeasures = JSON.parse(fs.readFileSync(paths.perfDist('result.json'), 'utf-8'))
-  console.log(createMarkdownTable(perExamplePerfMeasures))
-  cb()
-})
-
 task('perf:serve', cb => {
   server = express()
     .use(express.static(paths.perfDist()))

--- a/build/gulp/tasks/stats.ts
+++ b/build/gulp/tasks/stats.ts
@@ -139,6 +139,10 @@ function readSummaryPerfStats() {
     .mapKeys((value, key) => _.camelCase(key)) // mongodb does not allow dots in keys
     .mapValues(result => ({
       actualTime: _.omit(result.actualTime, 'values'),
+      renderComponentTime: {
+        ..._.omit(result.renderComponentTime, 'values'),
+        componentCount: result.componentCount.median,
+      },
     }))
     .value()
 }

--- a/perf/src/index.tsx
+++ b/perf/src/index.tsx
@@ -1,6 +1,6 @@
 import '@babel/polyfill'
 
-import { Provider, themes } from '@fluentui/react'
+import { Provider, Telemetry, themes } from '@fluentui/react'
 import * as _ from 'lodash'
 import * as minimatch from 'minimatch'
 import * as React from 'react'
@@ -32,9 +32,10 @@ const renderCycle = async (
   exampleIndex: number,
 ): Promise<ProfilerMeasure> => {
   let profilerMeasure: ProfilerMeasure
+  const telemetryRef: React.Ref<Telemetry> = React.createRef()
 
   await asyncRender(
-    <Provider theme={themes.teams}>
+    <Provider theme={themes.teams} telemetryRef={telemetryRef}>
       <Profiler
         id={exampleName}
         onRender={(
@@ -44,12 +45,24 @@ const renderCycle = async (
           startTime: number,
           commitTime: number,
         ) => {
+          const renderComponentTelemetry = _.reduce(
+            _.values(telemetryRef.current.performance),
+            (acc, next) => {
+              return {
+                componentCount: acc.componentCount + next.count,
+                renderComponentTime: acc.renderComponentTime + next.msTotal,
+              }
+            },
+            { componentCount: 0, renderComponentTime: 0 },
+          )
+
           profilerMeasure = {
             actualTime,
             exampleIndex,
             phase,
             commitTime,
             startTime,
+            ...renderComponentTelemetry,
           }
         }}
       >

--- a/perf/types.ts
+++ b/perf/types.ts
@@ -4,13 +4,16 @@ declare global {
   }
 }
 
-export type MeasuredValues = 'actualTime'
+export type MeasuredValues = 'actualTime' | 'renderComponentTime' | 'componentCount'
 
 export type ProfilerMeasure = { [key in MeasuredValues]: number } & {
   exampleIndex: number
   phase: string
   startTime: number
   commitTime: number
+
+  componentCount: number
+  renderComponentTime: number
 }
 
 export type ProfilerMeasureCycle = Record<string, ProfilerMeasure>


### PR DESCRIPTION
Rendering performance telemetry support was added in #2079.

This PR adds rendering performance numbers to performance tests.

`yarn:perf` outputs them:

| Example                    | min    | avg    | median | max    | renderComponent.min | renderComponent.avg | renderComponent.median | renderComponent.max | components |
| -------------------------- | ------ | ------ | ------ | ------ | ------------------- | ------------------- | ---------------------- | ------------------- | ---------- |
| DropdownManyItems.perf.tsx | 448.39 | 480.54 | 478.89 | 636.36 | 284.17              | 308.52              | 306.41                 | 405.62              | 1807       |
| DropdownMinimal.perf.tsx   | 5.4    | 15.78  | 6.45   | 34.65  | 3.33                | 9.92                | 4.14                   | 21                  | 6          |

`yarn stats:save` stores them to DB:
```json
...
"dropdownManyItemsPerfTsx": {
  "actualTime": {
    "avg": 480.54,
    "median": 478.89,
    "min": 448.39,
    "max": 636.36
  },
  "renderComponentTime": {
    "avg": 308.52,
    "median": 306.41,
    "min": 284.17,
    "max": 405.62,
    "componentCount": 1807
  }
},
...
```

**renderComponent times are not displayed in perf charts yet. Will be done in a separate PR.**