### PR TITLE
chore(tests): refactor Dropdown tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
     "@types/enzyme": "^3.9.3",
     "@types/gulp": "^4.0.6",
     "@types/lodash": "^4.14.118",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.1.1",
     "@types/enzyme": "^3.9.3",
     "@types/gulp": "^4.0.6",
     "@types/lodash": "^4.14.118",
@@ -91,6 +91,13 @@
     "typescript": "~3.7.2"
   },
   "workspaces": {
-    "packages": ["packages/*", "scripts", "build", "docs", "e2e", "perf"]
+    "packages": [
+      "packages/*",
+      "scripts",
+      "build",
+      "docs",
+      "e2e",
+      "perf"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.1.1",
-    "@types/enzyme": "^3.9.3",
+    "@types/enzyme": "^3.10.5",
     "@types/gulp": "^4.0.6",
     "@types/lodash": "^4.14.118",
     "@types/node": "^10.3.2",

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -11,4 +11,5 @@ module.exports = {
     '^src/(.*)$': `<rootDir>/src/$1`,
     'test/(.*)$': `<rootDir>/test/$1`,
   },
+  setupFilesAfterEnv: [...commonConfig.setupFilesAfterEnv, './test/setup.ts'],
 }

--- a/packages/react/test/setup.ts
+++ b/packages/react/test/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect'
+import '@testing-library/jest-dom'

--- a/packages/react/test/setup.ts
+++ b/packages/react/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -25,25 +25,25 @@ describe('Dropdown', () => {
 
   describe('clearable', () => {
     it('value is cleared at Icon click', () => {
-      const { triggerButton, wrapper } = renderDropdown({
+      const { triggerButton, clickOnClearIndicator } = renderDropdown({
         clearable: true,
         defaultValue: items[0],
       })
 
-      findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.clearIndicator}`).simulate('click')
+      clickOnClearIndicator()
 
       expect(triggerButton).toHaveTextContent('')
     })
 
     it('calls onChange on Icon click with an `empty` value', () => {
       const onChange = jest.fn()
-      const { wrapper } = renderDropdown({
+      const { clickOnClearIndicator } = renderDropdown({
         onChange,
         defaultValue: items[0],
         clearable: true,
       })
 
-      findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.clearIndicator}`).simulate('click')
+      clickOnClearIndicator()
 
       expect(onChange).toBeCalledTimes(1)
       expect(onChange).toHaveBeenCalledWith(

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -25,14 +25,14 @@ describe('Dropdown', () => {
 
   describe('clearable', () => {
     it('value is cleared at Icon click', () => {
-      const { triggerButton, clickOnClearIndicator } = renderDropdown({
+      const { triggerButtonNode, clickOnClearIndicator } = renderDropdown({
         clearable: true,
         defaultValue: items[0],
       })
 
       clickOnClearIndicator()
 
-      expect(triggerButton).toHaveTextContent('')
+      expect(triggerButtonNode).toHaveTextContent('')
     })
 
     it('calls onChange on Icon click with an `empty` value', () => {
@@ -61,41 +61,41 @@ describe('Dropdown', () => {
 
   describe('open', () => {
     it('it takes the value of the controlled prop', () => {
-      const { getItems, clickOnItemAtIndex } = renderDropdown({ open: true })
+      const { getItemNodes, clickOnItemAtIndex } = renderDropdown({ open: true })
 
-      expect(getItems()).toHaveLength(items.length)
+      expect(getItemNodes()).toHaveLength(items.length)
 
       clickOnItemAtIndex(0)
 
-      expect(getItems()).toHaveLength(items.length)
+      expect(getItemNodes()).toHaveLength(items.length)
     })
 
     it('it takes the value of the default prop but can be changed', () => {
-      const { getItems, clickOnItemAtIndex } = renderDropdown({ defaultOpen: true })
+      const { getItemNodes, clickOnItemAtIndex } = renderDropdown({ defaultOpen: true })
 
-      expect(getItems()).toHaveLength(items.length)
+      expect(getItemNodes()).toHaveLength(items.length)
 
       clickOnItemAtIndex(0)
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is "true" when opened by trigger button click', () => {
-      const { getItems, clickOnTriggerButton } = renderDropdown()
+      const { getItemNodes, clickOnTriggerButton } = renderDropdown()
 
       clickOnTriggerButton()
 
-      expect(getItems()).toHaveLength(items.length)
+      expect(getItemNodes()).toHaveLength(items.length)
     })
 
     it('is "false" when closed by trigger button click', () => {
-      const { clickOnTriggerButton, getItems } = renderDropdown({
+      const { clickOnTriggerButton, getItemNodes } = renderDropdown({
         defaultOpen: true,
       })
 
       clickOnTriggerButton()
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('calls onOpenChange with a value that represents the open state', () => {
@@ -126,93 +126,96 @@ describe('Dropdown', () => {
     })
 
     it('is "true" when opened by toggle indicator click', () => {
-      const { clickOnToggleIndicator, getItems } = renderDropdown()
+      const { clickOnToggleIndicator, getItemNodes } = renderDropdown()
 
       clickOnToggleIndicator()
 
-      expect(getItems()).toHaveLength(items.length)
+      expect(getItemNodes()).toHaveLength(items.length)
     })
 
     it('is "false" when closed by toggle indicator click', () => {
-      const { clickOnToggleIndicator, getItems } = renderDropdown({
+      const { clickOnToggleIndicator, getItemNodes } = renderDropdown({
         defaultOpen: true,
       })
 
       clickOnToggleIndicator()
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is "false" when closed by hitting Escape in search input', () => {
-      const { keyDownOnSearchInput, getItems } = renderDropdown({
+      const { keyDownOnSearchInput, getItemNodes } = renderDropdown({
         search: true,
         defaultOpen: true,
       })
 
       keyDownOnSearchInput('Escape')
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is "false" when closed by hitting Escape in items list', () => {
-      const { keyDownOnItemsList, getItems } = renderDropdown({ defaultOpen: true })
+      const { keyDownOnItemsList, getItemNodes } = renderDropdown({ defaultOpen: true })
 
       expect(items).toHaveLength(items.length)
 
       keyDownOnItemsList('Escape')
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is "false" when an item has been selected', () => {
-      const { clickOnItemAtIndex, getItems } = renderDropdown({ defaultOpen: true })
+      const { clickOnItemAtIndex, getItemNodes } = renderDropdown({ defaultOpen: true })
 
       clickOnItemAtIndex(0)
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('when set to "true" by trigger button click will move focus to the items list', () => {
-      const { clickOnTriggerButton, itemsList } = renderDropdown()
+      const { clickOnTriggerButton, itemsListNode } = renderDropdown()
 
       clickOnTriggerButton()
 
-      expect(document.activeElement).toEqual(itemsList)
+      expect(document.activeElement).toEqual(itemsListNode)
     })
 
     it('is "false" when blurred by Tab on items list', () => {
-      const { getItems, keyDownOnItemsList } = renderDropdown({ defaultOpen: true })
+      const { getItemNodes, keyDownOnItemsList } = renderDropdown({ defaultOpen: true })
 
       keyDownOnItemsList('Tab')
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is "false" when blurred by Shift+Tab on items list', () => {
-      const { getItems, keyDownOnItemsList } = renderDropdown({ defaultOpen: true })
+      const { getItemNodes, keyDownOnItemsList } = renderDropdown({ defaultOpen: true })
 
       keyDownOnItemsList('Tab', { shiftKey: true })
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
-    it('is "false" when blurred by Tab on searchInput', () => {
-      const { getItems, keyDownOnSearchInput } = renderDropdown({
+    it('is "false" when blurred by Tab on search input', () => {
+      const { getItemNodes, keyDownOnSearchInput } = renderDropdown({
         defaultOpen: true,
         search: true,
       })
 
       keyDownOnSearchInput('Tab')
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is "false" when blurred by Shift+Tab on items list', () => {
-      const { getItems, keyDownOnSearchInput } = renderDropdown({ defaultOpen: true, search: true })
+      const { getItemNodes, keyDownOnSearchInput } = renderDropdown({
+        defaultOpen: true,
+        search: true,
+      })
 
       keyDownOnSearchInput('Tab', { shiftKey: true })
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
   })
 
@@ -222,38 +225,38 @@ describe('Dropdown', () => {
     })
 
     it('is null when opened by click', () => {
-      const { clickOnTriggerButton, itemsList } = renderDropdown()
+      const { clickOnTriggerButton, itemsListNode } = renderDropdown()
 
       clickOnTriggerButton()
 
-      expect(itemsList).not.toHaveAttribute('aria-activedescendant')
+      expect(itemsListNode).not.toHaveAttribute('aria-activedescendant')
     })
 
     it('is null when opened by toggle indicator click', () => {
-      const { clickOnToggleIndicator, itemsList } = renderDropdown()
+      const { clickOnToggleIndicator, itemsListNode } = renderDropdown()
 
       clickOnToggleIndicator()
 
-      expect(itemsList).not.toHaveAttribute('aria-activedescendant')
+      expect(itemsListNode).not.toHaveAttribute('aria-activedescendant')
     })
 
     it('is first item index when opened by arrow down key', () => {
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown()
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown()
 
       keyDownOnTriggerButton('ArrowDown')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
     })
 
     it('is last item index when opened by arrow up key', () => {
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown()
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown()
 
       keyDownOnTriggerButton('ArrowUp')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(items.length - 1)),
       )
@@ -261,13 +264,13 @@ describe('Dropdown', () => {
 
     it('has the provided prop value when opened by click', () => {
       const highlightedIndex = 2
-      const { clickOnTriggerButton, itemsList } = renderDropdown({
+      const { clickOnTriggerButton, itemsListNode } = renderDropdown({
         highlightedIndex,
       })
 
       clickOnTriggerButton()
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(highlightedIndex)),
       )
@@ -275,13 +278,13 @@ describe('Dropdown', () => {
 
     it('has the provided prop value when opened by arrow down key', () => {
       const highlightedIndex = 1
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown({
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown({
         highlightedIndex,
       })
 
       keyDownOnTriggerButton('ArrowDown')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(highlightedIndex)),
       )
@@ -289,13 +292,13 @@ describe('Dropdown', () => {
 
     it('has the provided prop value when opened by arrow up key', () => {
       const highlightedIndex = 1
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown({
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown({
         highlightedIndex,
       })
 
       keyDownOnTriggerButton('ArrowUp')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(highlightedIndex)),
       )
@@ -303,13 +306,13 @@ describe('Dropdown', () => {
 
     it('is defaultHighlightedIndex prop value at first opening, then null', () => {
       const defaultHighlightedIndex = 2
-      const { clickOnTriggerButton, itemsList } = renderDropdown({
+      const { clickOnTriggerButton, itemsListNode } = renderDropdown({
         defaultHighlightedIndex,
       })
 
       clickOnTriggerButton()
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(defaultHighlightedIndex)),
       )
@@ -317,17 +320,17 @@ describe('Dropdown', () => {
       clickOnTriggerButton()
       clickOnTriggerButton()
 
-      expect(itemsList).not.toHaveAttribute('aria-activedescendant')
+      expect(itemsListNode).not.toHaveAttribute('aria-activedescendant')
     })
 
     it('is 0 on every open when highlightFirstItemOnOpen prop is provided', () => {
-      const { clickOnTriggerButton, itemsList } = renderDropdown({
+      const { clickOnTriggerButton, itemsListNode } = renderDropdown({
         highlightFirstItemOnOpen: true,
       })
 
       clickOnTriggerButton()
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
@@ -335,70 +338,70 @@ describe('Dropdown', () => {
       clickOnTriggerButton()
       clickOnTriggerButton()
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
     })
 
     it('is set to 0 on searchQuery change and when highlightFirstItemOnOpen prop is provided', () => {
-      const { changeSearchInput, keyDownOnSearchInput, searchInput } = renderDropdown({
+      const { changeSearchInput, keyDownOnSearchInput, searchInputNode } = renderDropdown({
         highlightFirstItemOnOpen: true,
         search: true,
       })
 
       changeSearchInput('i')
 
-      expect(searchInput).toHaveAttribute(
+      expect(searchInputNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
 
       keyDownOnSearchInput('ArrowDown')
 
-      expect(searchInput).toHaveAttribute(
+      expect(searchInputNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(1)),
       )
 
       changeSearchInput('it')
 
-      expect(searchInput).toHaveAttribute(
+      expect(searchInputNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
     })
 
     it('is null on searchQuery change and when highlightFirstItemOnOpen prop is not provided', () => {
-      const { changeSearchInput, keyDownOnSearchInput, searchInput } = renderDropdown({
+      const { changeSearchInput, keyDownOnSearchInput, searchInputNode } = renderDropdown({
         search: true,
       })
 
       changeSearchInput('i')
 
-      expect(searchInput).not.toHaveAttribute('aria-activedescendant')
+      expect(searchInputNode).not.toHaveAttribute('aria-activedescendant')
 
       keyDownOnSearchInput('ArrowDown')
 
-      expect(searchInput).toHaveAttribute(
+      expect(searchInputNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
 
       changeSearchInput('it')
 
-      expect(searchInput).not.toHaveAttribute('aria-activedescendant')
+      expect(searchInputNode).not.toHaveAttribute('aria-activedescendant')
     })
 
     it('is the index of the value previously selected when opened', () => {
       const highlightedIndex = 2
-      const { clickOnTriggerButton, itemsList } = renderDropdown({
+      const { clickOnTriggerButton, itemsListNode } = renderDropdown({
         value: items[highlightedIndex],
       })
 
       clickOnTriggerButton()
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(highlightedIndex)),
       )
@@ -406,13 +409,13 @@ describe('Dropdown', () => {
 
     it('is the index of the (value previously selected + 1) when opened by arrow down', () => {
       const highlightedIndex = 2
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown({
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown({
         value: items[highlightedIndex],
       })
 
       keyDownOnTriggerButton('ArrowDown')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(highlightedIndex + 1)),
       )
@@ -420,25 +423,25 @@ describe('Dropdown', () => {
 
     it('is the index of the (value previously selected - 1) when opened by arrow up', () => {
       const highlightedIndex = 2
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown({
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown({
         value: items[highlightedIndex],
       })
 
       keyDownOnTriggerButton('ArrowUp')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(highlightedIndex - 1)),
       )
     })
 
     it('is changed correctly on arrow down navigation', () => {
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown()
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown()
 
       for (let index = 0; index < items.length; index++) {
         keyDownOnTriggerButton('ArrowDown')
 
-        expect(itemsList).toHaveAttribute(
+        expect(itemsListNode).toHaveAttribute(
           'aria-activedescendant',
           expect.stringMatching(getItemIdRegexByIndex(index)),
         )
@@ -446,121 +449,121 @@ describe('Dropdown', () => {
     })
 
     it('is changed correctly on arrow up navigation', () => {
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown()
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown()
 
-      for (let index = 0; index < items.length; index++) {
+      for (let index = items.length - 1; index >= 0; index--) {
         keyDownOnTriggerButton('ArrowUp')
 
-        expect(itemsList).toHaveAttribute(
+        expect(itemsListNode).toHaveAttribute(
           'aria-activedescendant',
-          expect.stringMatching(getItemIdRegexByIndex(items.length - 1 - index)),
+          expect.stringMatching(getItemIdRegexByIndex(index)),
         )
       }
     })
 
     it('is changed correctly on arrow down and shift navigation', () => {
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown({ defaultOpen: true })
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown({ defaultOpen: true })
 
       keyDownOnTriggerButton('ArrowDown', { shiftKey: true })
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(4)),
       )
     })
 
     it('is changed correctly on arrow up and shift navigation', () => {
-      const { keyDownOnTriggerButton, itemsList } = renderDropdown({
+      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown({
         defaultHighlightedIndex: items.length - 1,
         defaultOpen: true,
       })
 
       keyDownOnTriggerButton('ArrowUp', { shiftKey: true })
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
     })
 
     it('is changed correctly on home key navigation', () => {
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         defaultHighlightedIndex: 2,
         defaultOpen: true,
       })
 
       keyDownOnItemsList('Home')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
     })
 
     it('is changed correctly on end key navigation', () => {
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         defaultHighlightedIndex: 2,
         defaultOpen: true,
       })
 
       keyDownOnItemsList('End')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(items.length - 1)),
       )
     })
 
     it('wraps to start and end on navigation', () => {
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         defaultHighlightedIndex: 0,
         defaultOpen: true,
       })
 
       keyDownOnItemsList('ArrowUp')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(items.length - 1)),
       )
 
       keyDownOnItemsList('ArrowDown')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
     })
 
     it('is updated correctly when hovering over items', () => {
-      const { mouseOverItemAtIndex, itemsList } = renderDropdown({
+      const { mouseOverItemAtIndex, itemsListNode } = renderDropdown({
         defaultOpen: true,
       })
 
       mouseOverItemAtIndex(1)
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(1)),
       )
 
       mouseOverItemAtIndex(3)
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(3)),
       )
     })
 
     it('is updated correctly when hovering over items and using arrow keys to navigate', () => {
-      const { mouseOverItemAtIndex, keyDownOnItemsList, itemsList } = renderDropdown({
+      const { mouseOverItemAtIndex, keyDownOnItemsList, itemsListNode } = renderDropdown({
         defaultOpen: true,
       })
 
       mouseOverItemAtIndex(1)
       keyDownOnItemsList('ArrowDown')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(2)),
       )
@@ -568,7 +571,7 @@ describe('Dropdown', () => {
       mouseOverItemAtIndex(4)
       keyDownOnItemsList('ArrowUp')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(3)),
       )
@@ -576,14 +579,14 @@ describe('Dropdown', () => {
 
     it('jumps to the item starting with the character key pressed', () => {
       const items = ['Athos', 'Porthos', 'Aramis', `D'Artagnan`]
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         items,
         defaultOpen: true,
       })
 
       keyDownOnItemsList('P')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(1)),
       )
@@ -591,7 +594,7 @@ describe('Dropdown', () => {
 
     it('jumps starting from the current highlightedIndex on character key press', () => {
       const items = ['Athos', 'Porthos', 'Aramis', `D'Artagnan`]
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         items,
         defaultHighlightedIndex: 1,
         defaultOpen: true,
@@ -599,7 +602,7 @@ describe('Dropdown', () => {
 
       keyDownOnItemsList('A')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(2)),
       )
@@ -607,7 +610,7 @@ describe('Dropdown', () => {
 
     it('wraps to the start of the list when no options remain', () => {
       const items = ['Athos', 'Porthos', 'Aramis', `D'Artagnan`]
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         items,
         defaultHighlightedIndex: 2,
         defaultOpen: true,
@@ -615,7 +618,7 @@ describe('Dropdown', () => {
 
       keyDownOnItemsList('A')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
@@ -623,14 +626,14 @@ describe('Dropdown', () => {
 
     it('jumps from item to item when pressing the same key with enough time in between', () => {
       const items = ['Athos', 'Porthos', 'Aramis', `D'Artagnan`]
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         items,
         defaultOpen: true,
       })
 
       keyDownOnItemsList('A')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
@@ -638,7 +641,7 @@ describe('Dropdown', () => {
       jest.runAllTimers()
       keyDownOnItemsList('A')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(2)),
       )
@@ -646,7 +649,7 @@ describe('Dropdown', () => {
       jest.runAllTimers()
       keyDownOnItemsList('A')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
@@ -654,14 +657,14 @@ describe('Dropdown', () => {
 
     it('jumps to the item starting with the keys tapped in rapid succession', () => {
       const items = ['Albert', 'Alfred', 'Alena', 'Ali']
-      const { keyDownOnItemsList, itemsList } = renderDropdown({
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({
         items,
         defaultOpen: true,
       })
 
       keyDownOnItemsList('A')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
@@ -669,7 +672,7 @@ describe('Dropdown', () => {
       jest.advanceTimersByTime(Dropdown.charKeyPressedCleanupTime / 2)
       keyDownOnItemsList('L')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(0)),
       )
@@ -677,7 +680,7 @@ describe('Dropdown', () => {
       jest.advanceTimersByTime(Dropdown.charKeyPressedCleanupTime / 2)
       keyDownOnItemsList('E')
 
-      expect(itemsList).toHaveAttribute(
+      expect(itemsListNode).toHaveAttribute(
         'aria-activedescendant',
         expect.stringMatching(getItemIdRegexByIndex(2)),
       )
@@ -687,28 +690,28 @@ describe('Dropdown', () => {
   describe('value', () => {
     it('it takes the value of the controlled prop', () => {
       const value = items[2]
-      const { triggerButton, clickOnItemAtIndex } = renderDropdown({ value, defaultOpen: true })
+      const { triggerButtonNode, clickOnItemAtIndex } = renderDropdown({ value, defaultOpen: true })
 
-      expect(triggerButton).toHaveTextContent(value)
+      expect(triggerButtonNode).toHaveTextContent(value)
 
       clickOnItemAtIndex(0)
 
-      expect(triggerButton).toHaveTextContent(value)
+      expect(triggerButtonNode).toHaveTextContent(value)
     })
 
     it('it takes the value of the default prop but can be changed', () => {
       const defaultValue = items[2]
       const itemToBeClickedIndex = 1
-      const { triggerButton, clickOnItemAtIndex } = renderDropdown({
+      const { triggerButtonNode, clickOnItemAtIndex } = renderDropdown({
         defaultValue,
         defaultOpen: true,
       })
 
-      expect(triggerButton).toHaveTextContent(defaultValue)
+      expect(triggerButtonNode).toHaveTextContent(defaultValue)
 
       clickOnItemAtIndex(itemToBeClickedIndex)
 
-      expect(triggerButton).toHaveTextContent(items[itemToBeClickedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[itemToBeClickedIndex])
     })
 
     it('has onChange called when item is added', () => {
@@ -763,77 +766,81 @@ describe('Dropdown', () => {
 
     it('is set by clicking on item', () => {
       const itemSelectedIndex = 2
-      const { triggerButton, clickOnItemAtIndex } = renderDropdown({ defaultOpen: true })
+      const { triggerButtonNode, clickOnItemAtIndex } = renderDropdown({ defaultOpen: true })
 
       clickOnItemAtIndex(itemSelectedIndex)
 
-      expect(triggerButton).toHaveTextContent(items[itemSelectedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[itemSelectedIndex])
     })
 
     it('is set by using Enter on highlighted item', () => {
       const itemSelectedIndex = 1
-      const { triggerButton, keyDownOnItemsList } = renderDropdown({
+      const { triggerButtonNode, keyDownOnItemsList } = renderDropdown({
         defaultOpen: true,
         defaultHighlightedIndex: itemSelectedIndex,
       })
 
       keyDownOnItemsList('Enter')
 
-      expect(triggerButton).toHaveTextContent(items[itemSelectedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[itemSelectedIndex])
     })
 
     it('is set by using Tab on highlighted item', () => {
       const itemSelectedIndex = 3
-      const { triggerButton, keyDownOnItemsList } = renderDropdown({
+      const { triggerButtonNode, keyDownOnItemsList } = renderDropdown({
         defaultOpen: true,
         defaultHighlightedIndex: itemSelectedIndex,
       })
 
       keyDownOnItemsList('Tab')
 
-      expect(triggerButton).toHaveTextContent(items[itemSelectedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[itemSelectedIndex])
     })
 
     it('is set by using Shift+Tab on highlighted item', () => {
       const itemSelectedIndex = 2
-      const { triggerButton, keyDownOnItemsList } = renderDropdown({
+      const { triggerButtonNode, keyDownOnItemsList } = renderDropdown({
         defaultOpen: true,
         defaultHighlightedIndex: itemSelectedIndex,
       })
 
       keyDownOnItemsList('Tab', { shiftKey: true })
 
-      expect(triggerButton).toHaveTextContent(items[itemSelectedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[itemSelectedIndex])
     })
 
     it('is replaced when another item is selected', () => {
       const defaultSelectedIndex = 0
       const itemSelectedIndex = 2
-      const { triggerButton, clickOnItemAtIndex } = renderDropdown({
+      const { triggerButtonNode, clickOnItemAtIndex } = renderDropdown({
         defaultOpen: true,
         defaultValue: items[defaultSelectedIndex],
       })
 
-      expect(triggerButton).toHaveTextContent(items[defaultSelectedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[defaultSelectedIndex])
 
       clickOnItemAtIndex(itemSelectedIndex)
 
-      expect(triggerButton).toHaveTextContent(items[itemSelectedIndex])
+      expect(triggerButtonNode).toHaveTextContent(items[itemSelectedIndex])
     })
 
     it('has an array of items if more items are selected and the multiple prop is supplied', () => {
-      const { getSelectedItems, getSelectedItemAtIndex } = renderDropdown({
+      const { getSelectedItemNodes, getSelectedItemNodeAtIndex } = renderDropdown({
         multiple: true,
         defaultValue: [items[0], items[1]],
       })
 
-      expect(getSelectedItems()).toHaveLength(2)
-      expect(getSelectedItemAtIndex(0)).toHaveTextContent(items[0])
-      expect(getSelectedItemAtIndex(1)).toHaveTextContent(items[1])
+      expect(getSelectedItemNodes()).toHaveLength(2)
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[0])
+      expect(getSelectedItemNodeAtIndex(1)).toHaveTextContent(items[1])
     })
 
     it('emoves last item on backspace when query is emtpy', () => {
-      const { getSelectedItems, getSelectedItemAtIndex, keyDownOnSearchInput } = renderDropdown({
+      const {
+        getSelectedItemNodes,
+        getSelectedItemNodeAtIndex,
+        keyDownOnSearchInput,
+      } = renderDropdown({
         multiple: true,
         search: true,
         defaultValue: [items[0], items[1]],
@@ -841,30 +848,30 @@ describe('Dropdown', () => {
 
       keyDownOnSearchInput('Backspace')
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getSelectedItemAtIndex(0)).toHaveTextContent(items[0])
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[0])
     })
 
     it('does not rempve last item on backspace when query is not empty', () => {
-      const { getSelectedItems, keyDownOnSearchInput, searchInput } = renderDropdown({
+      const { getSelectedItemNodes, keyDownOnSearchInput, searchInputNode } = renderDropdown({
         multiple: true,
         search: true,
         defaultSearchQuery: 'bla',
         defaultValue: [items[0], items[1]],
       })
 
-      searchInput.setSelectionRange(1, 2)
+      searchInputNode.setSelectionRange(1, 2)
       keyDownOnSearchInput('Backspace')
 
-      expect(getSelectedItems()).toHaveLength(2)
+      expect(getSelectedItemNodes()).toHaveLength(2)
     })
 
     it('removes last item on backspace when selection range is 0, 0', () => {
       const {
-        getSelectedItems,
-        getSelectedItemAtIndex,
+        getSelectedItemNodes,
+        getSelectedItemNodeAtIndex,
         keyDownOnSearchInput,
-        searchInput,
+        searchInputNode,
       } = renderDropdown({
         multiple: true,
         search: true,
@@ -872,31 +879,31 @@ describe('Dropdown', () => {
         defaultValue: [items[0], items[1]],
       })
 
-      searchInput.setSelectionRange(0, 0)
+      searchInputNode.setSelectionRange(0, 0)
       keyDownOnSearchInput('Backspace')
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getSelectedItemAtIndex(0)).toHaveTextContent(items[0])
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[0])
     })
 
     it('does not rempve last item on backspace when selection range is 0, (y>0)', () => {
-      const { getSelectedItems, keyDownOnSearchInput, searchInput } = renderDropdown({
+      const { getSelectedItemNodes, keyDownOnSearchInput, searchInputNode } = renderDropdown({
         multiple: true,
         search: true,
         defaultSearchQuery: 'bla',
         defaultValue: [items[0], items[1]],
       })
 
-      searchInput.setSelectionRange(0, 1)
+      searchInputNode.setSelectionRange(0, 1)
       keyDownOnSearchInput('Backspace')
 
-      expect(getSelectedItems()).toHaveLength(2)
+      expect(getSelectedItemNodes()).toHaveLength(2)
     })
 
     it('has the item removed if it receives delete key down', () => {
       const {
-        getSelectedItems,
-        getSelectedItemAtIndex,
+        getSelectedItemNodes,
+        getSelectedItemNodeAtIndex,
         keyDownOnSelectedItemAtIndex,
       } = renderDropdown({
         multiple: true,
@@ -906,12 +913,12 @@ describe('Dropdown', () => {
 
       keyDownOnSelectedItemAtIndex(0, 'Delete')
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getSelectedItemAtIndex(0)).toHaveTextContent(items[1])
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[1])
     })
 
     it('has the item removed if it receives click on remove icon', () => {
-      const { getSelectedItems, getSelectedItemAtIndex, wrapper } = renderDropdown({
+      const { getSelectedItemNodes, getSelectedItemNodeAtIndex, wrapper } = renderDropdown({
         multiple: true,
         search: true,
         defaultValue: [items[0], items[1]],
@@ -921,8 +928,8 @@ describe('Dropdown', () => {
         .at(0)
         .simulate('click')
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getSelectedItemAtIndex(0)).toHaveTextContent(items[1])
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[1])
     })
   })
 
@@ -932,9 +939,9 @@ describe('Dropdown', () => {
     })
 
     it('creates message container element', () => {
-      const { getA11yMessageContainer } = renderDropdown({ getA11ySelectionMessage: {} })
+      const { getA11yMessageContainerNode } = renderDropdown({ getA11ySelectionMessage: {} })
 
-      expect(getA11yMessageContainer()).toMatchInlineSnapshot(`
+      expect(getA11yMessageContainerNode()).toMatchInlineSnapshot(`
         <div
           aria-live="polite"
           aria-relevant="additions text"
@@ -946,25 +953,25 @@ describe('Dropdown', () => {
 
     it('has the onAdd message inserted and cleared after an item has been added to selection', () => {
       const itemToBeClickedIndex = 1
-      const { getA11yMessageContainer, clickOnItemAtIndex } = renderDropdown({
+      const { getA11yMessageContainerNode, clickOnItemAtIndex } = renderDropdown({
         defaultOpen: true,
         getA11ySelectionMessage: { onAdd: item => `${item} has been added` },
       })
 
       clickOnItemAtIndex(itemToBeClickedIndex)
 
-      expect(getA11yMessageContainer()).toHaveTextContent(
+      expect(getA11yMessageContainerNode()).toHaveTextContent(
         `${items[itemToBeClickedIndex]} has been added`,
       )
 
       jest.runAllTimers()
 
-      expect(getA11yMessageContainer()).toHaveTextContent('')
+      expect(getA11yMessageContainerNode()).toHaveTextContent('')
     })
 
     it('has the onRemove message inserted and cleared after an item has been removed from selection', () => {
       const itemSelectedByDefaultIndex = 2
-      const { getA11yMessageContainer, keyDownOnSelectedItemAtIndex } = renderDropdown({
+      const { getA11yMessageContainerNode, keyDownOnSelectedItemAtIndex } = renderDropdown({
         defaultOpen: true,
         multiple: true,
         defaultValue: [items[itemSelectedByDefaultIndex]],
@@ -973,56 +980,56 @@ describe('Dropdown', () => {
 
       keyDownOnSelectedItemAtIndex(0, 'Delete')
 
-      expect(getA11yMessageContainer()).toHaveTextContent(
+      expect(getA11yMessageContainerNode()).toHaveTextContent(
         `${items[itemSelectedByDefaultIndex]} has been removed`,
       )
 
       jest.runAllTimers()
 
-      expect(getA11yMessageContainer()).toHaveTextContent('')
+      expect(getA11yMessageContainerNode()).toHaveTextContent('')
     })
   })
 
   describe('searchQuery', () => {
     it('it takes the value of the controlled prop', () => {
       const searchQuery = "can't touch this"
-      const { changeSearchInput, searchInput } = renderDropdown({ searchQuery, search: true })
+      const { changeSearchInput, searchInputNode } = renderDropdown({ searchQuery, search: true })
 
-      expect(searchInput).toHaveValue(searchQuery)
+      expect(searchInputNode).toHaveValue(searchQuery)
 
       changeSearchInput('but I can try!')
 
-      expect(searchInput).toHaveValue(searchQuery)
+      expect(searchInputNode).toHaveValue(searchQuery)
     })
 
     it('it takes the value of the default prop but can be changed', () => {
       const defaultSearchQuery = "maybe you can't touch this"
       const finalSearchQuery = 'you underestimate my power'
-      const { changeSearchInput, searchInput } = renderDropdown({
+      const { changeSearchInput, searchInputNode } = renderDropdown({
         defaultSearchQuery,
         search: true,
       })
 
-      expect(searchInput).toHaveValue(defaultSearchQuery)
+      expect(searchInputNode).toHaveValue(defaultSearchQuery)
 
       changeSearchInput(finalSearchQuery)
 
-      expect(searchInput).toHaveValue(finalSearchQuery)
+      expect(searchInputNode).toHaveValue(finalSearchQuery)
     })
 
     it("updates component's state on props updates", () => {
       const newSearchQueryProp = 'bar'
-      const { wrapper, searchInput } = renderDropdown({
+      const { wrapper, searchInputNode } = renderDropdown({
         searchQuery: 'foo',
         search: true,
       })
 
       wrapper.setProps({ searchQuery: newSearchQueryProp })
-      expect(searchInput).toHaveValue(newSearchQueryProp)
+      expect(searchInputNode).toHaveValue(newSearchQueryProp)
     })
 
     it('closes dropdown when changed to empty string', () => {
-      const { getItems, changeSearchInput } = renderDropdown({
+      const { getItemNodes, changeSearchInput } = renderDropdown({
         defaultSearchQuery: 'foo',
         defaultOpen: true,
         search: true,
@@ -1030,13 +1037,13 @@ describe('Dropdown', () => {
 
       changeSearchInput('')
 
-      expect(getItems()).toHaveLength(0)
+      expect(getItemNodes()).toHaveLength(0)
     })
 
     it('is the string equivalent of selected item in single search', () => {
       const itemSelectedIndex = 2
       const itemsAsObjects = items.map(item => ({ value: item, key: item }))
-      const { searchInput, clickOnItemAtIndex } = renderDropdown({
+      const { searchInputNode, clickOnItemAtIndex } = renderDropdown({
         search: true,
         defaultOpen: true,
         items: itemsAsObjects,
@@ -1045,22 +1052,22 @@ describe('Dropdown', () => {
 
       clickOnItemAtIndex(itemSelectedIndex)
 
-      expect(searchInput).toHaveValue(itemsAsObjects[itemSelectedIndex].value)
+      expect(searchInputNode).toHaveValue(itemsAsObjects[itemSelectedIndex].value)
     })
 
     it('is set to empty by hitting Escape in search input', () => {
-      const { keyDownOnSearchInput, searchInput } = renderDropdown({
+      const { keyDownOnSearchInput, searchInputNode } = renderDropdown({
         defaultSearchQuery: 'foo',
         search: true,
       })
 
       keyDownOnSearchInput('Escape')
 
-      expect(searchInput).toHaveValue('')
+      expect(searchInputNode).toHaveValue('')
     })
 
     it('is set to empty when item is selected in multiple search', () => {
-      const { clickOnItemAtIndex, searchInput, getSelectedItems } = renderDropdown({
+      const { clickOnItemAtIndex, searchInputNode, getSelectedItemNodes } = renderDropdown({
         search: true,
         multiple: true,
         defaultOpen: true,
@@ -1068,25 +1075,25 @@ describe('Dropdown', () => {
 
       clickOnItemAtIndex(2)
 
-      expect(searchInput).toHaveValue('')
-      expect(getSelectedItems()).toHaveLength(1)
+      expect(searchInputNode).toHaveValue('')
+      expect(getSelectedItemNodes()).toHaveLength(1)
     })
   })
 
   describe('activeSelectedIndex', () => {
     it('is set on active item click', () => {
-      const { getSelectedItemAtIndex, clickOnSelectedItemAtIndex } = renderDropdown({
+      const { getSelectedItemNodeAtIndex, clickOnSelectedItemAtIndex } = renderDropdown({
         multiple: true,
         value: [items[2]],
       })
 
       clickOnSelectedItemAtIndex(0)
 
-      expect(document.activeElement).toBe(getSelectedItemAtIndex(0))
+      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(0))
     })
 
     it('is set as last index on left arrow from the search query', () => {
-      const { getSelectedItemAtIndex, keyDownOnSearchInput } = renderDropdown({
+      const { getSelectedItemNodeAtIndex, keyDownOnSearchInput } = renderDropdown({
         multiple: true,
         value: [items[0], items[1], items[2]],
         search: true,
@@ -1094,23 +1101,23 @@ describe('Dropdown', () => {
 
       keyDownOnSearchInput('ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemAtIndex(2))
+      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(2))
     })
 
     it('is set as last index on left arrow from the trigger button', () => {
-      const { getSelectedItemAtIndex, keyDownOnTriggerButton } = renderDropdown({
+      const { getSelectedItemNodeAtIndex, keyDownOnTriggerButton } = renderDropdown({
         multiple: true,
         value: [items[0], items[1], items[2]],
       })
 
       keyDownOnTriggerButton('ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemAtIndex(2))
+      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(2))
     })
 
     it('is updated on arrow navigation after being set by click', () => {
       const {
-        getSelectedItemAtIndex,
+        getSelectedItemNodeAtIndex,
         keyDownOnSelectedItemAtIndex,
         clickOnSelectedItemAtIndex,
       } = renderDropdown({
@@ -1121,12 +1128,12 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemAtIndex(1))
+      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(1))
     })
 
     it('stays as "0" on left arrow from the first selected item', () => {
       const {
-        getSelectedItemAtIndex,
+        getSelectedItemNodeAtIndex,
         keyDownOnSelectedItemAtIndex,
         clickOnSelectedItemAtIndex,
       } = renderDropdown({
@@ -1137,12 +1144,12 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(0)
       keyDownOnSelectedItemAtIndex(0, 'ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemAtIndex(0))
+      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(0))
     })
 
     it('gets unset on right arrow from the last selected item and moves focus to trigger button', () => {
       const {
-        triggerButton,
+        triggerButtonNode,
         keyDownOnSelectedItemAtIndex,
         clickOnSelectedItemAtIndex,
       } = renderDropdown({
@@ -1153,12 +1160,12 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'ArrowRight')
 
-      expect(document.activeElement).toBe(triggerButton)
+      expect(document.activeElement).toBe(triggerButtonNode)
     })
 
     it('gets unset on the removal of selected item and moves focus to trigger button', () => {
       const {
-        triggerButton,
+        triggerButtonNode,
         keyDownOnSelectedItemAtIndex,
         clickOnSelectedItemAtIndex,
       } = renderDropdown({
@@ -1169,12 +1176,12 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'Delete')
 
-      expect(document.activeElement).toBe(triggerButton)
+      expect(document.activeElement).toBe(triggerButtonNode)
     })
 
     it('gets unset on right arrow from the last selected item and moves focus to search input', () => {
       const {
-        searchInput,
+        searchInputNode,
         keyDownOnSelectedItemAtIndex,
         clickOnSelectedItemAtIndex,
       } = renderDropdown({
@@ -1186,12 +1193,12 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'ArrowRight')
 
-      expect(document.activeElement).toBe(searchInput)
+      expect(document.activeElement).toBe(searchInputNode)
     })
 
     it('gets unset on the removal of selected item and moves focus to search input', () => {
       const {
-        searchInput,
+        searchInputNode,
         keyDownOnSelectedItemAtIndex,
         clickOnSelectedItemAtIndex,
       } = renderDropdown({
@@ -1203,7 +1210,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'Delete')
 
-      expect(document.activeElement).toBe(searchInput)
+      expect(document.activeElement).toBe(searchInputNode)
     })
   })
 
@@ -1233,21 +1240,21 @@ describe('Dropdown', () => {
     })
   })
 
-  describe('toggleIndicator', () => {
+  describe('toggleIndicatorNode', () => {
     it('moves focus to list at click', () => {
-      const { clickOnToggleIndicator, itemsList } = renderDropdown()
+      const { clickOnToggleIndicator, itemsListNode } = renderDropdown()
 
       clickOnToggleIndicator()
 
-      expect(document.activeElement).toBe(itemsList)
+      expect(document.activeElement).toBe(itemsListNode)
     })
 
     it('moves focus to input in search mode', () => {
-      const { clickOnToggleIndicator, searchInput } = renderDropdown({ search: true })
+      const { clickOnToggleIndicator, searchInputNode } = renderDropdown({ search: true })
 
       clickOnToggleIndicator()
 
-      expect(document.activeElement).toBe(searchInput)
+      expect(document.activeElement).toBe(searchInputNode)
     })
   })
 
@@ -1314,55 +1321,55 @@ describe('Dropdown', () => {
 
   describe('multiple', () => {
     it('can be switched to "multiple"', () => {
-      const { wrapper, getSelectedItems } = renderDropdown({ value: items[0] })
+      const { wrapper, getSelectedItemNodes } = renderDropdown({ value: items[0] })
 
-      expect(getSelectedItems()).toHaveLength(0)
+      expect(getSelectedItemNodes()).toHaveLength(0)
 
       wrapper.setProps({ multiple: true })
-      expect(getSelectedItems()).toHaveLength(1)
+      expect(getSelectedItemNodes()).toHaveLength(1)
     })
 
     it('does not contain duplicates after an item is selected', () => {
-      const { getSelectedItems, getItems, clickOnItemAtIndex } = renderDropdown({
+      const { getSelectedItemNodes, getItemNodes, clickOnItemAtIndex } = renderDropdown({
         multiple: true,
         open: true,
       })
 
       clickOnItemAtIndex(0)
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getItems()).toHaveLength(items.length - 1)
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getItemNodes()).toHaveLength(items.length - 1)
 
       clickOnItemAtIndex(0)
 
-      expect(getSelectedItems()).toHaveLength(2)
-      expect(getItems()).toHaveLength(items.length - 2)
+      expect(getSelectedItemNodes()).toHaveLength(2)
+      expect(getItemNodes()).toHaveLength(items.length - 2)
     })
 
     it('does not contain duplicates when value is set', () => {
-      const { getSelectedItems, getItems } = renderDropdown({
+      const { getSelectedItemNodes, getItemNodes } = renderDropdown({
         multiple: true,
         open: true,
         value: items[0],
       })
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getItems()).toHaveLength(items.length - 1)
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getItemNodes()).toHaveLength(items.length - 1)
     })
 
     it('contains duplicates by default', () => {
       const items = [{ key: '1', header: 'James Smith' }]
       const value = [{ key: '1', header: 'John Locke' }]
 
-      const { getSelectedItems, getItems } = renderDropdown({
+      const { getSelectedItemNodes, getItemNodes } = renderDropdown({
         multiple: true,
         open: true,
         value,
         items,
       })
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getItems()).toHaveLength(items.length)
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getItemNodes()).toHaveLength(items.length)
     })
 
     it('does not contain duplicates when proper itemToValue prop is used', () => {
@@ -1375,7 +1382,7 @@ describe('Dropdown', () => {
         return (item as any).id
       }
 
-      const { getSelectedItems, getItems } = renderDropdown({
+      const { getSelectedItemNodes, getItemNodes } = renderDropdown({
         multiple: true,
         open: true,
         value,
@@ -1383,8 +1390,8 @@ describe('Dropdown', () => {
         itemToValue,
       })
 
-      expect(getSelectedItems()).toHaveLength(1)
-      expect(getItems()).toHaveLength(items.length - 1)
+      expect(getSelectedItemNodes()).toHaveLength(1)
+      expect(getItemNodes()).toHaveLength(items.length - 1)
     })
   })
 

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -1318,7 +1318,7 @@ describe('Dropdown', () => {
 
       expect(getSelectedItems()).toHaveLength(0)
 
-      wrapper.setProps({ multiple: true } as any)
+      wrapper.setProps({ multiple: true })
       expect(getSelectedItems()).toHaveLength(1)
     })
 
@@ -1392,8 +1392,7 @@ describe('Dropdown', () => {
     it('have onClick called when passed stop event from being propagated', () => {
       const onClick = jest.fn()
       const stopPropagation = jest.fn()
-      const stopImmediatePropagation = jest.fn()
-      const mockedEvent = { stopPropagation, nativeEvent: { stopImmediatePropagation } }
+      const mockedEvent = { stopPropagation }
       const items = [{ header: 'Venom', onClick }]
       const { clickOnItemAtIndex } = renderDropdown({ items, defaultOpen: true })
 
@@ -1407,14 +1406,12 @@ describe('Dropdown', () => {
         }),
       )
       expect(stopPropagation).toBeCalledTimes(1)
-      expect(stopImmediatePropagation).toBeCalledTimes(1)
     })
 
     it('when selected have onClick called when passed stop event from being propagated', () => {
       const onClick = jest.fn()
       const stopPropagation = jest.fn()
-      const stopImmediatePropagation = jest.fn()
-      const mockedEvent = { stopPropagation, nativeEvent: { stopImmediatePropagation } }
+      const mockedEvent = { stopPropagation }
       const items = [{ header: 'Venom', onClick }]
       const { clickOnSelectedItemAtIndex } = renderDropdown({
         items,

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -177,7 +177,7 @@ describe('Dropdown', () => {
 
       clickOnTriggerButton()
 
-      expect(document.activeElement).toEqual(itemsListNode)
+      expect(itemsListNode).toHaveFocus()
     })
 
     it('is "false" when blurred by Tab on items list', () => {
@@ -207,7 +207,7 @@ describe('Dropdown', () => {
       expect(getItemNodes()).toHaveLength(0)
     })
 
-    it('is "false" when blurred by Shift+Tab on items list', () => {
+    it('is "false" when blurred by Shift+Tab on search input', () => {
       const { getItemNodes, keyDownOnSearchInput } = renderDropdown({
         defaultOpen: true,
         search: true,
@@ -1089,7 +1089,7 @@ describe('Dropdown', () => {
 
       clickOnSelectedItemAtIndex(0)
 
-      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(0))
+      expect(getSelectedItemNodeAtIndex(0)).toHaveFocus()
     })
 
     it('is set as last index on left arrow from the search query', () => {
@@ -1101,7 +1101,7 @@ describe('Dropdown', () => {
 
       keyDownOnSearchInput('ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(2))
+      expect(getSelectedItemNodeAtIndex(2)).toHaveFocus()
     })
 
     it('is set as last index on left arrow from the trigger button', () => {
@@ -1112,7 +1112,7 @@ describe('Dropdown', () => {
 
       keyDownOnTriggerButton('ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(2))
+      expect(getSelectedItemNodeAtIndex(2)).toHaveFocus()
     })
 
     it('is updated on arrow navigation after being set by click', () => {
@@ -1128,7 +1128,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(1))
+      expect(getSelectedItemNodeAtIndex(1)).toHaveFocus()
     })
 
     it('stays as "0" on left arrow from the first selected item', () => {
@@ -1144,7 +1144,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(0)
       keyDownOnSelectedItemAtIndex(0, 'ArrowLeft')
 
-      expect(document.activeElement).toBe(getSelectedItemNodeAtIndex(0))
+      expect(getSelectedItemNodeAtIndex(0)).toHaveFocus()
     })
 
     it('gets unset on right arrow from the last selected item and moves focus to trigger button', () => {
@@ -1160,7 +1160,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'ArrowRight')
 
-      expect(document.activeElement).toBe(triggerButtonNode)
+      expect(triggerButtonNode).toHaveFocus()
     })
 
     it('gets unset on the removal of selected item and moves focus to trigger button', () => {
@@ -1176,7 +1176,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'Delete')
 
-      expect(document.activeElement).toBe(triggerButtonNode)
+      expect(triggerButtonNode).toHaveFocus()
     })
 
     it('gets unset on right arrow from the last selected item and moves focus to search input', () => {
@@ -1193,7 +1193,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'ArrowRight')
 
-      expect(document.activeElement).toBe(searchInputNode)
+      expect(searchInputNode).toHaveFocus()
     })
 
     it('gets unset on the removal of selected item and moves focus to search input', () => {
@@ -1210,7 +1210,7 @@ describe('Dropdown', () => {
       clickOnSelectedItemAtIndex(2)
       keyDownOnSelectedItemAtIndex(2, 'Delete')
 
-      expect(document.activeElement).toBe(searchInputNode)
+      expect(searchInputNode).toHaveFocus()
     })
   })
 
@@ -1246,7 +1246,7 @@ describe('Dropdown', () => {
 
       clickOnToggleIndicator()
 
-      expect(document.activeElement).toBe(itemsListNode)
+      expect(itemsListNode).toHaveFocus()
     })
 
     it('moves focus to input in search mode', () => {
@@ -1254,7 +1254,7 @@ describe('Dropdown', () => {
 
       clickOnToggleIndicator()
 
-      expect(document.activeElement).toBe(searchInputNode)
+      expect(searchInputNode).toHaveFocus()
     })
   })
 
@@ -1326,6 +1326,7 @@ describe('Dropdown', () => {
       expect(getSelectedItemNodes()).toHaveLength(0)
 
       wrapper.setProps({ multiple: true })
+
       expect(getSelectedItemNodes()).toHaveLength(1)
     })
 

--- a/packages/react/test/specs/components/Dropdown/test-utils.tsx
+++ b/packages/react/test/specs/components/Dropdown/test-utils.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react'
+import * as _ from 'lodash'
+
+import Dropdown, { DropdownProps } from 'src/components/Dropdown/Dropdown'
+import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
+import { findIntrinsicElement, mountWithProvider } from 'test/utils'
+
+const items = ['item0', 'item1', 'item2', 'item3', 'item4', 'item5']
+
+const renderDropdown = (props: DropdownProps = {}) => {
+  const wrapper = mountWithProvider(<Dropdown items={items} {...props} />)
+  const triggerButtonWrapper = findIntrinsicElement(
+    wrapper,
+    `.${Dropdown.slotClassNames.triggerButton}`,
+  )
+  const toggleIndicatorWrapper = findIntrinsicElement(
+    wrapper,
+    `.${Dropdown.slotClassNames.toggleIndicator}`,
+  )
+  const searchInputWrapper = findIntrinsicElement(
+    wrapper,
+    `.${DropdownSearchInput.slotClassNames.input}`,
+  )
+  const itemsListWrapper = findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.itemsList}`)
+  const getItemsWrapper = () => findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.item}`)
+  const getSelectedItemsWrapper = () =>
+    findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.selectedItem}`)
+  const getSelectedItemWrapperAtIndex = index => getSelectedItemsWrapper().at(index)
+  const getItemWrapperAtIndex = index => getItemsWrapper().at(index)
+
+  return {
+    wrapper,
+    triggerButton: triggerButtonWrapper.length ? triggerButtonWrapper.getDOMNode() : null,
+    toggleIndicator: toggleIndicatorWrapper.length ? toggleIndicatorWrapper.getDOMNode() : null,
+    itemsList: itemsListWrapper.getDOMNode(),
+    searchInput: searchInputWrapper.length
+      ? searchInputWrapper.getDOMNode<HTMLInputElement>()
+      : null,
+    getA11yMessageContainer: () => findIntrinsicElement(wrapper, '[role="status"]').getDOMNode(),
+    getItems: () => getItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
+    getSelectedItems: () => getSelectedItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
+    getItemAtIndex: index => getItemWrapperAtIndex(index).getDOMNode(),
+    getSelectedItemAtIndex: index => getSelectedItemWrapperAtIndex(index).getDOMNode(),
+    mouseOverItemAtIndex: index => getItemWrapperAtIndex(index).simulate('mousemove'),
+    changeSearchInput: value => {
+      searchInputWrapper.simulate('change', { target: { value } })
+    },
+    clickOnTriggerButton: () => {
+      triggerButtonWrapper.simulate('click')
+    },
+    clickOnToggleIndicator: () => {
+      toggleIndicatorWrapper.simulate('click')
+    },
+    clickOnSearchInput: () => {
+      searchInputWrapper.simulate('click')
+    },
+    clickOnItemAtIndex: (index: number, optional = {}) => {
+      getItemWrapperAtIndex(index).simulate(
+        'click',
+        _.merge(
+          {
+            nativeEvent: { stopImmediatePropagation: jest.fn() },
+          },
+          optional,
+        ),
+      )
+    },
+    clickOnSelectedItemAtIndex: (index: number, optional = {}) => {
+      getSelectedItemWrapperAtIndex(index).simulate(
+        'click',
+        _.merge(
+          {
+            nativeEvent: { stopImmediatePropagation: jest.fn() },
+          },
+          optional,
+        ),
+      )
+    },
+    keyDownOnSearchInput: (key: string, optional?: Object) =>
+      searchInputWrapper.simulate('keydown', { key, ...optional }),
+    keyDownOnItemsList: (key: string, optional?: Object) =>
+      itemsListWrapper.simulate('keydown', { key, ...optional }),
+    keyDownOnTriggerButton: (key: string, optional?: Object) =>
+      triggerButtonWrapper.simulate('keydown', { key, ...optional }),
+    keyDownOnSelectedItemAtIndex: (index: number, key: string, optional?: Object) => {
+      getSelectedItemWrapperAtIndex(index).simulate('keydown', { key, ...optional })
+    },
+    focusTriggerButton: () => {
+      triggerButtonWrapper.simulate('focus')
+    },
+    focusSearchInput: () => {
+      searchInputWrapper.simulate('focus')
+    },
+    focusItemsList: () => {
+      itemsListWrapper.simulate('focus')
+    },
+  }
+}
+
+const getItemIdRegexByIndex = index => new RegExp(`downshift-\\d+-item-${index}`)
+
+export { getItemIdRegexByIndex, renderDropdown, items }

--- a/packages/react/test/specs/components/Dropdown/test-utils.tsx
+++ b/packages/react/test/specs/components/Dropdown/test-utils.tsx
@@ -30,17 +30,18 @@ const renderDropdown = (props: DropdownProps = {}) => {
 
   return {
     wrapper,
-    triggerButton: triggerButtonWrapper.length ? triggerButtonWrapper.getDOMNode() : null,
-    toggleIndicator: toggleIndicatorWrapper.length ? toggleIndicatorWrapper.getDOMNode() : null,
-    itemsList: itemsListWrapper.getDOMNode(),
-    searchInput: searchInputWrapper.length
+    triggerButtonNode: triggerButtonWrapper.length ? triggerButtonWrapper.getDOMNode() : null,
+    toggleIndicatorNode: toggleIndicatorWrapper.length ? toggleIndicatorWrapper.getDOMNode() : null,
+    itemsListNode: itemsListWrapper.getDOMNode(),
+    searchInputNode: searchInputWrapper.length
       ? searchInputWrapper.getDOMNode<HTMLInputElement>()
       : null,
-    getA11yMessageContainer: () => findIntrinsicElement(wrapper, '[role="status"]').getDOMNode(),
-    getItems: () => getItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
-    getSelectedItems: () => getSelectedItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
-    getItemAtIndex: index => getItemWrapperAtIndex(index).getDOMNode(),
-    getSelectedItemAtIndex: index => getSelectedItemWrapperAtIndex(index).getDOMNode(),
+    getA11yMessageContainerNode: () =>
+      findIntrinsicElement(wrapper, '[role="status"]').getDOMNode(),
+    getItemNodes: () => getItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
+    getSelectedItemNodes: () =>
+      getSelectedItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
+    getSelectedItemNodeAtIndex: index => getSelectedItemWrapperAtIndex(index).getDOMNode(),
     mouseOverItemAtIndex: index => getItemWrapperAtIndex(index).simulate('mousemove'),
     changeSearchInput: value => {
       searchInputWrapper.simulate('change', { target: { value } })

--- a/packages/react/test/specs/components/Dropdown/test-utils.tsx
+++ b/packages/react/test/specs/components/Dropdown/test-utils.tsx
@@ -65,6 +65,9 @@ const renderDropdown = (props: DropdownProps = {}) => {
         ),
       )
     },
+    clickOnClearIndicator: () => {
+      findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.clearIndicator}`).simulate('click')
+    },
     clickOnSelectedItemAtIndex: (index: number, optional = {}) => {
       getSelectedItemWrapperAtIndex(index).simulate(
         'click',

--- a/packages/react/test/utils/withProvider.tsx
+++ b/packages/react/test/utils/withProvider.tsx
@@ -1,6 +1,6 @@
 import { emptyTheme, ThemeInput } from '@fluentui/styles'
 import * as React from 'react'
-import { mount, ReactWrapper, MountRendererProps, ComponentType } from 'enzyme'
+import { mount, MountRendererProps, ComponentType } from 'enzyme'
 import { ThemeProvider } from 'react-fela'
 
 import { felaRenderer } from 'src/utils'
@@ -20,15 +20,11 @@ export const EmptyThemeProvider: React.FunctionComponent = ({ children }) => {
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>
 }
 
-interface AugmentedMountRendererProps extends MountRendererProps {
-  wrappingComponent?: React.FunctionComponent
-}
-
 export const mountWithProvider = <C extends React.Component, P = C['props'], S = C['state']>(
   node: React.ReactElement<P>,
-  options?: AugmentedMountRendererProps,
+  options?: MountRendererProps,
   theme?: ThemeInput,
-): ReactWrapper<P, S, C> => {
+) => {
   return mount(node, {
     wrappingComponent: EmptyThemeProvider,
     ...options,
@@ -42,8 +38,8 @@ export const mountWithProviderAndGetComponent = <
 >(
   Component: ComponentType<P>,
   elementToMount: React.ReactElement<P>,
-  options?: AugmentedMountRendererProps,
+  options?: MountRendererProps,
   theme?: ThemeInput,
-): ReactWrapper<P, any> => {
+) => {
   return mountWithProvider(elementToMount, options, theme).find(Component)
 }

--- a/packages/react/test/utils/withProvider.tsx
+++ b/packages/react/test/utils/withProvider.tsx
@@ -1,6 +1,6 @@
 import { emptyTheme, ThemeInput } from '@fluentui/styles'
 import * as React from 'react'
-import { mount } from 'enzyme'
+import { mount, ReactWrapper, MountRendererProps, ComponentType } from 'enzyme'
 import { ThemeProvider } from 'react-fela'
 
 import { felaRenderer } from 'src/utils'
@@ -20,18 +20,30 @@ export const EmptyThemeProvider: React.FunctionComponent = ({ children }) => {
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>
 }
 
-export const mountWithProvider = (node, options?, theme?: ThemeInput) => {
+interface AugmentedMountRendererProps extends MountRendererProps {
+  wrappingComponent: React.FunctionComponent
+}
+
+export const mountWithProvider = <C extends React.Component, P = C['props'], S = C['state']>(
+  node: React.ReactElement<P>,
+  options?: AugmentedMountRendererProps,
+  theme?: ThemeInput,
+): ReactWrapper<P, S, C> => {
   return mount(node, {
     wrappingComponent: EmptyThemeProvider,
     ...options,
   })
 }
 
-export const mountWithProviderAndGetComponent = (
-  Component,
-  elementToMount,
-  options?: {},
+export const mountWithProviderAndGetComponent = <
+  C extends React.Component,
+  P = C['props'],
+  S = C['state']
+>(
+  Component: ComponentType<P>,
+  elementToMount: React.ReactElement<P>,
+  options?: AugmentedMountRendererProps,
   theme?: ThemeInput,
-) => {
+): ReactWrapper<P, any> => {
   return mountWithProvider(elementToMount, options, theme).find(Component)
 }

--- a/packages/react/test/utils/withProvider.tsx
+++ b/packages/react/test/utils/withProvider.tsx
@@ -21,7 +21,7 @@ export const EmptyThemeProvider: React.FunctionComponent = ({ children }) => {
 }
 
 interface AugmentedMountRendererProps extends MountRendererProps {
-  wrappingComponent: React.FunctionComponent
+  wrappingComponent?: React.FunctionComponent
 }
 
 export const mountWithProvider = <C extends React.Component, P = C['props'], S = C['state']>(

--- a/types/jest-dom.d.ts
+++ b/types/jest-dom.d.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect.d'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,8 +2601,8 @@
 
 "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3":
   version "7.8.4"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
-  integrity sha1-159aIED3yqJNU+VjqtScvAVYEwg=
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -8699,13 +8699,13 @@ css-what@^3.2.1:
 
 css.escape@^1.5.1:
   version "1.5.1"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
 css@2.X, css@^2.2.1, css@^2.2.4:
   version "2.2.4"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
   dependencies:
     inherits "^2.0.3"
     source-map "^0.6.1"
@@ -17871,7 +17871,7 @@ react-inspector@^3.0.2:
 
 react-is@^16.10.2, react-is@^16.12.0, react-is@^16.8.3:
   version "16.12.0"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,10 +2599,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.7.6":
+"@babel/runtime@^7.5.1", "@babel/runtime@^7.7.6":
   version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
-  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha1-159aIED3yqJNU+VjqtScvAVYEwg=
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -8644,10 +8644,15 @@ css-what@^3.2.1:
   resolved "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
 
-css@2.X, css@^2.2.1:
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@2.X, css@^2.2.1, css@^2.2.3:
   version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=
   dependencies:
     inherits "^2.0.3"
     source-map "^0.6.1"
@@ -13257,7 +13262,7 @@ jest-dev-server@^4.3.0:
     tree-kill "^1.2.1"
     wait-on "^3.3.0"
 
-jest-diff@^24.3.0, jest-diff@^24.8.0, jest-diff@^24.9.0:
+jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.8.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -17131,7 +17136,7 @@ pretty-format@^23.2.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.8.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.8.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4735,6 +4735,21 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@testing-library/jest-dom@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
+  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+  dependencies:
+    "@babel/runtime" "^7.5.1"
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^3.0.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -13395,7 +13410,7 @@ jest-matcher-utils@24.8.0:
     jest-get-type "^24.8.0"
     pretty-format "^24.8.0"
 
-jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -15368,6 +15383,11 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
+
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
 mini-create-react-context@^0.3.0:
   version "0.3.2"
@@ -18262,6 +18282,14 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 redeyed@~2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
@@ -19869,6 +19897,13 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,7 +2599,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.5.1", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3":
   version "7.8.4"
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha1-159aIED3yqJNU+VjqtScvAVYEwg=
@@ -3160,6 +3160,16 @@
   dependencies:
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
+
+"@jest/types@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
+  integrity sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
 
 "@lerna/add@3.11.0":
   version "3.11.0"
@@ -4735,19 +4745,20 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/jest-dom@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
-  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+"@testing-library/jest-dom@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.1.1.tgz#e88a5c08f9b9f36b384f948a0532eae2abbc8204"
+  integrity sha512-7xnmBFcUmmUVAUhFiZ/u3CxFh1e46THAwra4SiiKNCW4By26RedCRwEk0rtleFPZG0wlTSNOKDvJjWYy93dp0w==
   dependencies:
-    "@babel/runtime" "^7.5.1"
-    chalk "^2.4.1"
-    css "^2.2.3"
+    "@babel/runtime" "^7.8.3"
+    "@types/testing-library__jest-dom" "^5.0.0"
+    chalk "^3.0.0"
+    css "^2.2.4"
     css.escape "^1.5.1"
-    jest-diff "^24.0.0"
-    jest-matcher-utils "^24.0.0"
-    lodash "^4.17.11"
-    pretty-format "^24.0.0"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    pretty-format "^25.1.0"
     redent "^3.0.0"
 
 "@types/anymatch@*":
@@ -4824,6 +4835,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.0.tgz#926f76f7e66f49cc59ad880bb15b030abbf0b66d"
   integrity sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==
+
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/color@^3.0.0":
   version "3.0.0"
@@ -5278,6 +5294,13 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
   integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
 
+"@types/testing-library__jest-dom@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.1.tgz#cc7f384535a3d9597e27f58d38a795f5c137cc53"
+  integrity sha512-GiPXQBVF9O4DG9cssD2d266vozBJvC5Tnv6aeH5ujgYJgys1DYm9AFCz7YC+STR5ksGxq3zCt+yP8T1wbk2DFg==
+  dependencies:
+    "@types/jest" "*"
+
 "@types/through2@*":
   version "2.0.33"
   resolved "https://registry.yarnpkg.com/@types/through2/-/through2-2.0.33.tgz#1ff2e88a100dfb5b140e7bb98791f1194400d131"
@@ -5400,6 +5423,13 @@
   version "13.0.3"
   resolved "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
   integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.3.tgz#41453a0bc7ab393e995d1f5451455638edbd2baf"
+  integrity sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -6015,6 +6045,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 ansi-to-html@^0.6.11:
   version "0.6.13"
@@ -7529,6 +7567,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-case@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
@@ -7936,12 +7982,19 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -8649,7 +8702,7 @@ css.escape@^1.5.1:
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@2.X, css@^2.2.1, css@^2.2.3:
+css@2.X, css@^2.2.1, css@^2.2.4:
   version "2.2.4"
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=
@@ -9199,6 +9252,11 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
+diff-sequences@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.1.0.tgz#fd29a46f1c913fd66c22645dc75bffbe43051f32"
+  integrity sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==
 
 diff@^3.2.0:
   version "3.5.0"
@@ -11862,6 +11920,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -13262,7 +13325,7 @@ jest-dev-server@^4.3.0:
     tree-kill "^1.2.1"
     wait-on "^3.3.0"
 
-jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.8.0, jest-diff@^24.9.0:
+jest-diff@^24.3.0, jest-diff@^24.8.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -13271,6 +13334,16 @@ jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.8.0, jest-diff@^24.9.0:
     diff-sequences "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-diff@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.1.0.tgz#58b827e63edea1bc80c1de952b80cec9ac50e1ad"
+  integrity sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
 jest-docblock@^24.3.0:
   version "24.3.0"
@@ -13340,6 +13413,11 @@ jest-get-type@^24.8.0, jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
+  integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
 
 jest-haste-map@^24.5.0:
   version "24.5.0"
@@ -13415,7 +13493,7 @@ jest-matcher-utils@24.8.0:
     jest-get-type "^24.8.0"
     pretty-format "^24.8.0"
 
-jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -13424,6 +13502,16 @@ jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz#fa5996c45c7193a3c24e73066fc14acdee020220"
+  integrity sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
 jest-message-util@^24.5.0:
   version "24.5.0"
@@ -17136,7 +17224,7 @@ pretty-format@^23.2.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.0.0, pretty-format@^24.8.0, pretty-format@^24.9.0:
+pretty-format@^24.8.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -17145,6 +17233,16 @@ pretty-format@^24.0.0, pretty-format@^24.8.0, pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
+
+pretty-format@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
+  integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
 
 pretty-hrtime@^1.0.0, pretty-hrtime@^1.0.3:
   version "1.0.3"
@@ -17771,7 +17869,7 @@ react-inspector@^3.0.2:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
-react-is@^16.10.2, react-is@^16.8.3:
+react-is@^16.10.2, react-is@^16.12.0, react-is@^16.8.3:
   version "16.12.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -19981,6 +20079,13 @@ supports-color@^5.0.0, supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-hyperlinks@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,10 +4870,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/enzyme@^3.9.3":
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.9.3.tgz#d1029c0edd353d7b00f3924803eb88216460beed"
-  integrity sha512-jDKoZiiMA3lGO3skSO7dfqEHNvmiTLLV+PHD9EBQVlJANJvpY6qq1zzjRI24ZOtG7F+CS7BVWDXKewRmN8PjHQ==
+"@types/enzyme@^3.10.5":
+  version "3.10.5"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
+  integrity sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"


### PR DESCRIPTION
Tests changes:

- extend jest expect with jest-dom for more relevant assertions. Using assertions such as `toHaveFocus`, `toHaveTextContent`, `toHaveAttribute`.
- move utilities to separate file, including the refactored `render` method.
- simplify tests by getting all slots directly from the result of the render method, rather than querying them all the time in the tests.
- improve types in `withProvider` and updated `enzyme` types.