### PR TITLE
docs: Add component perf charts to public docsite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `@fluentui/styles` package for all styles' related utilities and TS types @layershifter, @mnajdova ([#2222](https://github.com/microsoft/fluent-ui-react/pull/2222))
 
 ### Fixes
-- Fix event lister leak in `FocusZone` @miroslavstastny ([#2227](https://github.com/microsoft/fluent-ui-react/pull/2227))
+- Fix event listener leak in `FocusZone` @miroslavstastny ([#2227](https://github.com/microsoft/fluent-ui-react/pull/2227))
 - Fix styleParam to always be required in the styles functions @layershifter, @mnajdova ([#2235](https://github.com/microsoft/fluent-ui-react/pull/2235))
 
 ### Features
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `useStyles()` hook to use theming capabilities in custom components @layershifter, @mnajdova ([#2217](https://github.com/microsoft/fluent-ui-react/pull/2217))
 
 ### Documentation
-- Add per-component performance charts @miroslavstastny ([#2240](https://github.com/microsoft/fluent-ui-react/pull/2240.))
+- Add per-component performance charts @miroslavstastny ([#2240](https://github.com/microsoft/fluent-ui-react/pull/2240))
 
 <!--------------------------------[ v0.43.0 ]------------------------------- -->
 ## [v0.43.0](https://github.com/microsoft/fluent-ui-react/tree/v0.43.0) (2020-01-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Allow `useRef` hook used for storing debugging data to be defined in any order with other hooks in functional components @layershifter, @mnajdova ([#2236](https://github.com/microsoft/fluent-ui-react/pull/2236))
 - Add `useStyles()` hook to use theming capabilities in custom components @layershifter, @mnajdova ([#2217](https://github.com/microsoft/fluent-ui-react/pull/2217))
 
+### Documentation
+- Add per-component performance charts @miroslavstastny ([#2240](https://github.com/microsoft/fluent-ui-react/pull/2240.))
+
 <!--------------------------------[ v0.43.0 ]------------------------------- -->
 ## [v0.43.0](https://github.com/microsoft/fluent-ui-react/tree/v0.43.0) (2020-01-08)
 [Compare changes](https://github.com/microsoft/fluent-ui-react/compare/v0.42.0..v0.43.0)

--- a/docs/src/components/ComponentDoc/ComponentPerfExample/ComponentPerfChart.tsx
+++ b/docs/src/components/ComponentDoc/ComponentPerfExample/ComponentPerfChart.tsx
@@ -90,16 +90,18 @@ export const ComponentPerfChart = ({ perfTestName }) => {
   return (
     <div>
       <Flex vAlign="center" gap="gap.large">
-        <RadioGroup
-          defaultCheckedValue={FILTER_BY.CI_BUILD}
-          checkedValueChanged={handleFilterChange}
-          items={[
-            { key: 'ci-build', label: FILTER_BY.CI_BUILD, value: FILTER_BY.CI_BUILD },
-            { key: 'release', label: FILTER_BY.RELEASE, value: FILTER_BY.RELEASE },
-            { key: 'day', label: FILTER_BY.DAY, value: FILTER_BY.DAY },
-            { key: 'month', label: FILTER_BY.MONTH, value: FILTER_BY.MONTH },
-          ]}
-        />
+        {process.env.NODE_ENV !== 'production' && (
+          <RadioGroup
+            defaultCheckedValue={FILTER_BY.CI_BUILD}
+            checkedValueChanged={handleFilterChange}
+            items={[
+              { key: 'ci-build', label: FILTER_BY.CI_BUILD, value: FILTER_BY.CI_BUILD },
+              { key: 'release', label: FILTER_BY.RELEASE, value: FILTER_BY.RELEASE },
+              { key: 'day', label: FILTER_BY.DAY, value: FILTER_BY.DAY },
+              { key: 'month', label: FILTER_BY.MONTH, value: FILTER_BY.MONTH },
+            ]}
+          />
+        )}
         <Checkbox
           label="Show extremes"
           defaultChecked={withExtremes}

--- a/docs/src/components/ComponentDoc/PerfChart/PerfDataProvider.tsx
+++ b/docs/src/components/ComponentDoc/PerfChart/PerfDataProvider.tsx
@@ -17,21 +17,18 @@ const PerfDataProvider: React.FC = ({ children }) => {
   const [data, setData] = React.useState()
 
   React.useEffect(() => {
-    if (process.env.NODE_ENV === 'production') {
-      setError(new Error('Stats data not available in production'))
-      setLoading(false)
-    } else {
-      fetch(config.getStatsUri)
-        .then(response => response.json())
-        .then(responseJson => {
-          setData(responseJson)
-          setLoading(false)
-        })
-        .catch(e => {
-          setError(e)
-          setLoading(false)
-        })
-    }
+    const query = process.env.NODE_ENV === 'production' ? '' : '?withPrivateBuilds=true'
+
+    fetch(`${config.getStatsUri}${query}`)
+      .then(response => response.json())
+      .then(responseJson => {
+        setData(responseJson)
+        setLoading(false)
+      })
+      .catch(e => {
+        setError(e)
+        setLoading(false)
+      })
   }, [])
 
   return (

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -1,5 +1,5 @@
 const config = {
-  getStatsUri: 'https://stardust.azurewebsites.net/api/GetPerfStats',
+  getStatsUri: 'https://fluent-ui-react-stats.azurewebsites.net/api/GetPerfStats',
 }
 
 export default config

--- a/docs/src/examples/components/Attachment/Performance/index.tsx
+++ b/docs/src/examples/components/Attachment/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
       examplePath="components/Attachment/Performance/AttachmentMinimal.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Button/Performance/index.tsx
+++ b/docs/src/examples/components/Button/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
       examplePath="components/Button/Performance/ButtonMinimal.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Chat/Performance/index.tsx
+++ b/docs/src/examples/components/Chat/Performance/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Duplicate Messages"
       description="Chat with many duplicate messages."
@@ -15,7 +15,7 @@ const Performance = () => (
       description="Chat with actions menu in a popover."
       examplePath="components/Chat/Performance/ChatWithPopover.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Divider/Performance/index.tsx
+++ b/docs/src/examples/components/Divider/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
       examplePath="components/Divider/Performance/DividerMinimal.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Dropdown/Performance/index.tsx
+++ b/docs/src/examples/components/Dropdown/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
       examplePath="components/Dropdown/Performance/DropdownManyItems.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Header/Performance/index.tsx
+++ b/docs/src/examples/components/Header/Performance/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
@@ -15,7 +15,7 @@ const Performance = () => (
       description="Header with no props."
       examplePath="components/Header/Performance/HeaderMinimal.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Icon/Performance/index.tsx
+++ b/docs/src/examples/components/Icon/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
       examplePath="components/Icon/Performance/IconMinimal.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/List/Performance/index.tsx
+++ b/docs/src/examples/components/List/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Common"
       description="A typical list with common slots filled."
       examplePath="components/List/Performance/ListCommon.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Loader/Performance/index.tsx
+++ b/docs/src/examples/components/Loader/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Default"
       description="A default test."
       examplePath="components/Loader/Performance/LoaderMinimal.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Provider/Performance/index.tsx
+++ b/docs/src/examples/components/Provider/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Merge themes"
       description="mergeThemes perf"
       examplePath="components/Provider/Performance/ProviderMergeThemes.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance

--- a/docs/src/examples/components/Toolbar/Performance/index.tsx
+++ b/docs/src/examples/components/Toolbar/Performance/index.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
 import ComponentPerfExample from 'docs/src/components/ComponentDoc/ComponentPerfExample'
-import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection'
+import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
 const Performance = () => (
-  <NonPublicSection title="Performance">
+  <ExampleSection title="Performance">
     <ComponentPerfExample
       title="Custom styled"
       description="Custom styled toolbar"
       examplePath="components/Toolbar/Performance/CustomToolbar.perf"
     />
-  </NonPublicSection>
+  </ExampleSection>
 )
 
 export default Performance


### PR DESCRIPTION
Enable per-component perf charts in production docsite.
Filter results to public builds only.

![image](https://user-images.githubusercontent.com/9615899/72385423-c06b6900-371f-11ea-9ada-103c83e25f8e.png)

Depends on changes in GetPerfStats: miroslavstastny/stardust-stats-azure/pull/5