### PR TITLE
Remove path aliases from tests

### DIFF
--- a/.github/test-a-feature.md
+++ b/.github/test-a-feature.md
@@ -51,9 +51,9 @@ These tests are typically imported into individual component tests.
 Every common test receives your component as its first argument.
 
 ```tsx
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Divider from 'src/components/Divider/Divider'
+import { Divider } from '@fluentui/react'
 
 describe('Divider', () => {
   isConformant(Divider)
@@ -85,9 +85,9 @@ There should be one describe block for each prop of your component.
 Example for `Button` component:
 
 ```tsx
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Button from 'src/components/Button'
+import { Button } from '@fluentui/react'
 
 describe('Button', () => {
   isConformant(Button)
@@ -242,7 +242,7 @@ Add your spec file into the array of files `skipSpecChecksForFiles` in `testHelp
 
 ## Performance Tests
 
-Performance tests will measure performance, set a baseline for performance and help guard against regressions. 
+Performance tests will measure performance, set a baseline for performance and help guard against regressions.
 
 ### Adding a Perf Test
 

--- a/build/screener/screener.config.js
+++ b/build/screener/screener.config.js
@@ -1,7 +1,10 @@
 require('@fluentui/internal-tooling/babel/register')
 
 const config = require('../config').default
-const { compilerOptions } = require('../tsconfig.docs.json')
+
+// Ensure that paths to local packages are interpreted properly
+// (see https://github.com/microsoft/fluent-ui-react/pull/837)
+const { compilerOptions } = require('../../tsconfig.json')
 
 require('tsconfig-paths').register({
   baseUrl: config.path_base,

--- a/build/tsconfig.common.json
+++ b/build/tsconfig.common.json
@@ -3,14 +3,6 @@
     "module": "commonjs",
     "target": "es5",
     "lib": ["es2015", "dom"],
-    "baseUrl": "../",
-    "paths": {
-      "@fluentui/docs": ["docs"],
-      "@fluentui/e2e": ["e2e"],
-      "@fluentui/internal-tooling": ["build"],
-      "@fluentui/perf": ["perf"],
-      "@fluentui/*": ["packages/*/src"]
-    },
     "types": ["node", "jest"],
     "typeRoots": ["../types", "../node_modules/@types"],
     "jsx": "react",

--- a/build/tsconfig.docs.json
+++ b/build/tsconfig.docs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
     "module": "esnext",
+    "baseUrl": "../",
     "paths": {
       "@fluentui/*": ["packages/*/src"],
       "docs/*": ["docs/*"],

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -4,16 +4,18 @@ import * as tsPaths from 'tsconfig-paths'
 
 import config from './build/config'
 
-const { compilerOptions } = require('./build/tsconfig.docs.json')
-
-// add node_modules/.bin to the path so we can invoke .bin CLIs in tasks
-process.env.PATH =
-  process.env.PATH + path.delimiter + path.resolve(__dirname, 'node_modules', '.bin')
+// Ensure that paths to local packages are interpreted properly
+// (see https://github.com/microsoft/fluent-ui-react/pull/837)
+const { compilerOptions } = require('./tsconfig.json')
 
 tsPaths.register({
   baseUrl: config.path_base,
   paths: compilerOptions.paths,
 })
+
+// add node_modules/.bin to the path so we can invoke .bin CLIs in tasks
+process.env.PATH =
+  process.env.PATH + path.delimiter + path.resolve(__dirname, 'node_modules', '.bin')
 
 // load tasks in order of dependency usage
 require('./build/gulp/tasks/bundle')

--- a/packages/accessibility/test/behaviors/behavior-test.tsx
+++ b/packages/accessibility/test/behaviors/behavior-test.tsx
@@ -83,6 +83,7 @@ import {
 import { TestHelper } from './testHelper'
 import definitions from './testDefinitions'
 
+// TODO (@ecraig12345) - remove relative docs import
 const behaviorMenuItems = require('../../../../docs/src/behaviorMenu')
 
 const testHelper = new TestHelper()

--- a/packages/accessibility/tsconfig.json
+++ b/packages/accessibility/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../build/tsconfig.common",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist/dts"
+    "outDir": "dist/dts",
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/accessibility": ["./src"]
+    }
   },
   "include": ["src", "test"]
 }

--- a/packages/react-bindings/test/accesibility/getKeyDownHandlers-test.ts
+++ b/packages/react-bindings/test/accesibility/getKeyDownHandlers-test.ts
@@ -1,3 +1,4 @@
+// This is not exported
 import getKeyDownHandlers from '../../src/accessibility/getKeyDownHandlers'
 // @ts-ignore
 import * as keyboardKey from 'keyboard-key'

--- a/packages/react-bindings/test/accesibility/shouldHandleOnKeys-test.ts
+++ b/packages/react-bindings/test/accesibility/shouldHandleOnKeys-test.ts
@@ -1,3 +1,4 @@
+// This is not exported
 import shouldHandleOnKeys from '../../src/accessibility/shouldHandleOnKeys'
 
 const getEventArg = (

--- a/packages/react-bindings/test/styles/resolveStylesAndClasses-test.ts
+++ b/packages/react-bindings/test/styles/resolveStylesAndClasses-test.ts
@@ -4,7 +4,7 @@ import {
   emptyTheme,
   ICSSInJSStyle,
 } from '@fluentui/styles'
-import resolveStylesAndClasses from '../../src/styles/resolveStylesAndClasses'
+import resolveStylesAndClasses from '@fluentui/react-bindings/src/styles/resolveStylesAndClasses'
 
 const styleParam: ComponentStyleFunctionParam = {
   disableAnimations: false,

--- a/packages/react-bindings/test/styles/resolveStylesAndClasses-test.ts
+++ b/packages/react-bindings/test/styles/resolveStylesAndClasses-test.ts
@@ -4,7 +4,8 @@ import {
   emptyTheme,
   ICSSInJSStyle,
 } from '@fluentui/styles'
-import resolveStylesAndClasses from '@fluentui/react-bindings/src/styles/resolveStylesAndClasses'
+// This is not exported
+import resolveStylesAndClasses from '../../src/styles/resolveStylesAndClasses'
 
 const styleParam: ComponentStyleFunctionParam = {
   disableAnimations: false,

--- a/packages/react-bindings/tsconfig.json
+++ b/packages/react-bindings/tsconfig.json
@@ -7,7 +7,12 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react-bindings": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": [

--- a/packages/react-component-event-listener/tsconfig.json
+++ b/packages/react-component-event-listener/tsconfig.json
@@ -7,7 +7,12 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react-component-event-listener": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": []

--- a/packages/react-component-nesting-registry/tsconfig.json
+++ b/packages/react-component-nesting-registry/tsconfig.json
@@ -7,7 +7,12 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react-component-nesting-registry": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": []

--- a/packages/react-component-ref/tsconfig.json
+++ b/packages/react-component-ref/tsconfig.json
@@ -7,7 +7,12 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react-component-ref": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": []

--- a/packages/react-proptypes/tsconfig.json
+++ b/packages/react-proptypes/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../build/tsconfig.common",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist/dts"
+    "outDir": "dist/dts",
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react-proptypes": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": []

--- a/packages/react-theming/tsconfig.json
+++ b/packages/react-theming/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react-theming": ["./src"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -3,12 +3,5 @@ const commonConfig = require('@fluentui/internal-tooling/jest')
 module.exports = {
   ...commonConfig,
   name: 'react',
-  moduleNameMapper: {
-    ...require('lerna-alias').jest(),
-    'docs/(.*)$': `<rootDir>/../../docs/$1`,
-
-    // Legacy aliases, they should not be used in new tests
-    '^src/(.*)$': `<rootDir>/src/$1`,
-    'test/(.*)$': `<rootDir>/test/$1`,
-  },
+  moduleNameMapper: require('lerna-alias').jest(),
 }

--- a/packages/react/test/specs/commonTests/handlesAccessibility.tsx
+++ b/packages/react/test/specs/commonTests/handlesAccessibility.tsx
@@ -8,8 +8,8 @@ import { FocusZone, FOCUSZONE_WRAP_ATTRIBUTE } from '@fluentui/react-bindings'
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
-import { mountWithProviderAndGetComponent, mountWithProvider } from 'test/utils'
-import { UIComponent } from 'src/utils'
+import { mountWithProviderAndGetComponent, mountWithProvider } from '../../utils'
+import { UIComponent } from '@fluentui/react'
 import { EVENT_TARGET_ATTRIBUTE, getEventTargetComponent } from './eventTarget'
 
 export const getRenderedAttribute = (renderedComponent, propName, partSelector) => {

--- a/packages/react/test/specs/commonTests/htmlIsAccessibilityCompliant.ts
+++ b/packages/react/test/specs/commonTests/htmlIsAccessibilityCompliant.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as ReactDOMServer from 'react-dom/server'
 import { axe, toHaveNoViolations } from 'jest-axe'
-import { EmptyThemeProvider } from 'test/utils'
+import { EmptyThemeProvider } from '../../utils'
 
 type AxeMatcher<R> = jest.Matchers<R, any> & {
   toHaveNoViolations: () => R

--- a/packages/react/test/specs/commonTests/implementsCollectionShorthandProp.tsx
+++ b/packages/react/test/specs/commonTests/implementsCollectionShorthandProp.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { mountWithProvider as mount } from 'test/utils'
+import { mountWithProvider as mount } from '../../utils'
 import * as _ from 'lodash'
-import { PropsOf } from 'src/types'
+import { PropsOf } from '@fluentui/react'
 
 export type CollectionShorthandTestOptions<TProps = any> = {
   mapsValueToProp: keyof (TProps & React.HTMLProps<HTMLElement>) | false

--- a/packages/react/test/specs/commonTests/implementsShorthandProp.tsx
+++ b/packages/react/test/specs/commonTests/implementsShorthandProp.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { ReactWrapper } from 'enzyme'
-import { mountWithProvider } from 'test/utils'
-import { Props, PropsOf, InstanceOf } from 'src/types'
+import { mountWithProvider } from '../../utils'
+import { Props, PropsOf, InstanceOf } from '@fluentui/react'
 
 export type ShorthandTestOptions<TProps = any> = {
   mapsValueToProp: keyof (TProps & React.HTMLProps<HTMLElement>) | false

--- a/packages/react/test/specs/commonTests/implementsWrapperProp.tsx
+++ b/packages/react/test/specs/commonTests/implementsWrapperProp.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
 import { ReactWrapper } from 'enzyme'
-import { mountWithProvider as mount } from 'test/utils'
+import { mountWithProvider as mount } from '../../utils'
 
-import Box from 'src/components/Box/Box'
-import { Props, ShorthandValue } from 'src/types'
+import { Box, Props, ShorthandValue } from '@fluentui/react'
 
 export interface ImplementsWrapperPropOptions {
   wrapppedComponentSelector: any

--- a/packages/react/test/specs/commonTests/isConformant.tsx
+++ b/packages/react/test/specs/commonTests/isConformant.tsx
@@ -14,10 +14,10 @@ import {
   getDisplayName,
   mountWithProvider as mount,
   syntheticEvent,
-} from 'test/utils'
+} from '../../utils'
 import helpers from './commonHelpers'
 
-import * as FluentUI from 'src/index'
+import * as FluentUI from '@fluentui/react'
 import { getEventTargetComponent, EVENT_TARGET_ATTRIBUTE } from './eventTarget'
 
 export interface Conformant {
@@ -112,7 +112,8 @@ export default function isConformant(
   // This is pretty ugly because:
   // - jest doesn't support custom error messages
   // - jest will run all test
-  const infoJSONPath = `docs/src/componentInfo/${constructorName}.info.json`
+  // TODO (@ecraig12345) - remove relative docs import
+  const infoJSONPath = `../../../../../docs/src/componentInfo/${constructorName}.info.json`
 
   let info
 
@@ -124,7 +125,7 @@ export default function isConformant(
       throw new Error(
         [
           '!! ==========================================================',
-          `!! Missing ${infoJSONPath}.`,
+          `!! Missing ${infoJSONPath.replace('../../../../../', '')}.`,
           '!! Run `yarn test` or `yarn test:watch` again to generate one.',
           '!! ==========================================================',
         ].join('\n'),

--- a/packages/react/test/specs/commonTests/isExportedAtTopLevel.tsx
+++ b/packages/react/test/specs/commonTests/isExportedAtTopLevel.tsx
@@ -1,5 +1,5 @@
 import * as _ from 'lodash'
-import * as FluentUI from 'src/index'
+import * as FluentUI from '@fluentui/react'
 
 // ----------------------------------------
 // Is exported or private
@@ -12,7 +12,7 @@ export default (constructorName: string, displayName: string) => {
   test('is exported at the top level', () => {
     const message = [
       `'${displayName}' must be exported at top level.`,
-      "Export it in 'src/index.js'.",
+      "Export it in 'src/index.ts'.",
     ].join(' ')
 
     expect({ isTopLevelAPIProp, message }).toEqual({

--- a/packages/react/test/specs/commonTests/stylesFunction-test.tsx
+++ b/packages/react/test/specs/commonTests/stylesFunction-test.tsx
@@ -2,8 +2,8 @@ import { Extendable, ICSSInJSStyle } from '@fluentui/styles'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
-import { UIComponent } from 'src/utils'
-import { mountWithProviderAndGetComponent } from 'test/utils'
+import { UIComponent } from '@fluentui/react'
+import { mountWithProviderAndGetComponent } from '../../utils'
 
 type AttrValue = 'props' | 'state'
 

--- a/packages/react/test/specs/components/Accordion/Accordion-test.tsx
+++ b/packages/react/test/specs/components/Accordion/Accordion-test.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
-import Accordion from 'src/components/Accordion/Accordion'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProvider, mountWithProviderAndGetComponent } from 'test/utils'
-import AccordionTitle from 'src/components/Accordion/AccordionTitle'
+import { Accordion, AccordionTitle } from '@fluentui/react'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { mountWithProvider, mountWithProviderAndGetComponent } from '../../../utils'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
 
 const panels = [

--- a/packages/react/test/specs/components/Accordion/AccordionContent-test.tsx
+++ b/packages/react/test/specs/components/Accordion/AccordionContent-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
-import AccordionContent from 'src/components/Accordion/AccordionContent'
-import { isConformant, handlesAccessibility, getRenderedAttribute } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
+import { AccordionContent } from '@fluentui/react'
+import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
 
 describe('AccordionContent', () => {
   isConformant(AccordionContent)

--- a/packages/react/test/specs/components/Accordion/AccordionTitle-test.tsx
+++ b/packages/react/test/specs/components/Accordion/AccordionTitle-test.tsx
@@ -1,5 +1,5 @@
-import AccordionTitle from 'src/components/Accordion/AccordionTitle'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
+import { AccordionTitle } from '@fluentui/react'
+import { isConformant, handlesAccessibility } from '../../commonTests'
 
 describe('AccordionTitle', () => {
   isConformant(AccordionTitle, {

--- a/packages/react/test/specs/components/Alert/Alert-test.tsx
+++ b/packages/react/test/specs/components/Alert/Alert-test.tsx
@@ -5,11 +5,9 @@ import {
   implementsShorthandProp,
   handlesAccessibility,
   htmlIsAccessibilityCompliant,
-} from 'test/specs/commonTests'
+} from '../../commonTests'
 
-import Alert from 'src/components/Alert/Alert'
-import Box from 'src/components/Box/Box'
-import Button from 'src/components/Button/Button'
+import { Alert, Box, Button } from '@fluentui/react'
 
 const alertImplementsShorthandProp = implementsShorthandProp(Alert)
 

--- a/packages/react/test/specs/components/Animation/Animation-test.tsx
+++ b/packages/react/test/specs/components/Animation/Animation-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Animation from 'src/components/Animation/Animation'
+import { Animation } from '@fluentui/react'
 
 describe('Animation', () => {
   isConformant(Animation, { hasAccessibilityProp: false })

--- a/packages/react/test/specs/components/Attachment/Attachment-test.tsx
+++ b/packages/react/test/specs/components/Attachment/Attachment-test.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react'
-import { isConformant, implementsShorthandProp, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProvider, findIntrinsicElement } from 'test/utils'
+import { isConformant, implementsShorthandProp, handlesAccessibility } from '../../commonTests'
+import { mountWithProvider, findIntrinsicElement } from '../../../utils'
 import * as keyboardKey from 'keyboard-key'
 
-import Attachment from 'src/components/Attachment/Attachment'
-import Text from 'src/components/Text/Text'
-import Icon from 'src/components/Icon/Icon'
-import Button from 'src/components/Button/Button'
+import { Attachment, Text, Icon, Button } from '@fluentui/react'
 import { ReactWrapper } from 'enzyme'
 
 const attachmentImplementsShorthandProp = implementsShorthandProp(Attachment)

--- a/packages/react/test/specs/components/Avatar/Avatar-test.tsx
+++ b/packages/react/test/specs/components/Avatar/Avatar-test.tsx
@@ -1,8 +1,6 @@
-import { implementsShorthandProp, isConformant } from 'test/specs/commonTests'
+import { implementsShorthandProp, isConformant } from '../../commonTests'
 
-import Avatar from 'src/components/Avatar/Avatar'
-import Label from 'src/components/Label/Label'
-import Image from 'src/components/Image/Image'
+import { Avatar, Label, Image } from '@fluentui/react'
 
 const avatarImplementsShorthandProp = implementsShorthandProp(Avatar)
 const { getInitials } = (Avatar as any).defaultProps

--- a/packages/react/test/specs/components/Button/Button-test.tsx
+++ b/packages/react/test/specs/components/Button/Button-test.tsx
@@ -6,12 +6,11 @@ import {
   htmlIsAccessibilityCompliant,
   implementsShorthandProp,
   getRenderedAttribute,
-} from 'test/specs/commonTests'
-import { mountWithProvider, mountWithProviderAndGetComponent } from 'test/utils'
+} from '../../commonTests'
+import { mountWithProvider, mountWithProviderAndGetComponent } from '../../../utils'
 import { toggleButtonBehavior } from '@fluentui/accessibility'
 
-import Button from 'src/components/Button/Button'
-import Icon from 'src/components/Icon/Icon'
+import { Button, Icon } from '@fluentui/react'
 
 const buttonImplementsShorthandProp = implementsShorthandProp(Button)
 

--- a/packages/react/test/specs/components/Button/ButtonGroup-test.tsx
+++ b/packages/react/test/specs/components/Button/ButtonGroup-test.tsx
@@ -1,7 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
-import ButtonGroup from 'src/components/Button/ButtonGroup'
+import { isConformant } from '../../commonTests'
+import { ButtonGroup, Button } from '@fluentui/react'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
-import Button from 'src/components/Button/Button'
 
 const buttonGroupImplementsCollectionShorthandProp = implementsCollectionShorthandProp(ButtonGroup)
 

--- a/packages/react/test/specs/components/Carousel/Carousel-test.tsx
+++ b/packages/react/test/specs/components/Carousel/Carousel-test.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react'
 
-import { isConformant } from 'test/specs/commonTests'
-import Carousel, { CarouselProps } from 'src/components/Carousel/Carousel'
-import CarouselItem from 'src/components/Carousel/CarouselItem'
-import CarouselNavigation from 'src/components/Carousel/CarouselNavigation'
-import CarouselNavigationItem from 'src/components/Carousel/CarouselNavigationItem'
-import Text from 'src/components/Text/Text'
+import { isConformant } from '../../commonTests'
+import {
+  Carousel,
+  CarouselProps,
+  CarouselItem,
+  CarouselNavigation,
+  CarouselNavigationItem,
+  Text,
+} from '@fluentui/react'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
-import { findIntrinsicElement, mountWithProvider } from 'test/utils'
+import { findIntrinsicElement, mountWithProvider } from '../../../utils'
 
 const items = [
   {

--- a/packages/react/test/specs/components/Carousel/CarouselItem-test.tsx
+++ b/packages/react/test/specs/components/Carousel/CarouselItem-test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 
-import { isConformant } from 'test/specs/commonTests'
-import CarouselItem, { CarouselItemProps } from 'src/components/Carousel/CarouselItem'
+import { isConformant } from '../../commonTests'
+import { CarouselItem, CarouselItemProps } from '@fluentui/react'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
-import { findIntrinsicElement, mountWithProvider } from 'test/utils'
+import { findIntrinsicElement, mountWithProvider } from '../../../utils'
 
 function renderCarouselItem(props?: CarouselItemProps): ReactWrapper {
   return mountWithProvider(<CarouselItem {...props} />)

--- a/packages/react/test/specs/components/Carousel/CarouselNavigation-test.tsx
+++ b/packages/react/test/specs/components/Carousel/CarouselNavigation-test.tsx
@@ -1,5 +1,5 @@
-import { isConformant } from 'test/specs/commonTests'
-import CarouselNavigation from 'src/components/Carousel/CarouselNavigation'
+import { isConformant } from '../../commonTests'
+import { CarouselNavigation } from '@fluentui/react'
 
 describe('CarouselNavigation', () => {
   isConformant(CarouselNavigation)

--- a/packages/react/test/specs/components/Carousel/CarouselNavigationItem-test.tsx
+++ b/packages/react/test/specs/components/Carousel/CarouselNavigationItem-test.tsx
@@ -1,5 +1,5 @@
-import { isConformant } from 'test/specs/commonTests'
-import CarouselNavigationItem from 'src/components/Carousel/CarouselNavigationItem'
+import { isConformant } from '../../commonTests'
+import { CarouselNavigationItem } from '@fluentui/react'
 
 describe('CarouselNavigationItem', () => {
   isConformant(CarouselNavigationItem)

--- a/packages/react/test/specs/components/Chat/Chat-test.ts
+++ b/packages/react/test/specs/components/Chat/Chat-test.ts
@@ -1,9 +1,8 @@
 import { chatBehavior, AccessibilityDefinition } from '@fluentui/accessibility'
-import { handlesAccessibility, isConformant } from 'test/specs/commonTests'
+import { handlesAccessibility, isConformant } from '../../commonTests'
 
-import Chat from 'src/components/Chat/Chat'
+import { Chat, ChatItem } from '@fluentui/react'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
-import ChatItem from 'src/components/Chat/ChatItem'
 
 const chatImplementsCollectionShorthandProp = implementsCollectionShorthandProp(Chat)
 

--- a/packages/react/test/specs/components/Chat/ChatItem-test.tsx
+++ b/packages/react/test/specs/components/Chat/ChatItem-test.tsx
@@ -1,6 +1,5 @@
-import { isConformant, implementsShorthandProp } from 'test/specs/commonTests'
-import ChatItem from 'src/components/Chat/ChatItem'
-import Box from 'src/components/Box/Box'
+import { isConformant, implementsShorthandProp } from '../../commonTests'
+import { ChatItem, Box } from '@fluentui/react'
 
 const chatItemImplementsShorthandProp = implementsShorthandProp(ChatItem)
 

--- a/packages/react/test/specs/components/Chat/ChatMessage-test.tsx
+++ b/packages/react/test/specs/components/Chat/ChatMessage-test.tsx
@@ -1,12 +1,10 @@
 import { chatMessageBehavior, AccessibilityDefinition } from '@fluentui/accessibility'
 import * as React from 'react'
 
-import { handlesAccessibility, implementsShorthandProp, isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { handlesAccessibility, implementsShorthandProp, isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 
-import ChatMessage from 'src/components/Chat/ChatMessage'
-import Text from 'src/components/Text/Text'
-import Box from 'src/components/Box/Box'
+import { ChatMessage, Text, Box } from '@fluentui/react'
 
 const chatMessageImplementsShorthandProp = implementsShorthandProp(ChatMessage)
 

--- a/packages/react/test/specs/components/Checkbox/Checkbox-test.tsx
+++ b/packages/react/test/specs/components/Checkbox/Checkbox-test.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react'
-import Checkbox from 'src/components/Checkbox/Checkbox'
-import {
-  isConformant,
-  handlesAccessibility,
-  htmlIsAccessibilityCompliant,
-} from 'test/specs/commonTests'
+import { Checkbox } from '@fluentui/react'
+import { isConformant, handlesAccessibility, htmlIsAccessibilityCompliant } from '../../commonTests'
 
 describe('Checkbox', () => {
   isConformant(Checkbox)

--- a/packages/react/test/specs/components/Debug/utils-test.ts
+++ b/packages/react/test/specs/components/Debug/utils-test.ts
@@ -1,4 +1,10 @@
-import { find, isOverridden, filter, getValues, removeNulls } from 'src/components/Debug/utils'
+import {
+  find,
+  isOverridden,
+  filter,
+  getValues,
+  removeNulls,
+} from '@fluentui/react/src/components/Debug/utils'
 
 describe('debugUtils', () => {
   describe('find', () => {

--- a/packages/react/test/specs/components/Debug/utils-test.ts
+++ b/packages/react/test/specs/components/Debug/utils-test.ts
@@ -1,10 +1,11 @@
+// These are not exported
 import {
   find,
   isOverridden,
   filter,
   getValues,
   removeNulls,
-} from '@fluentui/react/src/components/Debug/utils'
+} from '../../../../src/components/Debug/utils'
 
 describe('debugUtils', () => {
   describe('find', () => {

--- a/packages/react/test/specs/components/Dialog/Dialog-test.tsx
+++ b/packages/react/test/specs/components/Dialog/Dialog-test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 
-import Dialog from 'src/components/Dialog/Dialog'
-import Button from 'src/components/Button/Button'
-import { mountWithProvider, findIntrinsicElement } from 'test/utils'
+import { Dialog, Button } from '@fluentui/react'
+import { mountWithProvider, findIntrinsicElement } from '../../../utils'
 
 describe('Dialog', () => {
   describe('content', () => {

--- a/packages/react/test/specs/components/Dialog/DialogFooter-test.tsx
+++ b/packages/react/test/specs/components/Dialog/DialogFooter-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import DialogFooter from 'src/components/Dialog/DialogFooter'
+import { DialogFooter } from '@fluentui/react'
 
 describe('DialogFooter', () => {
   isConformant(DialogFooter)

--- a/packages/react/test/specs/components/Divider/Divider-test.tsx
+++ b/packages/react/test/specs/components/Divider/Divider-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Divider from 'src/components/Divider/Divider'
+import { Divider } from '@fluentui/react'
 
 describe('Divider', () => {
   isConformant(Divider)

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2,14 +2,10 @@ import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 import * as _ from 'lodash'
 
-import Dropdown from 'src/components/Dropdown/Dropdown'
-import DropdownSearchInput from 'src/components/Dropdown/DropdownSearchInput'
-import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
-import { isConformant } from 'test/specs/commonTests'
-import { findIntrinsicElement, mountWithProvider } from 'test/utils'
+import { Dropdown, DropdownSearchInput, DropdownItemProps, ShorthandValue } from '@fluentui/react'
+import { isConformant } from '../../commonTests'
+import { findIntrinsicElement, mountWithProvider } from '../../../utils'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
-import { DropdownItemProps } from 'src/components/Dropdown/DropdownItem'
-import { ShorthandValue } from 'src/types'
 
 jest.dontMock('keyboard-key')
 jest.useFakeTimers()

--- a/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2,7 +2,13 @@ import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 import * as _ from 'lodash'
 
-import { Dropdown, DropdownSearchInput, DropdownItemProps, ShorthandValue } from '@fluentui/react'
+import {
+  Dropdown,
+  DropdownSearchInput,
+  DropdownItemProps,
+  DropdownSelectedItem,
+  ShorthandValue,
+} from '@fluentui/react'
 import { isConformant } from '../../commonTests'
 import { findIntrinsicElement, mountWithProvider } from '../../../utils'
 import { ReactWrapper, CommonWrapper } from 'enzyme'

--- a/packages/react/test/specs/components/Dropdown/DropdownSelectedItem-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/DropdownSelectedItem-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
-import DropdownSelectedItem from 'src/components/Dropdown/DropdownSelectedItem'
-import { getRenderedAttribute } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
+import { DropdownSelectedItem } from '@fluentui/react'
+import { getRenderedAttribute } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
 
 describe('DropdownSelectedItem', () => {
   describe('active', () => {

--- a/packages/react/test/specs/components/Embed/Embed-test.tsx
+++ b/packages/react/test/specs/components/Embed/Embed-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import Embed from 'src/components/Embed/Embed'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
+import { Embed } from '@fluentui/react'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
 
 describe('Embed', () => {
   isConformant(Embed)

--- a/packages/react/test/specs/components/Form/Form-test.tsx
+++ b/packages/react/test/specs/components/Form/Form-test.tsx
@@ -1,8 +1,7 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Form from 'src/components/Form/Form'
+import { Form, FormField } from '@fluentui/react'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
-import FormField from 'src/components/Form/FormField'
 
 const formImplementsCollectionShorthandProp = implementsCollectionShorthandProp(Form)
 

--- a/packages/react/test/specs/components/Form/FormField-test.tsx
+++ b/packages/react/test/specs/components/Form/FormField-test.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react'
 
-import { isConformant, implementsShorthandProp } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
-import Button from 'src/components/Button/Button'
-import RadioGroup from 'src/components/RadioGroup/RadioGroup'
-import Input from 'src/components/Input/Input'
-import Text from 'src/components/Text/Text'
-import FormField from 'src/components/Form/FormField'
-import Box from 'src/components/Box/Box'
+import { isConformant, implementsShorthandProp } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
+import { Button, RadioGroup, Input, Text, FormField, Box } from '@fluentui/react'
 
 const formFieldImplementsShorthandProp = implementsShorthandProp(FormField)
 

--- a/packages/react/test/specs/components/Grid/Grid-test.tsx
+++ b/packages/react/test/specs/components/Grid/Grid-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Grid from 'src/components/Grid/Grid'
+import { Grid } from '@fluentui/react'
 
 describe('Grid', () => {
   isConformant(Grid)

--- a/packages/react/test/specs/components/Header/Header-test.ts
+++ b/packages/react/test/specs/components/Header/Header-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Header from 'src/components/Header/Header'
+import { Header } from '@fluentui/react'
 
 describe('Header', () => {
   isConformant(Header)

--- a/packages/react/test/specs/components/Header/HeaderDescription-test.ts
+++ b/packages/react/test/specs/components/Header/HeaderDescription-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import HeaderDescription from 'src/components/Header/HeaderDescription'
+import { HeaderDescription } from '@fluentui/react'
 
 describe('HeaderDescription', () => {
   isConformant(HeaderDescription)

--- a/packages/react/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
+++ b/packages/react/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
-import HierarchicalTree from 'src/components/HierarchicalTree/HierarchicalTree'
-import HierarchicalTreeTitle from 'src/components/HierarchicalTree/HierarchicalTreeTitle'
-import HierarchicalTreeItem from 'src/components/HierarchicalTree/HierarchicalTreeItem'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
+import { HierarchicalTree, HierarchicalTreeTitle, HierarchicalTreeItem } from '@fluentui/react'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
 
 const items = [

--- a/packages/react/test/specs/components/Icon/Icon-test.tsx
+++ b/packages/react/test/specs/components/Icon/Icon-test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
 
 import Icon from '../../../../src/components/Icon/Icon'
-import { mountWithProviderAndGetComponent } from 'test/utils'
+import { mountWithProviderAndGetComponent } from '../../../utils'
 
 describe('Icon', () => {
   isConformant(Icon, { requiredProps: { name: 'at' } })

--- a/packages/react/test/specs/components/Icon/Icon-test.tsx
+++ b/packages/react/test/specs/components/Icon/Icon-test.tsx
@@ -2,7 +2,7 @@ import { ThemeInput } from '@fluentui/styles'
 import * as React from 'react'
 import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
 
-import Icon from '../../../../src/components/Icon/Icon'
+import { Icon } from '@fluentui/react'
 import { mountWithProviderAndGetComponent } from '../../../utils'
 
 describe('Icon', () => {

--- a/packages/react/test/specs/components/Image/Image-test.tsx
+++ b/packages/react/test/specs/components/Image/Image-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { isConformant, handlesAccessibility, getRenderedAttribute } from 'test/specs/commonTests'
+import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
 
-import Image from 'src/components/Image/Image'
-import { mountWithProviderAndGetComponent } from 'test/utils'
+import { Image } from '@fluentui/react'
+import { mountWithProviderAndGetComponent } from '../../../utils'
 
 describe('Image', () => {
   isConformant(Image)

--- a/packages/react/test/specs/components/Input/Input-test.tsx
+++ b/packages/react/test/specs/components/Input/Input-test.tsx
@@ -3,16 +3,10 @@ import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
 import { ReactWrapper } from 'enzyme'
-import { mountWithProvider as mount } from 'test/utils'
-import {
-  isConformant,
-  implementsShorthandProp,
-  implementsWrapperProp,
-} from 'test/specs/commonTests'
+import { mountWithProvider as mount } from '../../../utils'
+import { isConformant, implementsShorthandProp, implementsWrapperProp } from '../../commonTests'
 
-import Input from 'src/components/Input/Input'
-import Icon from 'src/components/Icon/Icon'
-import Box from 'src/components/Box/Box'
+import { Input, Icon, Box } from '@fluentui/react'
 
 const testValue = 'test value'
 const htmlInputAttrs = ['id', 'name', 'pattern', 'placeholder', 'type', 'value']

--- a/packages/react/test/specs/components/ItemLayout/ItemLayout-test.ts
+++ b/packages/react/test/specs/components/ItemLayout/ItemLayout-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import ItemLayout from 'src/components/ItemLayout/ItemLayout'
+import { ItemLayout } from '@fluentui/react'
 
 describe('ItemLayout', () => {
   isConformant(ItemLayout, { hasAccessibilityProp: false })

--- a/packages/react/test/specs/components/Label/Label-test.tsx
+++ b/packages/react/test/specs/components/Label/Label-test.tsx
@@ -1,8 +1,6 @@
-import { isConformant, implementsShorthandProp } from 'test/specs/commonTests'
+import { isConformant, implementsShorthandProp } from '../../commonTests'
 
-import Label from 'src/components/Label/Label'
-import Icon from 'src/components/Icon/Icon'
-import Image from 'src/components/Image/Image'
+import { Label, Icon, Image } from '@fluentui/react'
 
 const labelImplementsShorthandProp = implementsShorthandProp(Label)
 

--- a/packages/react/test/specs/components/Layout/Layout-test.ts
+++ b/packages/react/test/specs/components/Layout/Layout-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Layout from 'src/components/Layout/Layout'
+import { Layout } from '@fluentui/react'
 
 describe('Layout', () => {
   isConformant(Layout, { hasAccessibilityProp: false })

--- a/packages/react/test/specs/components/List/List-test.tsx
+++ b/packages/react/test/specs/components/List/List-test.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
 
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 
-import List from 'src/components/List/List'
+import { List, ListItem, ListItemProps } from '@fluentui/react'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
-import ListItem, { ListItemProps } from 'src/components/List/ListItem'
 
 const listImplementsCollectionShorthandProp = implementsCollectionShorthandProp(List)
 

--- a/packages/react/test/specs/components/List/ListItem-test.tsx
+++ b/packages/react/test/specs/components/List/ListItem-test.tsx
@@ -1,10 +1,10 @@
 import { selectableListItemBehavior } from '@fluentui/accessibility'
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 
-import ListItem from 'src/components/List/ListItem'
+import { ListItem } from '@fluentui/react'
 
 describe('ListItem', () => {
   isConformant(ListItem)

--- a/packages/react/test/specs/components/Loader/Loader-test.tsx
+++ b/packages/react/test/specs/components/Loader/Loader-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
-import Loader from 'src/components/Loader/Loader'
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { Loader } from '@fluentui/react'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 
 describe('Loader', () => {
   isConformant(Loader)

--- a/packages/react/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/react/test/specs/components/Menu/Menu-test.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
 
-import Menu from 'src/components/Menu/Menu'
-import { isConformant, handlesAccessibility, getRenderedAttribute } from 'test/specs/commonTests'
-import { mountWithProvider, mountWithProviderAndGetComponent } from 'test/utils'
+import { Menu, MenuItem } from '@fluentui/react'
+import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
+import { mountWithProvider, mountWithProviderAndGetComponent } from '../../../utils'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
-import MenuItem from 'src/components/Menu/MenuItem'
 import {
   AccessibilityDefinition,
   menuBehavior,

--- a/packages/react/test/specs/components/Menu/MenuDivider-test.ts
+++ b/packages/react/test/specs/components/Menu/MenuDivider-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import MenuDivider from 'src/components/Menu/MenuDivider'
+import { MenuDivider } from '@fluentui/react'
 
 describe('MenuDivider', () => {
   isConformant(MenuDivider)

--- a/packages/react/test/specs/components/Menu/MenuItem-test.tsx
+++ b/packages/react/test/specs/components/Menu/MenuItem-test.tsx
@@ -5,10 +5,9 @@ import {
 } from '@fluentui/accessibility'
 import * as React from 'react'
 
-import { isConformant, handlesAccessibility, getRenderedAttribute } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
-import MenuItem from 'src/components/Menu/MenuItem'
-import Box from 'src/components/Box/Box'
+import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
+import { MenuItem, Box } from '@fluentui/react'
 
 describe('MenuItem', () => {
   isConformant(MenuItem, {

--- a/packages/react/test/specs/components/MenuButton/MenuButton-test.tsx
+++ b/packages/react/test/specs/components/MenuButton/MenuButton-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
-import MenuButton from 'src/components/MenuButton/MenuButton'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
+import { MenuButton } from '@fluentui/react'
+import { isConformant, handlesAccessibility } from '../../commonTests'
 import { mountWithProvider } from '../../../utils'
 
 const mockMenu = { items: ['1', '2', '3'] }

--- a/packages/react/test/specs/components/Popup/Popup-test.tsx
+++ b/packages/react/test/specs/components/Popup/Popup-test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as ReactTestUtils from 'react-dom/test-utils'
 
-import Popup, { PopupEvents } from 'src/components/Popup/Popup'
+import { Popup, PopupEvents } from '@fluentui/react'
 import { domEvent, EmptyThemeProvider, mountWithProvider } from '../../../utils'
 import * as keyboardKey from 'keyboard-key'
 import { ReactWrapper } from 'enzyme'

--- a/packages/react/test/specs/components/Popup/PopupContent-test.ts
+++ b/packages/react/test/specs/components/Popup/PopupContent-test.ts
@@ -1,5 +1,5 @@
-import { isConformant } from 'test/specs/commonTests'
-import PopupContent from 'src/components/Popup/PopupContent'
+import { isConformant } from '../../commonTests'
+import { PopupContent } from '@fluentui/react'
 
 describe('PopupContent', () => {
   isConformant(PopupContent, { rendersPortal: true })

--- a/packages/react/test/specs/components/Portal/Portal-test.tsx
+++ b/packages/react/test/specs/components/Portal/Portal-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { domEvent, nextFrame, mountWithProvider } from 'test/utils'
+import { domEvent, nextFrame, mountWithProvider } from '../../../utils'
 
-import Portal from 'src/components/Portal/Portal'
-import PortalInner from 'src/components/Portal/PortalInner'
+import { Portal } from '@fluentui/react'
+import PortalInner from '@fluentui/react/src/components/Portal/PortalInner'
 
 describe('Portal', () => {
   const testPortalInnerIsOpen = (rootWrapper, visible: boolean) => {

--- a/packages/react/test/specs/components/Portal/Portal-test.tsx
+++ b/packages/react/test/specs/components/Portal/Portal-test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react'
 import { domEvent, nextFrame, mountWithProvider } from '../../../utils'
 
 import { Portal } from '@fluentui/react'
-import PortalInner from '@fluentui/react/src/components/Portal/PortalInner'
+// This is not exported
+import PortalInner from '../../../../src/components/Portal/PortalInner'
 
 describe('Portal', () => {
   const testPortalInnerIsOpen = (rootWrapper, visible: boolean) => {

--- a/packages/react/test/specs/components/PortalInner/PortalInner-test.tsx
+++ b/packages/react/test/specs/components/PortalInner/PortalInner-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
-import PortalInner, { PortalInnerProps } from 'src/components/Portal/PortalInner'
-import { mountWithProvider } from 'test/utils'
+import PortalInner, { PortalInnerProps } from '@fluentui/react/src/components/Portal/PortalInner'
+import { mountWithProvider } from '../../../utils'
 
 const mountPortalInner = (props: PortalInnerProps) =>
   mountWithProvider(

--- a/packages/react/test/specs/components/PortalInner/PortalInner-test.tsx
+++ b/packages/react/test/specs/components/PortalInner/PortalInner-test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
-import PortalInner, { PortalInnerProps } from '@fluentui/react/src/components/Portal/PortalInner'
+// These are not exported
+import PortalInner, { PortalInnerProps } from '../../../../src/components/Portal/PortalInner'
 import { mountWithProvider } from '../../../utils'
 
 const mountPortalInner = (props: PortalInnerProps) =>

--- a/packages/react/test/specs/components/Provider/Provider-test.tsx
+++ b/packages/react/test/specs/components/Provider/Provider-test.tsx
@@ -1,18 +1,12 @@
 import { ThemeInput } from '@fluentui/styles'
 import { mount } from 'enzyme'
-import { createRenderer } from 'src/utils/felaRenderer'
 import * as React from 'react'
 
-import Provider from 'src/components/Provider/Provider'
-import ProviderConsumer from 'src/components/Provider/ProviderConsumer'
+import { Provider, ProviderConsumer, createRenderer } from '@fluentui/react'
 
 describe('Provider', () => {
-  test('is exported', () => {
-    expect(require('src/index.ts').Provider).toEqual(Provider)
-  })
-
   test('has a ProviderConsumer subcomponent', () => {
-    expect(require('src/index.ts').Provider.Consumer).toEqual(ProviderConsumer)
+    expect(Provider.Consumer).toEqual(ProviderConsumer)
   })
 
   describe('overwrite', () => {

--- a/packages/react/test/specs/components/Provider/ProviderConsumer-test.tsx
+++ b/packages/react/test/specs/components/Provider/ProviderConsumer-test.tsx
@@ -2,8 +2,7 @@ import { ComponentStyleFunctionParam, emptyTheme, ThemeInput } from '@fluentui/s
 import * as React from 'react'
 import { mount } from 'enzyme'
 
-import Provider from 'src/components/Provider/Provider'
-import ProviderConsumer from 'src/components/Provider/ProviderConsumer'
+import { Provider, ProviderConsumer } from '@fluentui/react'
 
 const styleParam: ComponentStyleFunctionParam = {
   disableAnimations: false,
@@ -15,10 +14,6 @@ const styleParam: ComponentStyleFunctionParam = {
 }
 
 describe('ProviderConsumer', () => {
-  test('is exported', () => {
-    expect(require('src/index.ts').ProviderConsumer).toEqual(ProviderConsumer)
-  })
-
   test('is a subcomponent of the Provider', () => {
     expect(Provider.Consumer).toEqual(ProviderConsumer)
   })

--- a/packages/react/test/specs/components/RadioGroup/RadioGroup-test.tsx
+++ b/packages/react/test/specs/components/RadioGroup/RadioGroup-test.tsx
@@ -1,15 +1,10 @@
 import * as React from 'react'
 
-import {
-  isConformant,
-  handlesAccessibility,
-  htmlIsAccessibilityCompliant,
-} from 'test/specs/commonTests'
+import { isConformant, handlesAccessibility, htmlIsAccessibilityCompliant } from '../../commonTests'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
-import { mountWithProvider } from 'test/utils'
+import { mountWithProvider } from '../../../utils'
 
-import RadioGroup from 'src/components/RadioGroup/RadioGroup'
-import RadioGroupItem from 'src/components/RadioGroup/RadioGroupItem'
+import { RadioGroup, RadioGroupItem } from '@fluentui/react'
 
 const radioGroupImplementsCollectionShorthandProp = implementsCollectionShorthandProp(RadioGroup)
 

--- a/packages/react/test/specs/components/RadioGroup/RadioGroupItem-test.ts
+++ b/packages/react/test/specs/components/RadioGroup/RadioGroupItem-test.ts
@@ -1,6 +1,6 @@
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
+import { isConformant, handlesAccessibility } from '../../commonTests'
 
-import RadioGroupItem from 'src/components/RadioGroup/RadioGroupItem'
+import { RadioGroupItem } from '@fluentui/react'
 
 describe('RadioGroupItem', () => {
   isConformant(RadioGroupItem)

--- a/packages/react/test/specs/components/Reaction/Reaction-test.tsx
+++ b/packages/react/test/specs/components/Reaction/Reaction-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Reaction from 'src/components/Reaction/Reaction'
+import { Reaction } from '@fluentui/react'
 
 describe('Reaction', () => {
   isConformant(Reaction)

--- a/packages/react/test/specs/components/Reaction/ReactionGroup-test.tsx
+++ b/packages/react/test/specs/components/Reaction/ReactionGroup-test.tsx
@@ -1,8 +1,7 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import ReactionGroup from 'src/components/Reaction/ReactionGroup'
-import Reaction from 'src/components/Reaction/Reaction'
-import implementsCollectionShorthandProp from 'test/specs/commonTests/implementsCollectionShorthandProp'
+import { ReactionGroup, Reaction } from '@fluentui/react'
+import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
 
 const reactionGroupImplementsCollectionShorthandProp = implementsCollectionShorthandProp(
   ReactionGroup,

--- a/packages/react/test/specs/components/Segment/Segment-test.ts
+++ b/packages/react/test/specs/components/Segment/Segment-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Segment from 'src/components/Segment/Segment'
+import { Segment } from '@fluentui/react'
 
 describe('Segment', () => {
   isConformant(Segment)

--- a/packages/react/test/specs/components/Slider/Slider-test.tsx
+++ b/packages/react/test/specs/components/Slider/Slider-test.tsx
@@ -1,5 +1,5 @@
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import Slider from 'src/components/Slider/Slider'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { Slider } from '@fluentui/react'
 
 describe('Slider', () => {
   isConformant(Slider, {

--- a/packages/react/test/specs/components/SplitButton/SplitButton-test.tsx
+++ b/packages/react/test/specs/components/SplitButton/SplitButton-test.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
-import SplitButton from 'src/components/SplitButton/SplitButton'
-import { isConformant } from 'test/specs/commonTests'
+import { SplitButton, Menu, MenuButton, Button } from '@fluentui/react'
+import { isConformant } from '../../commonTests'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
 import { mountWithProvider, findIntrinsicElement } from '../../../utils'
-import Menu from 'src/components/Menu/Menu'
-import MenuButton from 'src/components/MenuButton/MenuButton'
-import Button from 'src/components/Button/Button'
 
 const mockMenu = { items: ['1', '2', '3'] }
 

--- a/packages/react/test/specs/components/Status/Status-test.tsx
+++ b/packages/react/test/specs/components/Status/Status-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Status from 'src/components/Status/Status'
+import { Status } from '@fluentui/react'
 
 describe('Status', () => {
   isConformant(Status)

--- a/packages/react/test/specs/components/Table/Table-test.tsx
+++ b/packages/react/test/specs/components/Table/Table-test.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
-import TableRow from 'src/components/Table/TableRow'
-
-import Table from 'src/components/Table/Table'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
+import { TableRow, Table } from '@fluentui/react'
 
 describe('Table', () => {
   isConformant(Table)

--- a/packages/react/test/specs/components/Table/TableCell-test.tsx
+++ b/packages/react/test/specs/components/Table/TableCell-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
-import TableCell from 'src/components/Table/TableCell'
+import { isConformant, handlesAccessibility } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
+import { TableCell } from '@fluentui/react'
 
 describe('TableCell', () => {
   isConformant(TableCell)

--- a/packages/react/test/specs/components/Table/TableRow-test.tsx
+++ b/packages/react/test/specs/components/Table/TableRow-test.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
-import { isConformant, handlesAccessibility, getRenderedAttribute } from 'test/specs/commonTests'
-import { mountWithProviderAndGetComponent } from 'test/utils'
-import TableCell from 'src/components/Table/TableCell'
-
-import TableRow from 'src/components/Table/TableRow'
+import { isConformant, handlesAccessibility, getRenderedAttribute } from '../../commonTests'
+import { mountWithProviderAndGetComponent } from '../../../utils'
+import { TableCell, TableRow } from '@fluentui/react'
 
 describe('TableRow', () => {
   isConformant(TableRow)

--- a/packages/react/test/specs/components/Text/Text-test.tsx
+++ b/packages/react/test/specs/components/Text/Text-test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 
-import Text from 'src/components/Text/Text'
+import { Text } from '@fluentui/react'
 
 describe('Text', () => {
   isConformant(Text)

--- a/packages/react/test/specs/components/TextArea/TextArea-test.tsx
+++ b/packages/react/test/specs/components/TextArea/TextArea-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { mountWithProvider as mount } from 'test/utils'
-import TextArea from 'src/components/TextArea/TextArea'
-import { isConformant } from 'test/specs/commonTests'
+import { mountWithProvider as mount } from '../../../utils'
+import { TextArea } from '@fluentui/react'
+import { isConformant } from '../../commonTests'
 import * as faker from 'faker'
 
 describe('TextArea', () => {

--- a/packages/react/test/specs/components/Toolbar/Toolbar-test.tsx
+++ b/packages/react/test/specs/components/Toolbar/Toolbar-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import Toolbar from 'src/components/Toolbar/Toolbar'
+import { Toolbar } from '@fluentui/react'
 
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 import { ReactWrapper } from 'enzyme'
 
 describe('Toolbar', () => {

--- a/packages/react/test/specs/components/Toolbar/ToolbarCustomItem-test.ts
+++ b/packages/react/test/specs/components/Toolbar/ToolbarCustomItem-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import ToolbarCustomItem from 'src/components/Toolbar/ToolbarCustomItem'
+import { ToolbarCustomItem } from '@fluentui/react'
 
 describe('ToolbarCustomItem', () => {
   isConformant(ToolbarCustomItem, {

--- a/packages/react/test/specs/components/Toolbar/ToolbarDivider-test.ts
+++ b/packages/react/test/specs/components/Toolbar/ToolbarDivider-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import ToolbarDivider from 'src/components/Toolbar/ToolbarDivider'
+import { ToolbarDivider } from '@fluentui/react'
 
 describe('ToolbarDivider', () => {
   isConformant(ToolbarDivider)

--- a/packages/react/test/specs/components/Toolbar/ToolbarItem-test.tsx
+++ b/packages/react/test/specs/components/Toolbar/ToolbarItem-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import ToolbarItem from 'src/components/Toolbar/ToolbarItem'
+import { ToolbarItem } from '@fluentui/react'
 
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 import { ReactWrapper } from 'enzyme'
 
 describe('ToolbarItem', () => {

--- a/packages/react/test/specs/components/Toolbar/ToolbarMenu-test.tsx
+++ b/packages/react/test/specs/components/Toolbar/ToolbarMenu-test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import ToolbarMenu from 'src/components/Toolbar/ToolbarMenu'
+import { ToolbarMenu } from '@fluentui/react'
 
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
 import { ReactWrapper } from 'enzyme'
 
 describe('ToolbarMenu', () => {

--- a/packages/react/test/specs/components/Toolbar/ToolbarMenuDivider-test.ts
+++ b/packages/react/test/specs/components/Toolbar/ToolbarMenuDivider-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import ToolbarMenuDivider from 'src/components/Toolbar/ToolbarMenuDivider'
+import { ToolbarMenuDivider } from '@fluentui/react'
 
 describe('ToolbarMenuDivider', () => {
   isConformant(ToolbarMenuDivider)

--- a/packages/react/test/specs/components/Toolbar/ToolbarMenuItem-test.ts
+++ b/packages/react/test/specs/components/Toolbar/ToolbarMenuItem-test.ts
@@ -1,7 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import ToolbarMenuItem from 'src/components/Toolbar/ToolbarMenuItem'
-import Box from 'src/components/Box/Box'
+import { ToolbarMenuItem, Box } from '@fluentui/react'
 
 describe('ToolbarMenuItem', () => {
   isConformant(ToolbarMenuItem, {

--- a/packages/react/test/specs/components/Toolbar/ToolbarMenuRadioGroup-test.ts
+++ b/packages/react/test/specs/components/Toolbar/ToolbarMenuRadioGroup-test.ts
@@ -1,7 +1,6 @@
-import { handlesAccessibility, isConformant } from 'test/specs/commonTests'
+import { handlesAccessibility, isConformant } from '../../commonTests'
 
-import Box from 'src/components/Box/Box'
-import ToolbarMenuRadioGroup from 'src/components/Toolbar/ToolbarMenuRadioGroup'
+import { Box, ToolbarMenuRadioGroup } from '@fluentui/react'
 
 describe('ToolbarMenuRadioGroup', () => {
   isConformant(ToolbarMenuRadioGroup, {

--- a/packages/react/test/specs/components/Toolbar/ToolbarRadioGroup-test.tsx
+++ b/packages/react/test/specs/components/Toolbar/ToolbarRadioGroup-test.tsx
@@ -1,8 +1,8 @@
-import { isConformant, handlesAccessibility } from 'test/specs/commonTests'
+import { isConformant, handlesAccessibility } from '../../commonTests'
 
-import ToolbarRadioGroup from 'src/components/Toolbar/ToolbarRadioGroup'
+import { ToolbarRadioGroup } from '@fluentui/react'
 import { ReactWrapper } from 'enzyme'
-import { mountWithProvider } from 'test/utils'
+import { mountWithProvider } from '../../../utils'
 import * as React from 'react'
 
 describe('ToolbarRadioGroup', () => {

--- a/packages/react/test/specs/components/Tooltip/Tooltip-test.tsx
+++ b/packages/react/test/specs/components/Tooltip/Tooltip-test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
-import Tooltip from 'src/components/Tooltip/Tooltip'
-import Button from 'src/components/Button/Button'
+import { Tooltip, Button } from '@fluentui/react'
 
 import { mountWithProvider, findIntrinsicElement } from '../../../utils'
 

--- a/packages/react/test/specs/components/Tooltip/TooltipContent-test.ts
+++ b/packages/react/test/specs/components/Tooltip/TooltipContent-test.ts
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import TooltipContent from 'src/components/Tooltip/TooltipContent'
+import { TooltipContent } from '@fluentui/react'
 
 describe('TooltipContent', () => {
   isConformant(TooltipContent)

--- a/packages/react/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/react/test/specs/components/Tree/Tree-test.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
-import { isConformant } from 'test/specs/commonTests'
-import { mountWithProvider } from 'test/utils'
-import Tree from 'src/components/Tree/Tree'
-import TreeTitle from 'src/components/Tree/TreeTitle'
-import TreeItem from 'src/components/Tree/TreeItem'
+import { isConformant } from '../../commonTests'
+import { mountWithProvider } from '../../../utils'
+import { Tree, TreeTitle, TreeItem } from '@fluentui/react'
 import { ReactWrapper, CommonWrapper } from 'enzyme'
 
 const items = [

--- a/packages/react/test/specs/components/Tree/TreeItem-test.tsx
+++ b/packages/react/test/specs/components/Tree/TreeItem-test.tsx
@@ -1,5 +1,5 @@
-import { isConformant } from 'test/specs/commonTests'
-import TreeItem from 'src/components/Tree/TreeItem'
+import { isConformant } from '../../commonTests'
+import { TreeItem } from '@fluentui/react'
 
 describe('TreeItem', () => {
   isConformant(TreeItem, { requiredProps: { id: 'my-id' } })

--- a/packages/react/test/specs/components/Tree/TreeTitle-test.tsx
+++ b/packages/react/test/specs/components/Tree/TreeTitle-test.tsx
@@ -1,5 +1,5 @@
-import { isConformant } from 'test/specs/commonTests'
-import TreeTitle from 'src/components/Tree/TreeTitle'
+import { isConformant } from '../../commonTests'
+import { TreeTitle } from '@fluentui/react'
 
 describe('TreeTitle', () => {
   isConformant(TreeTitle)

--- a/packages/react/test/specs/components/Video/Video-test.tsx
+++ b/packages/react/test/specs/components/Video/Video-test.tsx
@@ -1,6 +1,6 @@
-import { isConformant } from 'test/specs/commonTests'
+import { isConformant } from '../../commonTests'
 
-import Video from 'src/components/Video/Video'
+import { Video } from '@fluentui/react'
 
 describe('Video', () => {
   isConformant(Video)

--- a/packages/react/test/specs/themes/colorUtils-test.ts
+++ b/packages/react/test/specs/themes/colorUtils-test.ts
@@ -1,5 +1,9 @@
-import { extendColorScheme, pickValuesFromColorScheme } from 'src/themes/colorUtils'
-import { ColorSchemeMapping, ComponentAreaName } from 'src/themes/types'
+import {
+  extendColorScheme,
+  pickValuesFromColorScheme,
+  ColorSchemeMapping,
+  ComponentAreaName,
+} from '@fluentui/react'
 
 const generateColorSchemeValues = color => ({
   foreground: color,

--- a/packages/react/test/specs/themes/teams/components/Icon/Icon-test.tsx
+++ b/packages/react/test/specs/themes/teams/components/Icon/Icon-test.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash'
 import * as React from 'react'
 import { shallow } from 'enzyme'
 
+// These are not exported
 import icons, { teamsIconClassNames } from '../../../../../../src/themes/teams/components/Icon/svg'
 import processedIcons from '../../../../../../src/themes/teams/components/Icon/svg/processedIndex'
 import { SvgIconSpecWithStyles } from '../../../../../../src/themes/teams/components/Icon/svg/types'

--- a/packages/react/test/specs/utils/AutoControlledComponent-test.tsx
+++ b/packages/react/test/specs/utils/AutoControlledComponent-test.tsx
@@ -1,9 +1,8 @@
 import * as _ from 'lodash'
 import * as React from 'react'
 import { shallow, ShallowWrapper } from 'enzyme'
-import { AutoControlledComponent } from 'src/utils'
-import { consoleUtil } from 'test/utils'
-import { Props } from 'src/types'
+import { AutoControlledComponent, Props } from '@fluentui/react'
+import { consoleUtil } from '../../utils'
 
 let TestClass
 

--- a/packages/react/test/specs/utils/accessibility/FocusContainer-test.ts
+++ b/packages/react/test/specs/utils/accessibility/FocusContainer-test.ts
@@ -1,4 +1,4 @@
-import { ContainerFocusHandler } from 'src/utils/accessibility/FocusHandling/FocusContainer'
+import { ContainerFocusHandler } from '@fluentui/react/src/utils/accessibility/FocusHandling/FocusContainer'
 
 const createFocusContainer = (
   { itemsCount, setFocusAtFn }: { itemsCount: number; setFocusAtFn?: () => void } = {

--- a/packages/react/test/specs/utils/accessibility/FocusContainer-test.ts
+++ b/packages/react/test/specs/utils/accessibility/FocusContainer-test.ts
@@ -1,4 +1,5 @@
-import { ContainerFocusHandler } from '@fluentui/react/src/utils/accessibility/FocusHandling/FocusContainer'
+// This is not exported
+import { ContainerFocusHandler } from '../../../../src/utils/accessibility/FocusHandling/FocusContainer'
 
 const createFocusContainer = (
   { itemsCount, setFocusAtFn }: { itemsCount: number; setFocusAtFn?: () => void } = {

--- a/packages/react/test/specs/utils/childrenExist-test.tsx
+++ b/packages/react/test/specs/utils/childrenExist-test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import childrenExist from 'src/utils/childrenExist'
+import { childrenExist } from '@fluentui/react'
 
 describe('childrenExist', () => {
   test('returns false when no children are passed', () => {

--- a/packages/react/test/specs/utils/createComponent-test.tsx
+++ b/packages/react/test/specs/utils/createComponent-test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { createComponent } from 'src/utils'
+import { createComponent } from '@fluentui/react'
 
 describe('createComponent', () => {
   describe('className', () => {

--- a/packages/react/test/specs/utils/doesNodeContainClick-test.ts
+++ b/packages/react/test/specs/utils/doesNodeContainClick-test.ts
@@ -1,4 +1,4 @@
-import { doesNodeContainClick } from 'src/utils'
+import { doesNodeContainClick } from '@fluentui/react'
 
 const makeEvent = (event?: any) => ({ clientX: 0, clientY: 0, ...event })
 

--- a/packages/react/test/specs/utils/factories-test.tsx
+++ b/packages/react/test/specs/utils/factories-test.tsx
@@ -2,9 +2,15 @@ import { callable } from '@fluentui/styles'
 import * as React from 'react'
 import * as _ from 'lodash'
 import { shallow } from 'enzyme'
-import { createShorthand, createShorthandFactory } from 'src/utils'
-import { Props, ShorthandValue, ObjectOf, ShorthandRenderFunction } from 'src/types'
-import { consoleUtil } from 'test/utils'
+import {
+  createShorthand,
+  createShorthandFactory,
+  Props,
+  ShorthandValue,
+  ObjectOf,
+  ShorthandRenderFunction,
+} from '@fluentui/react'
+import { consoleUtil } from '../../utils'
 
 // ----------------------------------------
 // Utils

--- a/packages/react/test/specs/utils/felaDisableAnimationsPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaDisableAnimationsPlugin-test.ts
@@ -1,4 +1,4 @@
-import felaDisableAnimationsPlugin from 'src/utils/felaDisableAnimationsPlugin'
+import felaDisableAnimationsPlugin from '@fluentui/react/src/utils/felaDisableAnimationsPlugin'
 
 const disableAnimationsPlugin = felaDisableAnimationsPlugin()
 

--- a/packages/react/test/specs/utils/felaDisableAnimationsPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaDisableAnimationsPlugin-test.ts
@@ -1,4 +1,5 @@
-import felaDisableAnimationsPlugin from '@fluentui/react/src/utils/felaDisableAnimationsPlugin'
+// This is not exported
+import felaDisableAnimationsPlugin from '../../../src/utils/felaDisableAnimationsPlugin'
 
 const disableAnimationsPlugin = felaDisableAnimationsPlugin()
 

--- a/packages/react/test/specs/utils/felaExpandCssShorthandsPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaExpandCssShorthandsPlugin-test.ts
@@ -1,4 +1,4 @@
-import felaExpandCssShorthandsPlugin from 'src/utils/felaExpandCssShorthandsPlugin'
+import felaExpandCssShorthandsPlugin from '@fluentui/react/src/utils/felaExpandCssShorthandsPlugin'
 
 const expandCssShorthands = felaExpandCssShorthandsPlugin()
 

--- a/packages/react/test/specs/utils/felaExpandCssShorthandsPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaExpandCssShorthandsPlugin-test.ts
@@ -1,4 +1,5 @@
-import felaExpandCssShorthandsPlugin from '@fluentui/react/src/utils/felaExpandCssShorthandsPlugin'
+// This is not exported
+import felaExpandCssShorthandsPlugin from '../../../src/utils/felaExpandCssShorthandsPlugin'
 
 const expandCssShorthands = felaExpandCssShorthandsPlugin()
 

--- a/packages/react/test/specs/utils/felaFocusVisibleEnhancer-test.ts
+++ b/packages/react/test/specs/utils/felaFocusVisibleEnhancer-test.ts
@@ -2,7 +2,7 @@ import { createRenderer } from 'fela'
 import { renderToString } from 'fela-tools'
 import { RULE_TYPE } from 'fela-utils'
 
-import felaFocusVisibleEnhancer from 'src/utils/felaFocusVisibleEnhancer'
+import { felaFocusVisibleEnhancer } from '@fluentui/react'
 
 describe('felaFocusVisibleEnhancer', () => {
   test('replaces :focus-visible', () => {

--- a/packages/react/test/specs/utils/felaFocusVisibleEnhancer-test.ts
+++ b/packages/react/test/specs/utils/felaFocusVisibleEnhancer-test.ts
@@ -2,7 +2,7 @@ import { createRenderer } from 'fela'
 import { renderToString } from 'fela-tools'
 import { RULE_TYPE } from 'fela-utils'
 
-import { felaFocusVisibleEnhancer } from '@fluentui/react'
+import felaFocusVisibleEnhancer from '@fluentui/react/src/utils/felaFocusVisibleEnhancer'
 
 describe('felaFocusVisibleEnhancer', () => {
   test('replaces :focus-visible', () => {

--- a/packages/react/test/specs/utils/felaFocusVisibleEnhancer-test.ts
+++ b/packages/react/test/specs/utils/felaFocusVisibleEnhancer-test.ts
@@ -2,7 +2,8 @@ import { createRenderer } from 'fela'
 import { renderToString } from 'fela-tools'
 import { RULE_TYPE } from 'fela-utils'
 
-import felaFocusVisibleEnhancer from '@fluentui/react/src/utils/felaFocusVisibleEnhancer'
+// This is not exported
+import felaFocusVisibleEnhancer from '../../../src/utils/felaFocusVisibleEnhancer'
 
 describe('felaFocusVisibleEnhancer', () => {
   test('replaces :focus-visible', () => {

--- a/packages/react/test/specs/utils/felaInvokeKeyframesPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaInvokeKeyframesPlugin-test.ts
@@ -1,4 +1,4 @@
-import felaInvokeKeyframesPlugin from 'src/utils/felaInvokeKeyframesPlugin'
+import felaInvokeKeyframesPlugin from '@fluentui/react/src/utils/felaInvokeKeyframesPlugin'
 
 const renderInvokeKeyframes = felaInvokeKeyframesPlugin()
 

--- a/packages/react/test/specs/utils/felaInvokeKeyframesPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaInvokeKeyframesPlugin-test.ts
@@ -1,4 +1,5 @@
-import felaInvokeKeyframesPlugin from '@fluentui/react/src/utils/felaInvokeKeyframesPlugin'
+// This is not exported
+import felaInvokeKeyframesPlugin from '../../../src/utils/felaInvokeKeyframesPlugin'
 
 const renderInvokeKeyframes = felaInvokeKeyframesPlugin()
 

--- a/packages/react/test/specs/utils/felaRenderer-test.tsx
+++ b/packages/react/test/specs/utils/felaRenderer-test.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react'
 import { createSnapshot } from 'jest-react-fela'
-import { EmptyThemeProvider } from 'test/utils'
-import Box from 'src/components/Box/Box'
-import Provider from 'src/components/Provider/Provider'
-import Text from 'src/components/Text/Text'
-import { felaRenderer } from 'src/utils'
+import { EmptyThemeProvider } from '../../utils'
+import { Box, Provider, Text, felaRenderer } from '@fluentui/react'
 
 describe('felaRenderer', () => {
   test('basic styles are rendered', () => {

--- a/packages/react/test/specs/utils/felaSanitizeCssPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaSanitizeCssPlugin-test.ts
@@ -1,4 +1,4 @@
-import sanitizeCss from 'src/utils/felaSanitizeCssPlugin'
+import sanitizeCss from '@fluentui/react/src/utils/felaSanitizeCssPlugin'
 
 const assertCssPropertyValue = (value: string, isValid: boolean) => {
   test(`assert that '${value}' is ${isValid ? 'valid' : 'invalid'}`, () => {

--- a/packages/react/test/specs/utils/felaSanitizeCssPlugin-test.ts
+++ b/packages/react/test/specs/utils/felaSanitizeCssPlugin-test.ts
@@ -1,4 +1,5 @@
-import sanitizeCss from '@fluentui/react/src/utils/felaSanitizeCssPlugin'
+// This is not exported
+import sanitizeCss from '../../../src/utils/felaSanitizeCssPlugin'
 
 const assertCssPropertyValue = (value: string, isValid: boolean) => {
   test(`assert that '${value}' is ${isValid ? 'valid' : 'invalid'}`, () => {

--- a/packages/react/test/specs/utils/fontSizeUtility-test.ts
+++ b/packages/react/test/specs/utils/fontSizeUtility-test.ts
@@ -1,4 +1,4 @@
-import { pxToRem } from 'src/utils'
+import { pxToRem } from '@fluentui/react'
 
 describe('fontSizeUtility', () => {
   describe('pxToRem', () => {

--- a/packages/react/test/specs/utils/htmlInputPropsUtils-test.ts
+++ b/packages/react/test/specs/utils/htmlInputPropsUtils-test.ts
@@ -1,4 +1,4 @@
-import { partitionHTMLProps } from 'src/utils/htmlPropsUtils'
+import { partitionHTMLProps } from '@fluentui/react'
 
 const props = {
   autoFocus: false,

--- a/packages/react/test/specs/utils/isBrowser-test.ts
+++ b/packages/react/test/specs/utils/isBrowser-test.ts
@@ -1,4 +1,4 @@
-import isBrowser from 'src/utils/isBrowser'
+import { isBrowser } from '@fluentui/react'
 
 describe('isBrowser', () => {
   describe('browser', () => {

--- a/packages/react/test/specs/utils/mergeProviderContexts/mergeBooleanValues-test.ts
+++ b/packages/react/test/specs/utils/mergeProviderContexts/mergeBooleanValues-test.ts
@@ -1,3 +1,4 @@
+// This is not exported
 import { mergeBooleanValues } from '../../../../src/utils/mergeProviderContexts'
 
 describe('mergeBooleanValues', () => {

--- a/packages/react/test/specs/utils/mergeProviderContexts/mergeProviderContexts-test.ts
+++ b/packages/react/test/specs/utils/mergeProviderContexts/mergeProviderContexts-test.ts
@@ -1,5 +1,5 @@
-import mergeProviderContexts, { mergeRenderers } from 'src/utils/mergeProviderContexts'
-import { felaRenderer } from 'src/utils/felaRenderer'
+import { mergeRenderers } from '@fluentui/react/src/utils/mergeProviderContexts'
+import { felaRenderer, mergeProviderContexts } from '@fluentui/react'
 
 describe('mergeRenderers', () => {
   test(`always uses "next" renderer`, () => {

--- a/packages/react/test/specs/utils/mergeProviderContexts/mergeProviderContexts-test.ts
+++ b/packages/react/test/specs/utils/mergeProviderContexts/mergeProviderContexts-test.ts
@@ -1,4 +1,5 @@
-import { mergeRenderers } from '@fluentui/react/src/utils/mergeProviderContexts'
+// This is not exported
+import { mergeRenderers } from '../../../../src/utils/mergeProviderContexts'
 import { felaRenderer, mergeProviderContexts } from '@fluentui/react'
 
 describe('mergeRenderers', () => {

--- a/packages/react/test/specs/utils/positioner/getScrollParent-test.ts
+++ b/packages/react/test/specs/utils/positioner/getScrollParent-test.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash'
 
-import getScrollParent from 'src/utils/positioner/getScrollParent'
+import getScrollParent from '@fluentui/react/src/utils/positioner/getScrollParent'
 
 const overflowStyles: Partial<CSSStyleDeclaration>[] = [
   { overflow: 'scroll' },

--- a/packages/react/test/specs/utils/positioner/getScrollParent-test.ts
+++ b/packages/react/test/specs/utils/positioner/getScrollParent-test.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash'
 
-import getScrollParent from '@fluentui/react/src/utils/positioner/getScrollParent'
+// This is not exported
+import getScrollParent from '../../../../src/utils/positioner/getScrollParent'
 
 const overflowStyles: Partial<CSSStyleDeclaration>[] = [
   { overflow: 'scroll' },

--- a/packages/react/test/specs/utils/positioner/positioningHelper-test.ts
+++ b/packages/react/test/specs/utils/positioner/positioningHelper-test.ts
@@ -1,7 +1,10 @@
 import { Placement } from 'popper.js'
 
-import { Alignment, Position } from 'src/utils/positioner'
-import { getPlacement, applyRtlToOffset } from 'src/utils/positioner/positioningHelper'
+import { Alignment, Position } from '@fluentui/react'
+import {
+  getPlacement,
+  applyRtlToOffset,
+} from '@fluentui/react/src/utils/positioner/positioningHelper'
 
 type PositionTestInput = {
   align: Alignment

--- a/packages/react/test/specs/utils/positioner/positioningHelper-test.ts
+++ b/packages/react/test/specs/utils/positioner/positioningHelper-test.ts
@@ -1,10 +1,8 @@
 import { Placement } from 'popper.js'
 
 import { Alignment, Position } from '@fluentui/react'
-import {
-  getPlacement,
-  applyRtlToOffset,
-} from '@fluentui/react/src/utils/positioner/positioningHelper'
+// These are not exported
+import { getPlacement, applyRtlToOffset } from '../../../../src/utils/positioner/positioningHelper'
 
 type PositionTestInput = {
   align: Alignment

--- a/packages/react/test/utils/withProvider.tsx
+++ b/packages/react/test/utils/withProvider.tsx
@@ -2,7 +2,7 @@ import { ThemeInput } from '@fluentui/styles'
 import * as React from 'react'
 import { mount } from 'enzyme'
 import { ThemeProvider } from 'react-fela'
-import { felaRenderer } from 'src/utils'
+import { felaRenderer } from '@fluentui/react'
 
 export const EmptyThemeProvider: React.FunctionComponent = ({ children }) => (
   <ThemeProvider theme={{ renderer: felaRenderer, target: document }}>{children}</ThemeProvider>

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,12 +2,7 @@
   "extends": "../../build/tsconfig.common",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist/dts",
-    "paths": {
-      "docs/*": ["docs/*"],
-      "src/*": ["packages/react/src/*"],
-      "test/*": ["packages/react/test/*"]
-    }
+    "outDir": "dist/dts"
   },
   "include": ["src", "test"],
   "references": [

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../build/tsconfig.common",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist/dts"
+    "outDir": "dist/dts",
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/react": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": [

--- a/packages/styles/test/mergeThemes/mergeComponentStyles-test.ts
+++ b/packages/styles/test/mergeThemes/mergeComponentStyles-test.ts
@@ -1,5 +1,6 @@
 import { ComponentStyleFunctionParam, emptyTheme, withDebugId } from '@fluentui/styles'
 
+// These are not exported
 import * as debugEnabled from '../../src/debugEnabled'
 import { mergeComponentStyles__PROD, mergeComponentStyles__DEV } from '../../src/mergeThemes'
 

--- a/packages/styles/test/mergeThemes/mergeComponentVariables-test.ts
+++ b/packages/styles/test/mergeThemes/mergeComponentVariables-test.ts
@@ -1,5 +1,6 @@
 import { objectKeyToValues, withDebugId } from '@fluentui/styles'
 
+// These are not exported
 import * as debugEnabled from '../../src/debugEnabled'
 import { mergeComponentVariables__PROD, mergeComponentVariables__DEV } from '../../src/mergeThemes'
 

--- a/packages/styles/test/mergeThemes/mergeSiteVariables-test.ts
+++ b/packages/styles/test/mergeThemes/mergeSiteVariables-test.ts
@@ -1,5 +1,6 @@
 import { withDebugId } from '@fluentui/styles'
 
+// These are not exported
 import * as debugEnabled from '../../src/debugEnabled'
 import { mergeSiteVariables__PROD, mergeSiteVariables__DEV } from '../../src/mergeThemes'
 

--- a/packages/styles/test/mergeThemes/mergeThemeVariables-test.ts
+++ b/packages/styles/test/mergeThemes/mergeThemeVariables-test.ts
@@ -1,6 +1,7 @@
 import { withDebugId } from '@fluentui/styles'
 import * as _ from 'lodash'
 
+// These are not exported
 import * as debugEnabled from '../../src/debugEnabled'
 import { mergeThemeVariables__PROD, mergeThemeVariables__DEV } from '../../src/mergeThemes'
 

--- a/packages/styles/test/mergeThemes/mergeThemes-test.ts
+++ b/packages/styles/test/mergeThemes/mergeThemes-test.ts
@@ -8,6 +8,7 @@ import {
   emptyTheme,
 } from '@fluentui/styles'
 
+// This is not exported
 import * as debugEnabled from '../../src/debugEnabled'
 
 const styleParam: ComponentStyleFunctionParam = {

--- a/packages/styles/tsconfig.json
+++ b/packages/styles/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../build/tsconfig.common",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist/dts"
+    "outDir": "dist/dts",
+    "baseUrl": ".",
+    "paths": {
+      // For tests
+      "@fluentui/styles": ["./src"]
+    }
   },
   "include": ["src", "test"],
   "references": []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,13 @@
 {
-  "extends": "./build/tsconfig.common.json"
+  "extends": "./build/tsconfig.docs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@fluentui/docs": ["docs"],
+      "@fluentui/e2e": ["e2e"],
+      "@fluentui/internal-tooling": ["build"],
+      "@fluentui/perf": ["perf"],
+      "@fluentui/*": ["packages/*/src"]
+    }
+  }
 }


### PR DESCRIPTION
Splitting out #2233 for (slightly) easier reviewing.

Replace legacy path aliases with more standard imports. This change only modifies the imports in tests.

- Replace `src` with `@fluentui/react` in tests, and fix unnecessary deep imports
  - For deep imports, ~~I used paths under `@fluentui/react/src`~~ I used relative paths into `src` with comments about why they're needed
- Replace `test` with relative paths
- A couple tests in `react` and `accessibility` import generated files which currently live under `docs` (`componentInfo`, `behaviorInfo`). These imports have to stay as path imports for now because having those packages depend on `@fluentui/docs` would cause circular imports. So we need a better all-up solution for where these generated files and/or the tests that rely on them should live (or get rid of the generated files?).

To fix the issue where .d.ts files were getting generated with relative path imports for inferred types, I removed these settings from `tsconfig.common.json`:
```
"baseUrl": "../",
"paths": {
  "@fluentui/*": ["../packages/*/src"]
}
```
And added to each package tsconfig:
```
"baseUrl": ".",
"paths": {
  "@fluentui/this-package": ["./src"]
}
```
And this to the root `tsconfig.json` (and update the places registering `tsconfig-paths` to use this config) to ensure that the build system and editors know where to find the packages:
```
    "baseUrl": ".",
    "paths": {
      "@fluentui/docs": ["docs"],
      "@fluentui/e2e": ["e2e"],
      "@fluentui/internal-tooling": ["build"],
      "@fluentui/perf": ["perf"],
      "@fluentui/*": ["packages/*/src"]
    }
```
(Also temporarily have it inherit from tsconfig.docs until all the aliases are removed.)

It's likely that if we switched the `main` field in `package.json` to point to `src` locally (like it does in staging), and added a pre-publish step to correct it to `dist` or whatever, we could get rid of all these aliases. But that should be done separately.