### PR TITLE
chore: Remove path aliases - the fun parts

### DIFF
--- a/build/gulp/plugins/gulp-example-source.ts
+++ b/build/gulp/plugins/gulp-example-source.ts
@@ -7,7 +7,7 @@ import Vinyl from 'vinyl'
 
 const prettierConfig = require('../../../.prettierrc.json')
 
-import { ExampleSource } from '../../../docs/src/types'
+import { ExampleSource } from './util/docs-types'
 import transformStarImportPlugin from '../../babel/transform-star-import-plugin'
 import { getRelativePathToSourceFile } from './util'
 

--- a/build/gulp/plugins/util/docs-types.ts
+++ b/build/gulp/plugins/util/docs-types.ts
@@ -1,0 +1,5 @@
+// Temporary workaround to prevent having a circular dependency on @fluentui/docs or
+// outside-package path imports in several files. Long-term the types and/or docs build scripts
+// should move somewhere else.
+// TODO (@ecraig12345) - remove relative docs import
+export * from '../../.././../docs/src/types'

--- a/build/gulp/plugins/util/getComponentInfo.ts
+++ b/build/gulp/plugins/util/getComponentInfo.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import path from 'path'
 import fs from 'fs'
 
-import { BehaviorInfo, ComponentInfo, ComponentProp } from 'docs/src/types'
+import { BehaviorInfo, ComponentInfo, ComponentProp } from './docs-types'
 import * as docgen from './docgen'
 import parseDefaultValue from './parseDefaultValue'
 import parseDocblock from './parseDocblock'

--- a/build/gulp/plugins/util/getShorthandInfo.ts
+++ b/build/gulp/plugins/util/getShorthandInfo.ts
@@ -2,7 +2,7 @@ import * as Babel from '@babel/core'
 import { NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
 
-import { ComponentInfo } from 'docs/src/types'
+import { ComponentInfo } from './docs-types'
 
 type ShorthandInfo = Required<
   Pick<ComponentInfo, 'implementsCreateShorthand' | 'mappedShorthandProp'>

--- a/build/gulp/plugins/util/parseDefaultValue.ts
+++ b/build/gulp/plugins/util/parseDefaultValue.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
 
-import { ComponentPropType } from 'docs/src/types'
+import { ComponentPropType } from './docs-types'
 import { PropItem } from './docgen'
 
 const parseDefaultValue = (

--- a/build/gulp/plugins/util/parseType.ts
+++ b/build/gulp/plugins/util/parseType.ts
@@ -3,7 +3,7 @@ import { NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
 import _ from 'lodash'
 
-import { ComponentPropType } from 'docs/src/types'
+import { ComponentPropType } from './docs-types'
 import { PropItem } from './docgen'
 import parseTypeAnnotation from './parseTypeAnnotation'
 

--- a/build/gulp/plugins/util/parseTypeAnnotation.ts
+++ b/build/gulp/plugins/util/parseTypeAnnotation.ts
@@ -1,7 +1,7 @@
 import * as t from '@babel/types'
 import _ from 'lodash'
 
-import { ComponentPropType } from 'docs/src/types'
+import { ComponentPropType } from './docs-types'
 
 const keywords: Record<string, Function> = {
   any: t.isTSAnyKeyword,

--- a/build/gulp/tasks/perf.ts
+++ b/build/gulp/tasks/perf.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../perf/types'
 import config from '../../config'
 import webpackPlugin from '../plugins/gulp-webpack'
-import { safeLaunchOptions } from 'build/puppeteer.config'
+import { safeLaunchOptions } from '../../puppeteer.config'
 
 const { paths } = config
 

--- a/build/gulp/tasks/test-dependencies/utils.ts
+++ b/build/gulp/tasks/test-dependencies/utils.ts
@@ -59,11 +59,7 @@ export const prepareWebpackConfig = (options: WebpackOptions) => {
     ],
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.json'],
-      alias: {
-        ...lernaAliases(),
-        src: paths.packageSrc('react'),
-        docs: paths.base('docs'),
-      },
+      alias: lernaAliases(),
     },
   }
 }

--- a/build/gulp/tasks/test-projects.ts
+++ b/build/gulp/tasks/test-projects.ts
@@ -11,7 +11,7 @@ import del from 'del'
 import config from '../../config'
 import tmp from 'tmp'
 import http from 'http'
-import { safeLaunchOptions } from 'build/puppeteer.config'
+import { safeLaunchOptions } from '../../puppeteer.config'
 
 type PackedPackages = Record<string, string>
 

--- a/build/tsconfig.docs.json
+++ b/build/tsconfig.docs.json
@@ -1,13 +1,7 @@
 {
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
-    "module": "esnext",
-    "paths": {
-      "@fluentui/*": ["packages/*/src"],
-      "docs/*": ["docs/*"],
-      "src/*": ["packages/react/src/*"],
-      "test/*": ["packages/react/test/*"]
-    }
+    "module": "esnext"
   },
-  "include": ["../docs/src", "../packages/react/src", "../types"]
+  "include": ["../docs/src", "../types"]
 }

--- a/build/webpack.config.perf.ts
+++ b/build/webpack.config.perf.ts
@@ -54,8 +54,6 @@ const webpackConfig: any = {
     extensions: ['.ts', '.tsx', '.js', '.json'],
     alias: {
       ...lernaAliases(),
-      docs: paths.base('docs'),
-      src: paths.packageSrc('react'),
 
       // We are using React in production mode with tracing.
       // https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977

--- a/build/webpack.config.ts
+++ b/build/webpack.config.ts
@@ -116,11 +116,7 @@ const webpackConfig: any = {
   ].filter(Boolean),
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
-    alias: {
-      ...lernaAliases(),
-      src: paths.packageSrc('react'),
-      docs: paths.base('docs'),
-    },
+    alias: lernaAliases(),
   },
   optimization: {
     // Automatically split vendor and commons

--- a/packages/perf-test/.digest/config.tsx
+++ b/packages/perf-test/.digest/config.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 import { Provider, themes } from '@fluentui/react'
 
 const reqContexts = [
-  // TODO: Relative pathing isn't the best here, but docs containing perf stories isn't a package that can be added as a dep.
-  require.context('../../../docs/src', true, /\.perf\.tsx$/),
+  require.context('@fluentui/docs/src', true, /\.perf\.tsx$/),
   require.context('..', true, /\.perf\.tsx$/),
   // TODO: why does this break index.html?? seems to pull in stories the same way...
   // require.context('../stories', true, /\.perf\.tsx$/),

--- a/packages/perf-test/package.json
+++ b/packages/perf-test/package.json
@@ -4,6 +4,7 @@
   "version": "0.43.0",
   "private": true,
   "dependencies": {
+    "@fluentui/docs": "^0.43.0",
     "office-ui-fabric-react": "^7.44.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"

--- a/perf/package.json
+++ b/perf/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/polyfill": "^7.7.0",
+    "@fluentui/docs": "^0.43.0",
     "@fluentui/internal-tooling": "^0.43.0",
     "@fluentui/react": "^0.43.0",
     "minimatch": "^3.0.4"

--- a/perf/src/index.tsx
+++ b/perf/src/index.tsx
@@ -12,7 +12,12 @@ import { ProfilerMeasure, ProfilerMeasureCycle } from '../types'
 const Profiler = (React as any).unstable_Profiler
 
 const mountNode = document.querySelector('#root')
-const performanceExamplesContext = require.context('docs/src/examples/', true, /.perf.tsx$/)
+const performanceExamplesContext = require.context(
+  // TODO (@ecraig12345) - switch to @fluentui/docs and add dep
+  '../../docs/src/examples/',
+  true,
+  /.perf.tsx$/,
+)
 
 // Heads up!
 // We want to randomize examples to avoid any notable issues with always first example

--- a/perf/src/index.tsx
+++ b/perf/src/index.tsx
@@ -13,8 +13,7 @@ const Profiler = (React as any).unstable_Profiler
 
 const mountNode = document.querySelector('#root')
 const performanceExamplesContext = require.context(
-  // TODO (@ecraig12345) - switch to @fluentui/docs and add dep
-  '../../docs/src/examples/',
+  '@fluentui/docs/src/examples/',
   true,
   /.perf.tsx$/,
 )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./build/tsconfig.docs.json",
+  "extends": "./build/tsconfig.common.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
This is the interesting part of removing aliases: update all the configs and deal with the few challenging special cases. (Temporarily targeted into a combo branch of #2218 and #2243.)

Alias strategy:

- A few doc-related files in `build/gulp/plugins/util` import from `docs/src/types`. For now, add a file in that directory which re-exports the types (imported by relative path) and update all imports to be from that file. Eventually the types should move to a shared location.
- Replace `docs` imports in `perf` and `perf-test` with deps on `@fluentui/docs`
- Replace `build` alias with relative paths