### PR TITLE
fix(Dropdown): check refs before focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix event listener leak in `FocusZone` @miroslavstastny ([#2227](https://github.com/microsoft/fluent-ui-react/pull/2227))
 - Fix styleParam to always be required in the styles functions @layershifter, @mnajdova ([#2235](https://github.com/microsoft/fluent-ui-react/pull/2235))
+- Check input and button refs exist before focus in `Dropdown` @silviuavram ([#2248](https://github.com/microsoft/fluent-ui-react/pull/2248))
 
 ### Features
 - Allow `useRef` hook used for storing debugging data to be defined in any order with other hooks in functional components @layershifter, @mnajdova ([#2236](https://github.com/microsoft/fluent-ui-react/pull/2236))

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -1270,13 +1270,13 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
   }
 
   tryFocusTriggerButton = () => {
-    if (!this.props.search) {
+    if (!this.props.search && this.buttonRef.current) {
       this.buttonRef.current.focus()
     }
   }
 
   tryFocusSearchInput = () => {
-    if (this.props.search) {
+    if (this.props.search && this.inputRef.current) {
       this.inputRef.current.focus()
     }
   }


### PR DESCRIPTION
Check inputRef and buttonRef if they exist before focusing them. 