### PR TITLE
perf: Store perf bundle and results to CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,8 @@ jobs:
               yarn danger ci
             fi
       - store_artifacts:
-          path: dist/artifacts
-          destination: artifacts
+          path: packages/perf-test/dist
+          destination: artifacts/perf
       - run:
           name: Publish npm package (master only)
           command: |

--- a/build/dangerjs/checkPerfRegressions.ts
+++ b/build/dangerjs/checkPerfRegressions.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash'
-import * as fs from 'fs-extra'
 import * as path from 'path'
 
 import { DangerJS } from './types'
@@ -42,15 +41,6 @@ function fluentFabricComparision(danger, markdown, warn) {
       }
     },
   )
-
-  fs.mkdirpSync(config.paths.ciArtifacts('perf'))
-
-  _.forEach(results, value => {
-    fs.copyFileSync(
-      value.fluentFlamegraphFile,
-      config.paths.ciArtifacts('perf', path.basename(value.fluentFlamegraphFile)),
-    )
-  })
 
   const getStatus = fluentToFabric =>
     fluentToFabric > 1 ? '🔧' : fluentToFabric >= 0.7 ? '🎯' : '🦄'


### PR DESCRIPTION
Store the whole perf bundle (and perf results) to CI artifacts.

We need to have master perf bundle stored in order to be able to do regression testing.