### PR TITLE
chore: remove FocusZoneMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Add `@fluentui/styles` package for all styles' related utilities and TS types @layershifter, @mnajdova ([#2222](https://github.com/microsoft/fluent-ui-react/pull/2222))
 - Remove `animation` prop from all components @joschect ([#2239](https://github.com/microsoft/fluent-ui-react/pull/2239))
-- `mode` property from `focusZone` configuration in accessibility behaviors is no longer supported @layershifter ([#2265](https://github.com/microsoft/fluent-ui-react/pull/2265))
+- `mode` property from `focusZone` configuration in accessibility behaviors is no longer supported - the focus zone will always be in embed mode @layershifter ([#2265](https://github.com/microsoft/fluent-ui-react/pull/2265))
 - `FocusZoneMode` and `FOCUSZONE_WRAP_ATTRIBUTE` are no longer exported @layershifter ([#2265](https://github.com/microsoft/fluent-ui-react/pull/2265))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Add `@fluentui/styles` package for all styles' related utilities and TS types @layershifter, @mnajdova ([#2222](https://github.com/microsoft/fluent-ui-react/pull/2222))
 - Remove `animation` prop from all components @joschect ([#2239](https://github.com/microsoft/fluent-ui-react/pull/2239))
+- `mode` property from `focusZone` configuration in accessibility behaviors is no longer supported @layershifter ([#2265](https://github.com/microsoft/fluent-ui-react/pull/2265))
+- `FocusZoneMode` and `FOCUSZONE_WRAP_ATTRIBUTE` are no longer exported @layershifter ([#2265](https://github.com/microsoft/fluent-ui-react/pull/2265))
 
 ### Fixes
 - Fix event listener leak in `FocusZone` @miroslavstastny ([#2227](https://github.com/microsoft/fluent-ui-react/pull/2227))

--- a/docs/src/views/AccessibilityBehaviors.tsx
+++ b/docs/src/views/AccessibilityBehaviors.tsx
@@ -57,7 +57,7 @@ export default () => (
           these navigable components (navigate between Menu and List components by pressing TAB and
           use arrow keys to navigate between their items).{' '}
           <Link to="focus-zone">Read more about FocusZone.</Link>
-          <p>Type: {code('{ mode: FocusZoneMode, props?: FocusZoneProps }')}.</p>
+          <p>Type: {code('{ props?: FocusZoneProps }')}.</p>
         </li>
         <li>
           <b>childBehaviors</b> - {code('{ [childBehaviorSlot: string]: Accessibility }')} are used

--- a/packages/accessibility/src/behaviors/Chat/chatBehavior.ts
+++ b/packages/accessibility/src/behaviors/Chat/chatBehavior.ts
@@ -11,7 +11,6 @@ const CHAT_FOCUSZONE_ATTRIBUTE = 'chat-focuszone'
  * Adds a vertical focus zone navigation with a last message as a default tabbable element, pressing enter key focuses inside a message.
  *
  * @specification
- * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Focus is set initially on the specified default tabbable element.
  * Focused active element of the component is reset when TAB from the component.

--- a/packages/accessibility/src/behaviors/Chat/chatBehavior.ts
+++ b/packages/accessibility/src/behaviors/Chat/chatBehavior.ts
@@ -2,7 +2,7 @@ import * as keyboardKey from 'keyboard-key'
 
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes'
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 
 const CHAT_FOCUSZONE_ATTRIBUTE = 'chat-focuszone'
 
@@ -22,7 +22,6 @@ const ChatBehavior: Accessibility = () => ({
     root: {},
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldEnterInnerZone: event => keyboardKey.getCode(event) === keyboardKey.Enter,
       direction: FocusZoneDirection.vertical,

--- a/packages/accessibility/src/behaviors/Chat/chatMessageBehavior.ts
+++ b/packages/accessibility/src/behaviors/Chat/chatMessageBehavior.ts
@@ -12,7 +12,6 @@ import { FocusZoneTabbableElements, FocusZoneDirection } from '../../focusZone/t
  * Adds an escape key action which focuses the chat message, i.e., moves key handling from inside a message back to the chat list.
  *
  * @specification
- * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Keyboard navigation is circular.
  * Focus is moved within the focusable children of the component using TAB key.

--- a/packages/accessibility/src/behaviors/Chat/chatMessageBehavior.ts
+++ b/packages/accessibility/src/behaviors/Chat/chatMessageBehavior.ts
@@ -2,7 +2,7 @@ import * as keyboardKey from 'keyboard-key'
 
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes'
 import { Accessibility } from '../../types'
-import { FocusZoneTabbableElements, FocusZoneDirection, FocusZoneMode } from '../../focusZone/types'
+import { FocusZoneTabbableElements, FocusZoneDirection } from '../../focusZone/types'
 
 /**
  * @description
@@ -25,7 +25,6 @@ const chatMessageBehavior: Accessibility = () => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       handleTabKey: FocusZoneTabbableElements.all,
       isCircularNavigation: true,

--- a/packages/accessibility/src/behaviors/Grid/gridBehavior.ts
+++ b/packages/accessibility/src/behaviors/Grid/gridBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 
 /**
  * @description
@@ -12,7 +12,6 @@ import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
 const gridBehavior: Accessibility = () => ({
   attributes: {},
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       direction: FocusZoneDirection.bidirectional,
     },

--- a/packages/accessibility/src/behaviors/Grid/gridBehavior.ts
+++ b/packages/accessibility/src/behaviors/Grid/gridBehavior.ts
@@ -6,7 +6,6 @@ import { FocusZoneDirection } from '../../focusZone/types'
  * Provides navigation between focusable children of Grid component with arrow keys in 4 directions.
  *
  * @specification
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectional direction.
  */
 const gridBehavior: Accessibility = () => ({

--- a/packages/accessibility/src/behaviors/Grid/gridHorizontalBehavior.ts
+++ b/packages/accessibility/src/behaviors/Grid/gridHorizontalBehavior.ts
@@ -7,7 +7,6 @@ import { FocusZoneDirection } from '../../focusZone/types'
  * Right/Down arrow keys move to next item, Up/Left  arrow keys to previous item. Right and Left arrow keys are switched in RTL mode.
  *
  * @specification
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectionalDomOrder direction.
  */
 const gridHorizontalBehavior: Accessibility = () => ({

--- a/packages/accessibility/src/behaviors/Grid/gridHorizontalBehavior.ts
+++ b/packages/accessibility/src/behaviors/Grid/gridHorizontalBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 
 /**
  * @description
@@ -13,7 +13,6 @@ import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
 const gridHorizontalBehavior: Accessibility = () => ({
   attributes: {},
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       direction: FocusZoneDirection.bidirectionalDomOrder,
     },

--- a/packages/accessibility/src/behaviors/HierarchicalTree/hierarchicalTreeBehavior.ts
+++ b/packages/accessibility/src/behaviors/HierarchicalTree/hierarchicalTreeBehavior.ts
@@ -6,7 +6,6 @@ import hierarchicalSubtreeBehavior from './hierarchicalSubtreeBehavior'
  * @specification
  * Adds role 'tree' to 'root' slot.
  * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Triggers 'expandSiblings' action with '*' on 'root'.
  */

--- a/packages/accessibility/src/behaviors/HierarchicalTree/hierarchicalTreeBehavior.ts
+++ b/packages/accessibility/src/behaviors/HierarchicalTree/hierarchicalTreeBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility, AccessibilityAttributes } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import hierarchicalSubtreeBehavior from './hierarchicalSubtreeBehavior'
 
 /**
@@ -26,7 +26,6 @@ const hierarchicalTreeBehavior: Accessibility<TreeBehaviorProps> = props => {
       },
     },
     focusZone: {
-      mode: FocusZoneMode.Embed,
       props: {
         direction: FocusZoneDirection.vertical,
       },

--- a/packages/accessibility/src/behaviors/List/navigableListBehavior.ts
+++ b/packages/accessibility/src/behaviors/List/navigableListBehavior.ts
@@ -5,7 +5,6 @@ import { ListBehaviorProps } from './listBehavior'
 /**
  * @specification
  * Adds role='menu'.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectionalDomOrder direction.
  */
 const navigableListBehavior: Accessibility<ListBehaviorProps> = props => ({

--- a/packages/accessibility/src/behaviors/List/navigableListBehavior.ts
+++ b/packages/accessibility/src/behaviors/List/navigableListBehavior.ts
@@ -1,4 +1,4 @@
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import { Accessibility } from '../../types'
 import { ListBehaviorProps } from './listBehavior'
 
@@ -15,7 +15,6 @@ const navigableListBehavior: Accessibility<ListBehaviorProps> = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldFocusInnerElementWhenReceivedFocus: true,
       direction: FocusZoneDirection.bidirectionalDomOrder,

--- a/packages/accessibility/src/behaviors/List/selectableListBehavior.ts
+++ b/packages/accessibility/src/behaviors/List/selectableListBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import { ListBehaviorProps } from './listBehavior'
 
 /**
@@ -24,7 +24,6 @@ const selectableListBehavior: Accessibility<ListBehaviorProps> = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldFocusInnerElementWhenReceivedFocus: true,
       direction: FocusZoneDirection.bidirectionalDomOrder,

--- a/packages/accessibility/src/behaviors/List/selectableListBehavior.ts
+++ b/packages/accessibility/src/behaviors/List/selectableListBehavior.ts
@@ -10,7 +10,6 @@ import { ListBehaviorProps } from './listBehavior'
  * Adds role='listbox'.
  * Adds attribute 'tabIndex=-1' to 'root' slot.
  * Adds attribute 'aria-orientation=horizontal' to 'root' slot if 'horizontal' property is true. Does not set the attribute otherwise.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectionalDomOrder direction.
  */
 const selectableListBehavior: Accessibility<ListBehaviorProps> = props => ({

--- a/packages/accessibility/src/behaviors/Menu/menuBehavior.ts
+++ b/packages/accessibility/src/behaviors/Menu/menuBehavior.ts
@@ -10,7 +10,6 @@ import menuDividerBehavior from './menuDividerBehavior'
  *
  * @specification
  * Adds role='menu'.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in horizontal direction.
  * When 'vertical' prop is used, provides keyboard navigation in vertical direction.
  * Keyboard navigation is circular.

--- a/packages/accessibility/src/behaviors/Menu/menuBehavior.ts
+++ b/packages/accessibility/src/behaviors/Menu/menuBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import menuItemBehavior from './menuItemBehavior'
 import menuDividerBehavior from './menuDividerBehavior'
 
@@ -22,7 +22,6 @@ const menuBehavior: Accessibility<MenuBehaviorProps> = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       isCircularNavigation: true,
       shouldFocusInnerElementWhenReceivedFocus: true,

--- a/packages/accessibility/src/behaviors/Menu/submenuBehavior.ts
+++ b/packages/accessibility/src/behaviors/Menu/submenuBehavior.ts
@@ -8,7 +8,6 @@ import menuItemBehavior from './menuItemBehavior'
  *
  * @specification
  * Adds role='menu'.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Keyboard navigation is circular.
  * Component will get focus when mounted.

--- a/packages/accessibility/src/behaviors/Menu/submenuBehavior.ts
+++ b/packages/accessibility/src/behaviors/Menu/submenuBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import menuItemBehavior from './menuItemBehavior'
 
 /**
@@ -20,7 +20,6 @@ const submenuBehavior: Accessibility = () => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       isCircularNavigation: true,
       shouldFocusOnMount: true,

--- a/packages/accessibility/src/behaviors/Tab/tabListBehavior.ts
+++ b/packages/accessibility/src/behaviors/Tab/tabListBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import tabBehavior from './tabBehavior'
 
 /**
@@ -19,7 +19,6 @@ const tabListBehavior: Accessibility = () => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldFocusInnerElementWhenReceivedFocus: true,
       direction: FocusZoneDirection.bidirectionalDomOrder,

--- a/packages/accessibility/src/behaviors/Tab/tabListBehavior.ts
+++ b/packages/accessibility/src/behaviors/Tab/tabListBehavior.ts
@@ -8,7 +8,6 @@ import tabBehavior from './tabBehavior'
  * Child item components need to have tabBehavior assigned.
  * @specification
  * Adds role 'tablist' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectionalDomOrder direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.
  */

--- a/packages/accessibility/src/behaviors/Table/gridCellMultipleFocusableBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridCellMultipleFocusableBehavior.ts
@@ -1,6 +1,6 @@
 import { Accessibility } from '../../types'
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import * as keyboardKey from 'keyboard-key'
 
 /**
@@ -19,7 +19,6 @@ const gridCellMultipleFocusableBehavior: Accessibility = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       direction: FocusZoneDirection.bidirectional,
     },

--- a/packages/accessibility/src/behaviors/Table/gridCellMultipleFocusableBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridCellMultipleFocusableBehavior.ts
@@ -7,7 +7,6 @@ import * as keyboardKey from 'keyboard-key'
  * @specification
  * Adds role='gridcell'.
  * Adds attribute 'data-is-focusable=true' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectional direction.
  * Triggers 'focusCell' action with 'Escape' on 'root'.
  */

--- a/packages/accessibility/src/behaviors/Table/gridHeaderRowBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridHeaderRowBehavior.ts
@@ -8,7 +8,6 @@ import gridHeaderCellBehavior from './gridHeaderCellBehavior'
  * @specification
  * Adds role='row'.
  * Adds attribute 'data-is-focusable=true' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in horizontal direction.
  * Focused active element of the component is reset when TAB from the component.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.

--- a/packages/accessibility/src/behaviors/Table/gridHeaderRowBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridHeaderRowBehavior.ts
@@ -1,6 +1,6 @@
 import { Accessibility } from '../../types'
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import * as keyboardKey from 'keyboard-key'
 import gridHeaderCellBehavior from './gridHeaderCellBehavior'
 
@@ -23,7 +23,6 @@ const gridHeaderRowBehavior: Accessibility = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       direction: FocusZoneDirection.horizontal,
       shouldFocusInnerElementWhenReceivedFocus: true,

--- a/packages/accessibility/src/behaviors/Table/gridNestedBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridNestedBehavior.ts
@@ -1,6 +1,6 @@
 import { Accessibility } from '../../types'
 import * as keyboardKey from 'keyboard-key'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import gridRowBehavior from './gridRowBehavior'
 
 /**
@@ -21,7 +21,6 @@ const gridNestedBehavior: Accessibility = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldEnterInnerZone: event => keyboardKey.getCode(event) === keyboardKey.ArrowRight,
       direction: FocusZoneDirection.vertical,

--- a/packages/accessibility/src/behaviors/Table/gridNestedBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridNestedBehavior.ts
@@ -6,7 +6,6 @@ import gridRowBehavior from './gridRowBehavior'
 /**
  * @specification
  * Adds role='grid'.
- * Embeds component into FocusZone.
  * Focus can be moved inside a child component with embeded inner FocusZone by pressing a specified key.
  * Provides arrow key navigation in vertical direction.
  * Focused active element of the component is reset when TAB from the component.

--- a/packages/accessibility/src/behaviors/Table/gridRowNestedBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridRowNestedBehavior.ts
@@ -1,6 +1,6 @@
 import { Accessibility } from '../../types'
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import * as keyboardKey from 'keyboard-key'
 import gridCellBehavior from './gridCellBehavior'
 
@@ -23,7 +23,6 @@ const gridRowNestedBehavior: Accessibility = props => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldEnterInnerZone: event => keyboardKey.getCode(event) === keyboardKey.Enter,
       direction: FocusZoneDirection.horizontal,

--- a/packages/accessibility/src/behaviors/Table/gridRowNestedBehavior.ts
+++ b/packages/accessibility/src/behaviors/Table/gridRowNestedBehavior.ts
@@ -8,7 +8,6 @@ import gridCellBehavior from './gridCellBehavior'
  * @specification
  * Adds role='row'.
  * Adds attribute 'data-is-focusable=true' to 'root' slot.
- * Embeds component into FocusZone.
  * Focus can be moved inside a child component with embeded inner FocusZone by pressing a specified key.
  * Provides arrow key navigation in horizontal direction.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.

--- a/packages/accessibility/src/behaviors/Toolbar/menuAsToolbarBehavior.ts
+++ b/packages/accessibility/src/behaviors/Toolbar/menuAsToolbarBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import menuItemAsToolbarButtonBehavior from './menuItemAsToolbarButtonBehavior'
 
 /**
@@ -19,7 +19,6 @@ const menuAsToolbarBehavior: Accessibility = () => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldFocusInnerElementWhenReceivedFocus: true,
       direction: FocusZoneDirection.bidirectionalDomOrder,

--- a/packages/accessibility/src/behaviors/Toolbar/menuAsToolbarBehavior.ts
+++ b/packages/accessibility/src/behaviors/Toolbar/menuAsToolbarBehavior.ts
@@ -8,7 +8,6 @@ import menuItemAsToolbarButtonBehavior from './menuItemAsToolbarButtonBehavior'
  * Child item components need to have menuItemAsToolbarButtonBehavior assigned.
  * @specification
  * Adds role 'toolbar' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in bidirectionalDomOrder direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.
  */

--- a/packages/accessibility/src/behaviors/Toolbar/toolbarBehavior.ts
+++ b/packages/accessibility/src/behaviors/Toolbar/toolbarBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 
 /**
  * @description
@@ -11,14 +11,13 @@ import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
  * Provides arrow key navigation in horizontal direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.
  */
-const toolbarBehavior: Accessibility = (props: any) => ({
+const toolbarBehavior: Accessibility = props => ({
   attributes: {
     root: {
       role: 'toolbar',
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       shouldFocusInnerElementWhenReceivedFocus: true,
       direction: FocusZoneDirection.horizontal,

--- a/packages/accessibility/src/behaviors/Toolbar/toolbarBehavior.ts
+++ b/packages/accessibility/src/behaviors/Toolbar/toolbarBehavior.ts
@@ -7,7 +7,6 @@ import { FocusZoneDirection } from '../../focusZone/types'
  * Child item components need to have toolbarItemBehavior assigned.
  * @specification
  * Adds role 'toolbar' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in horizontal direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.
  */

--- a/packages/accessibility/src/behaviors/Toolbar/toolbarMenuBehavior.ts
+++ b/packages/accessibility/src/behaviors/Toolbar/toolbarMenuBehavior.ts
@@ -1,5 +1,5 @@
 import { Accessibility } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import toolbarMenuItemBehavior from './toolbarMenuItemBehavior'
 import * as keyboardKey from 'keyboard-key'
 
@@ -29,7 +29,6 @@ const toolbarMenuBehavior: Accessibility = () => ({
     },
   },
   focusZone: {
-    mode: FocusZoneMode.Embed,
     props: {
       isCircularNavigation: true,
       shouldFocusOnMount: true,

--- a/packages/accessibility/src/behaviors/Toolbar/toolbarMenuBehavior.ts
+++ b/packages/accessibility/src/behaviors/Toolbar/toolbarMenuBehavior.ts
@@ -9,7 +9,6 @@ import * as keyboardKey from 'keyboard-key'
  *
  * @specification
  * Adds role='menu'.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Keyboard navigation is circular.
  * Component will get focus when mounted.

--- a/packages/accessibility/src/behaviors/Tree/treeBehavior.ts
+++ b/packages/accessibility/src/behaviors/Tree/treeBehavior.ts
@@ -9,7 +9,6 @@ import treeItemBehavior from './treeItemBehavior'
  * Adds role 'tree' to 'root' slot.
  * Adds attribute 'tabIndex=-1' to 'root' slot.
  * Adds attribute 'aria-labelledby' based on the property 'aria-labelledby' to 'root' slot.
- * Embeds component into FocusZone.
  * Provides arrow key navigation in vertical direction.
  * Triggers 'expandSiblings' action with '*' on 'root'.
  */

--- a/packages/accessibility/src/behaviors/Tree/treeBehavior.ts
+++ b/packages/accessibility/src/behaviors/Tree/treeBehavior.ts
@@ -1,7 +1,7 @@
 import * as keyboardKey from 'keyboard-key'
 
 import { Accessibility, AccessibilityAttributes } from '../../types'
-import { FocusZoneMode, FocusZoneDirection } from '../../focusZone/types'
+import { FocusZoneDirection } from '../../focusZone/types'
 import treeItemBehavior from './treeItemBehavior'
 
 /**
@@ -30,7 +30,6 @@ const treeBehavior: Accessibility<TreeBehaviorProps> = props => {
       },
     },
     focusZone: {
-      mode: FocusZoneMode.Embed,
       props: {
         direction: FocusZoneDirection.vertical,
       },

--- a/packages/accessibility/src/focusZone/types.ts
+++ b/packages/accessibility/src/focusZone/types.ts
@@ -1,13 +1,6 @@
 import * as React from 'react'
 
-export enum FocusZoneMode {
-  Custom,
-  Wrap,
-  Embed,
-}
-
 export type FocusZoneDefinition = {
-  mode: FocusZoneMode
   props?: FocusZoneProperties
 }
 

--- a/packages/accessibility/test/behaviors/testDefinitions.ts
+++ b/packages/accessibility/test/behaviors/testDefinitions.ts
@@ -1,8 +1,4 @@
-import {
-  FocusZoneMode,
-  FocusZoneDirection,
-  FocusZoneTabbableElements,
-} from '@fluentui/accessibility'
+import { FocusZoneDirection, FocusZoneTabbableElements } from '@fluentui/accessibility'
 import * as keyboardKey from 'keyboard-key'
 
 import { TestDefinition, TestMethod, TestHelper } from './testHelper'
@@ -490,16 +486,6 @@ definitions.push({
 /*
  * ********************** FOCUS ZONE **********************
  */
-definitions.push({
-  regexp: /Embeds component into FocusZone\./g,
-  testMethod: (parameters: TestMethod) => {
-    const actualFocusZone = parameters.behavior({}).focusZone
-
-    const expectedFocusZoneMode = FocusZoneMode.Embed
-    expect(actualFocusZone.mode).toBe(expectedFocusZoneMode)
-  },
-})
-
 definitions.push({
   regexp: /arrow key navigation in horizontal direction/g,
   testMethod: (parameters: TestMethod) => {

--- a/packages/react-bindings/src/FocusZone/focusUtilities.ts
+++ b/packages/react-bindings/src/FocusZone/focusUtilities.ts
@@ -4,7 +4,6 @@ export const IS_VISIBLE_ATTRIBUTE = 'data-is-visible'
 export const FOCUSZONE_ID_ATTRIBUTE = 'data-focuszone-id'
 export const FOCUSZONE_SUB_ATTRIBUTE = 'data-is-sub-focuszone'
 export const HIDDEN_FROM_ACC_TREE = 'data-is-hidden-from-acc-tree'
-export const FOCUSZONE_WRAP_ATTRIBUTE = 'data-focuszone-wrap'
 
 /**
  * Gets the first focusable element.

--- a/packages/react/src/components/Portal/Portal.tsx
+++ b/packages/react/src/components/Portal/Portal.tsx
@@ -126,7 +126,7 @@ class Portal extends AutoControlledComponent<PortalProps, PortalState> {
 
     const contentToRender = childrenExist(children) ? children : content
     const focusTrapZoneProps = (_.keys(trapFocus).length && trapFocus) || {}
-    const targetRef = toRefObject(this.context.target)
+    const targetRef = toRefObject(this.context.target) // { current: Document }
 
     return (
       open && (

--- a/packages/react/src/components/Portal/Portal.tsx
+++ b/packages/react/src/components/Portal/Portal.tsx
@@ -126,7 +126,7 @@ class Portal extends AutoControlledComponent<PortalProps, PortalState> {
 
     const contentToRender = childrenExist(children) ? children : content
     const focusTrapZoneProps = (_.keys(trapFocus).length && trapFocus) || {}
-    const targetRef = toRefObject(this.context.target) // { current: Document }
+    const targetRef = toRefObject(this.context.target)
 
     return (
       open && (

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -150,9 +150,6 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
     if (this.props.target) {
       tryCleanupWhatInput(this.props.target)
     }
-
-    delete this.outgoingContext.target
-    console.log('DD', this.outgoingContext)
   }
 
   render() {

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -150,6 +150,9 @@ class Provider extends React.Component<WithAsProp<ProviderProps>> {
     if (this.props.target) {
       tryCleanupWhatInput(this.props.target)
     }
+
+    delete this.outgoingContext.target
+    console.log('DD', this.outgoingContext)
   }
 
   render() {

--- a/packages/react/src/utils/renderComponent.tsx
+++ b/packages/react/src/utils/renderComponent.tsx
@@ -1,10 +1,7 @@
-import { FocusZoneMode } from '@fluentui/accessibility'
 import {
   AccessibilityActionHandlers,
   ComponentSlotClasses,
   FocusZone,
-  FocusZoneProps,
-  FOCUSZONE_WRAP_ATTRIBUTE,
   getElementType,
   getUnhandledProps,
   ReactAccessibilityBehavior,
@@ -107,24 +104,11 @@ const renderComponent = <P extends {}>(
     rtl,
     theme,
   }
-  let wrapInFocusZone: (element: React.ReactElement) => React.ReactElement = element => element
+  const wrapInFocusZone: (element: React.ReactElement) => React.ReactElement = element => element
 
   setEnd()
 
-  if (accessibility.focusZone && accessibility.focusZone.mode === FocusZoneMode.Wrap) {
-    wrapInFocusZone = element =>
-      React.createElement(
-        FocusZone,
-        {
-          [FOCUSZONE_WRAP_ATTRIBUTE]: true,
-          ...accessibility.focusZone.props,
-          isRtl: rtl,
-        } as FocusZoneProps & { [FOCUSZONE_WRAP_ATTRIBUTE]: boolean },
-        element,
-      )
-  }
-
-  if (accessibility.focusZone && accessibility.focusZone.mode === FocusZoneMode.Embed) {
+  if (accessibility.focusZone) {
     const originalElementType = resolvedConfig.ElementType
 
     resolvedConfig.ElementType = FocusZone as any

--- a/packages/react/src/utils/renderComponent.tsx
+++ b/packages/react/src/utils/renderComponent.tsx
@@ -104,9 +104,6 @@ const renderComponent = <P extends {}>(
     rtl,
     theme,
   }
-  const wrapInFocusZone: (element: React.ReactElement) => React.ReactElement = element => element
-
-  setEnd()
 
   if (accessibility.focusZone) {
     const originalElementType = resolvedConfig.ElementType
@@ -120,7 +117,10 @@ const renderComponent = <P extends {}>(
     resolvedConfig.unhandledProps.isRtl = resolvedConfig.rtl
   }
 
-  return wrapInFocusZone(render(resolvedConfig))
+  const element = render(resolvedConfig)
+  setEnd()
+
+  return element
 }
 
 export default renderComponent

--- a/packages/react/test/specs/commonTests/handlesAccessibility.tsx
+++ b/packages/react/test/specs/commonTests/handlesAccessibility.tsx
@@ -1,5 +1,4 @@
-import { Accessibility, AriaRole, FocusZoneDefinition } from '@fluentui/accessibility'
-import { FocusZone, FOCUSZONE_WRAP_ATTRIBUTE } from '@fluentui/react-bindings'
+import { Accessibility, AriaRole } from '@fluentui/accessibility'
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
 
@@ -12,11 +11,7 @@ export const getRenderedAttribute = (renderedComponent, propName, partSelector) 
     ? renderedComponent.render().find(partSelector)
     : renderedComponent.render()
 
-  let node = target.first()
-  if (node.attr(FOCUSZONE_WRAP_ATTRIBUTE)) {
-    node = node.children().first() // traverse through FocusZone wrap <div>
-  }
-  return node.prop(propName)
+  return target.first().prop(propName)
 }
 
 const overriddenRootRole = 'test-mock-role' as AriaRole
@@ -42,7 +37,6 @@ export default (
     defaultRootRole?: string
     /** Selector to scope the test to a part */
     partSelector?: string
-    focusZoneDefinition?: FocusZoneDefinition
     usesWrapperSlot?: boolean
   } = {},
 ) => {
@@ -50,7 +44,6 @@ export default (
     requiredProps = {},
     defaultRootRole,
     partSelector = '',
-    focusZoneDefinition = {} as FocusZoneDefinition,
     usesWrapperSlot = false,
   } = options
 
@@ -145,15 +138,6 @@ export default (
         expect(actionHandler).toBeCalledTimes(1)
       }
       expect(eventHandler).toBeCalledTimes(1)
-    })
-  }
-
-  if (focusZoneDefinition) {
-    test('gets embedded with FocusZone', () => {
-      const rendered = mountWithProviderAndGetComponent(Component, <Component {...requiredProps} />)
-
-      const focusZone = rendered.childAt(0).childAt(0) // skip thru FelaTheme
-      expect(focusZone.type()).toEqual(FocusZone)
     })
   }
 }

--- a/packages/react/test/specs/commonTests/handlesAccessibility.tsx
+++ b/packages/react/test/specs/commonTests/handlesAccessibility.tsx
@@ -1,9 +1,4 @@
-import {
-  Accessibility,
-  AriaRole,
-  FocusZoneMode,
-  FocusZoneDefinition,
-} from '@fluentui/accessibility'
+import { Accessibility, AriaRole, FocusZoneDefinition } from '@fluentui/accessibility'
 import { FocusZone, FOCUSZONE_WRAP_ATTRIBUTE } from '@fluentui/react-bindings'
 import * as React from 'react'
 import * as keyboardKey from 'keyboard-key'
@@ -154,30 +149,11 @@ export default (
   }
 
   if (focusZoneDefinition) {
-    if (focusZoneDefinition.mode === FocusZoneMode.Wrap) {
-      test('gets wrapped in FocusZone', () => {
-        const rendered = mountWithProviderAndGetComponent(
-          Component,
-          <Component {...requiredProps} />,
-        )
+    test('gets embedded with FocusZone', () => {
+      const rendered = mountWithProviderAndGetComponent(Component, <Component {...requiredProps} />)
 
-        const focusZone = rendered.childAt(0).childAt(0) // skip thru FelaTheme
-        expect(focusZone.type()).toEqual(FocusZone)
-
-        const focusZoneDiv = focusZone.childAt(0)
-        expect(focusZoneDiv.type()).toBe('div')
-        expect(focusZoneDiv.children().length).toBeGreaterThan(0)
-      })
-    } else if (focusZoneDefinition.mode === FocusZoneMode.Embed) {
-      test('gets embedded with FocusZone', () => {
-        const rendered = mountWithProviderAndGetComponent(
-          Component,
-          <Component {...requiredProps} />,
-        )
-
-        const focusZone = rendered.childAt(0).childAt(0) // skip thru FelaTheme
-        expect(focusZone.type()).toEqual(FocusZone)
-      })
-    }
+      const focusZone = rendered.childAt(0).childAt(0) // skip thru FelaTheme
+      expect(focusZone.type()).toEqual(FocusZone)
+    })
   }
 }

--- a/packages/react/test/specs/commonTests/isConformant.tsx
+++ b/packages/react/test/specs/commonTests/isConformant.tsx
@@ -1,5 +1,5 @@
 import { Accessibility, AriaRole, IS_FOCUSABLE_ATTRIBUTE } from '@fluentui/accessibility'
-import { FocusZone, FOCUSZONE_WRAP_ATTRIBUTE } from '@fluentui/react-bindings'
+import { FocusZone } from '@fluentui/react-bindings'
 import { Ref, RefFindNode } from '@fluentui/react-component-ref'
 import * as faker from 'faker'
 import * as _ from 'lodash'
@@ -78,11 +78,8 @@ export default function isConformant(
 
     // passing through Focus Zone wrappers
     if (componentElement.type() === FocusZone) {
-      // another HOC component is added: FocuZone
+      // another HOC component is added: FocusZone
       componentElement = componentElement.childAt(0) // skip through <FocusZone>
-      if (componentElement.prop(FOCUSZONE_WRAP_ATTRIBUTE)) {
-        componentElement = componentElement.childAt(0) // skip the additional wrap <div> of the FocusZone
-      }
     }
 
     // in that case 'topLevelChildElement' we've found so far is a wrapper's topmost child
@@ -461,7 +458,6 @@ export default function isConformant(
       const classes = component
         .find('[className]')
         .hostNodes()
-        .filterWhere(c => !c.prop(FOCUSZONE_WRAP_ATTRIBUTE)) // filter out FocusZone wrap <div>
         .at(wrapperComponent ? 1 : 0)
         .prop('className')
       return classes

--- a/packages/react/test/specs/components/Chat/Chat-test.ts
+++ b/packages/react/test/specs/components/Chat/Chat-test.ts
@@ -1,4 +1,3 @@
-import { chatBehavior, AccessibilityDefinition } from '@fluentui/accessibility'
 import { handlesAccessibility, isConformant } from 'test/specs/commonTests'
 
 import Chat from 'src/components/Chat/Chat'
@@ -12,8 +11,6 @@ describe('Chat', () => {
   chatImplementsCollectionShorthandProp('items', ChatItem, { mapsValueToProp: 'message' })
 
   describe('accessibility', () => {
-    handlesAccessibility(Chat, {
-      focusZoneDefinition: (chatBehavior as AccessibilityDefinition).focusZone,
-    })
+    handlesAccessibility(Chat)
   })
 })

--- a/packages/react/test/specs/components/Chat/ChatMessage-test.tsx
+++ b/packages/react/test/specs/components/Chat/ChatMessage-test.tsx
@@ -1,4 +1,3 @@
-import { chatMessageBehavior, AccessibilityDefinition } from '@fluentui/accessibility'
 import * as React from 'react'
 
 import { handlesAccessibility, implementsShorthandProp, isConformant } from 'test/specs/commonTests'
@@ -18,9 +17,7 @@ describe('ChatMessage', () => {
   chatMessageImplementsShorthandProp('content', Box, { mapsValueToProp: 'children' })
 
   describe('accessibility', () => {
-    handlesAccessibility(ChatMessage, {
-      focusZoneDefinition: (chatMessageBehavior as AccessibilityDefinition).focusZone,
-    })
+    handlesAccessibility(ChatMessage)
   })
 
   describe('onMouseEnter', () => {

--- a/packages/react/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/react/test/specs/components/Menu/Menu-test.tsx
@@ -6,7 +6,6 @@ import { mountWithProvider, mountWithProviderAndGetComponent } from 'test/utils'
 import implementsCollectionShorthandProp from '../../commonTests/implementsCollectionShorthandProp'
 import MenuItem from 'src/components/Menu/MenuItem'
 import {
-  AccessibilityDefinition,
   menuBehavior,
   menuAsToolbarBehavior,
   tabListBehavior,
@@ -209,7 +208,6 @@ describe('Menu', () => {
     describe('accessibility', () => {
       handlesAccessibility(Menu, {
         defaultRootRole: 'menu',
-        focusZoneDefinition: (menuBehavior as AccessibilityDefinition).focusZone,
       })
 
       test('aria-label should be added to the menu', () => {


### PR DESCRIPTION
# BREAKING CHANGES

This PR removes:
- `mode` property from `focusZone` configuration accessibility behaviors
- `FocusZoneMode` and `FOCUSZONE_WRAP_ATTRIBUTE` are no longer exported

***

## Motivation

`FocusZoneMode` is never actually used as in all cases we used `FocusZoneMode.Embed` mode. It simplifies logic under `renderComponent()` and allows to have only single way to work with `FocusZone`. Related to #1980 as simplifies `FocusZone` integration.