### PR TITLE
fix(FocusTrapZone): Port FocusTrapZone leak fix from Fabric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix event listener leak in `FocusZone` @miroslavstastny ([#2227](https://github.com/microsoft/fluent-ui-react/pull/2227))
 - Fix styleParam to always be required in the styles functions @layershifter, @mnajdova ([#2235](https://github.com/microsoft/fluent-ui-react/pull/2235))
 - Check input and button refs exist before focus in `Dropdown` @silviuavram ([#2248](https://github.com/microsoft/fluent-ui-react/pull/2248))
-- Fix element reference memory leaks @jurokapsiar ([https://github.com/microsoft/fluent-ui-react/pull/2270](2270))
+- Fix element reference memory leaks @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
 
 ### Features
 - Allow `useRef` hook used for storing debugging data to be defined in any order with other hooks in functional components @layershifter, @mnajdova ([#2236](https://github.com/microsoft/fluent-ui-react/pull/2236))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix event listener leak in `FocusZone` @miroslavstastny ([#2227](https://github.com/microsoft/fluent-ui-react/pull/2227))
 - Fix styleParam to always be required in the styles functions @layershifter, @mnajdova ([#2235](https://github.com/microsoft/fluent-ui-react/pull/2235))
 - Check input and button refs exist before focus in `Dropdown` @silviuavram ([#2248](https://github.com/microsoft/fluent-ui-react/pull/2248))
+- Fix element reference memory leaks @jurokapsiar ([https://github.com/microsoft/fluent-ui-react/pull/2270](2270))
 
 ### Features
 - Allow `useRef` hook used for storing debugging data to be defined in any order with other hooks in functional components @layershifter, @mnajdova ([#2236](https://github.com/microsoft/fluent-ui-react/pull/2236))

--- a/packages/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/react-bindings/src/FocusZone/CHANGELOG.md
@@ -15,6 +15,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - `FocusZone` should respect elements with `contenteditable` attribute on Home/End key press @sophieH29 ([#1749](https://github.com/stardust-ui/react/pull/1749))
 - Fix bidirectional `FocusZone` to land focus correctly on DOWN key press after series of UP arrow keys @sophieH29 ([#1794](https://github.com/stardust-ui/react/pull/1794))
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
+- Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([https://github.com/microsoft/fluent-ui-react/pull/2270](2270))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))

--- a/packages/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/react-bindings/src/FocusZone/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - `FocusZone` should respect elements with `contenteditable` attribute on Home/End key press @sophieH29 ([#1749](https://github.com/stardust-ui/react/pull/1749))
 - Fix bidirectional `FocusZone` to land focus correctly on DOWN key press after series of UP arrow keys @sophieH29 ([#1794](https://github.com/stardust-ui/react/pull/1794))
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
-- Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([https://github.com/microsoft/fluent-ui-react/pull/2270](2270))
+- Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))

--- a/packages/react-bindings/src/FocusZone/FocusTrapZone.tsx
+++ b/packages/react-bindings/src/FocusZone/FocusTrapZone.tsx
@@ -124,6 +124,10 @@ export default class FocusTrapZone extends React.Component<FocusTrapZoneProps, {
     ) {
       this._releaseFocusTrapZone()
     }
+
+    // Dispose of element references so the DOM Nodes can be garbage-collected
+    delete this._previouslyFocusedElementInTrapZone
+    delete this._previouslyFocusedElementOutsideTrapZone
   }
 
   render(): JSX.Element {


### PR DESCRIPTION
FocusTrapZone was keeping reference to previously focused elements. This PR cleans up that reference when unmounted.

https://github.com/OfficeDev/office-ui-fabric-react/pull/11618/files