### PR TITLE
feat(useAccessibility): add support for FocusZone

### DIFF
--- a/packages/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -38,9 +38,7 @@ export interface IFocusZone {
 /**
  * FocusZone component props.
  */
-export interface FocusZoneProps
-  extends FocusZoneProperties,
-    React.HTMLAttributes<HTMLElement | FocusZone> {
+export interface FocusZoneProps extends FocusZoneProperties, React.HTMLAttributes<HTMLElement> {
   /** @docSiteIgnore */
   as?: React.ReactType
   /**

--- a/packages/react-bindings/src/hooks/useAccessibility.ts
+++ b/packages/react-bindings/src/hooks/useAccessibility.ts
@@ -3,12 +3,20 @@ import * as React from 'react'
 
 import getAccessibility from '../accessibility/getAccessibility'
 import { ReactAccessibilityBehavior, AccessibilityActionHandlers } from '../accessibility/types'
+import FocusZone from '../FocusZone/FocusZone'
 
 type UseAccessibilityOptions<Props> = {
   actionHandlers?: AccessibilityActionHandlers
   debugName?: string
   mapPropsToBehavior?: () => Props
   rtl?: boolean
+}
+
+type UseAccessibilityResult = (<SlotProps extends Record<string, any>>(
+  slotName: string,
+  slotProps: SlotProps,
+) => MergedProps<SlotProps>) & {
+  unstable_withFocusZone: (children: React.ReactElement) => React.ReactElement
 }
 
 type MergedProps<SlotProps extends Record<string, any>> = SlotProps &
@@ -62,8 +70,30 @@ const useAccessibility = <Props>(
     actionHandlers,
   )
 
-  return <SlotProps extends Record<string, any>>(slotName: string, slotProps: SlotProps) =>
+  const getA11Props: UseAccessibilityResult = (slotName, slotProps) =>
     mergeProps(slotName, slotProps, definition)
+
+  // Provides an experimental handling for FocusZone definition in behaviors
+  getA11Props.unstable_withFocusZone = (children: React.ReactElement) => {
+    if (definition.focusZone) {
+      let element: React.ReactElement = children
+
+      if (process.env.NODE_ENV !== 'production') {
+        element = React.Children.only(children)
+      }
+
+      return React.createElement(FocusZone, {
+        ...definition.focusZone.props,
+        ...element.props,
+        as: element.type,
+        isRtl: rtl,
+      })
+    }
+
+    return children
+  }
+
+  return getA11Props
 }
 
 export default useAccessibility

--- a/packages/react-bindings/src/hooks/useAccessibility.ts
+++ b/packages/react-bindings/src/hooks/useAccessibility.ts
@@ -16,7 +16,7 @@ type UseAccessibilityResult = (<SlotProps extends Record<string, any>>(
   slotName: string,
   slotProps: SlotProps,
 ) => MergedProps<SlotProps>) & {
-  unstable_withFocusZone: (children: React.ReactElement) => React.ReactElement
+  unstable_wrapWithFocusZone: (children: React.ReactElement) => React.ReactElement
 }
 
 type MergedProps<SlotProps extends Record<string, any>> = SlotProps &
@@ -74,23 +74,23 @@ const useAccessibility = <Props>(
     mergeProps(slotName, slotProps, definition)
 
   // Provides an experimental handling for FocusZone definition in behaviors
-  getA11Props.unstable_withFocusZone = (children: React.ReactElement) => {
+  getA11Props.unstable_wrapWithFocusZone = (element: React.ReactElement) => {
     if (definition.focusZone) {
-      let element: React.ReactElement = children
+      let child: React.ReactElement = element
 
       if (process.env.NODE_ENV !== 'production') {
-        element = React.Children.only(children)
+        child = React.Children.only(element)
       }
 
       return React.createElement(FocusZone, {
         ...definition.focusZone.props,
-        ...element.props,
-        as: element.type,
+        ...child.props,
+        as: child.type,
         isRtl: rtl,
       })
     }
 
-    return children
+    return element
   }
 
   return getA11Props

--- a/packages/react-bindings/test/hooks/useAccessibility-test.tsx
+++ b/packages/react-bindings/test/hooks/useAccessibility-test.tsx
@@ -161,7 +161,7 @@ describe('useAccessibility', () => {
       )
     })
 
-    it.only('passes "rtl" value', () => {
+    it('passes "rtl" value', () => {
       expect(
         shallow(<FocusZoneComponent />)
           .find('FocusZone')

--- a/packages/react-bindings/test/hooks/useAccessibility-test.tsx
+++ b/packages/react-bindings/test/hooks/useAccessibility-test.tsx
@@ -29,6 +29,15 @@ const testBehavior: Accessibility<TestBehaviorProps> = props => ({
   },
 })
 
+const focusZoneBehavior: Accessibility<never> = () => ({
+  focusZone: {
+    props: {
+      disabled: true,
+      shouldFocusOnMount: true,
+    },
+  },
+})
+
 type TestComponentProps = {
   disabled?: boolean
   onClick?: (e: React.KeyboardEvent<HTMLDivElement>, slotName: string) => void
@@ -48,14 +57,28 @@ const TestComponent: React.FunctionComponent<TestComponentProps> = props => {
     },
   })
 
-  return (
+  return getA11Props.unstable_withFocusZone(
     <div {...getA11Props('root', { onKeyDown, ...rest })}>
       <img
         {...getA11Props('img', {
           src: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
         })}
       />
-    </div>
+    </div>,
+  )
+}
+
+type FocusZoneComponentProps = {
+  as?: React.ElementType
+  rtl?: boolean
+}
+
+const FocusZoneComponent: React.FunctionComponent<FocusZoneComponentProps> = props => {
+  const { as: ElementType = 'div', children, rtl = false } = props
+  const getA11Props = useAccessibility(focusZoneBehavior, { rtl })
+
+  return getA11Props.unstable_withFocusZone(
+    <ElementType {...getA11Props('root', {})}>{children}</ElementType>,
   )
 }
 
@@ -114,5 +137,41 @@ describe('useAccessibility', () => {
       }),
       'root',
     )
+  })
+
+  describe('FocusZone', () => {
+    it('do not render FocusZone without the definition in a behavior', () => {
+      expect(shallow(<TestComponent />).find('FocusZone')).toHaveLength(0)
+    })
+
+    it('renders FocusZone with the definition in a behavior', () => {
+      expect(shallow(<FocusZoneComponent />).find('FocusZone')).toHaveLength(1)
+    })
+
+    it('applies props from the behavior to a FocusZone component', () => {
+      expect(
+        shallow(<FocusZoneComponent />)
+          .find('FocusZone')
+          .props(),
+      ).toEqual(
+        expect.objectContaining({
+          disabled: true,
+          shouldFocusOnMount: true,
+        }),
+      )
+    })
+
+    it.only('passes "rtl" value', () => {
+      expect(
+        shallow(<FocusZoneComponent />)
+          .find('FocusZone')
+          .prop('isRtl'),
+      ).toBe(false)
+      expect(
+        shallow(<FocusZoneComponent rtl />)
+          .find('FocusZone')
+          .prop('isRtl'),
+      ).toBe(true)
+    })
   })
 })

--- a/packages/react-bindings/test/hooks/useAccessibility-test.tsx
+++ b/packages/react-bindings/test/hooks/useAccessibility-test.tsx
@@ -57,7 +57,7 @@ const TestComponent: React.FunctionComponent<TestComponentProps> = props => {
     },
   })
 
-  return getA11Props.unstable_withFocusZone(
+  return getA11Props.unstable_wrapWithFocusZone(
     <div {...getA11Props('root', { onKeyDown, ...rest })}>
       <img
         {...getA11Props('img', {
@@ -77,7 +77,7 @@ const FocusZoneComponent: React.FunctionComponent<FocusZoneComponentProps> = pro
   const { as: ElementType = 'div', children, rtl = false } = props
   const getA11Props = useAccessibility(focusZoneBehavior, { rtl })
 
-  return getA11Props.unstable_withFocusZone(
+  return getA11Props.unstable_wrapWithFocusZone(
     <ElementType {...getA11Props('root', {})}>{children}</ElementType>,
   )
 }


### PR DESCRIPTION
This PR adds an experimental support for `FocusZone` to the `useAccessibility` hook as FocusZone behavior can be described in accessibility behaviors.

No changelog entries as this feature is an experimental. To be sure that this API is good we need to do more components, however there should be a way to use `FocusZone` right now and it allows to avoid breaking changes until we will be sure.