### PR TITLE
fix(Dropdown): Move scrollbar so it's reachable

### DIFF
--- a/packages/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -106,7 +106,7 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     overflowY: 'auto',
     maxHeight: v.selectedItemsMaxHeight,
     width: '100%',
-    ...(p.toggleIndicator && { paddingRight: v.toggleIndicatorSize }),
+    ...(p.toggleIndicator && { marginRight: v.toggleIndicatorSize }),
   }),
 
   triggerButton: ({ props: p, variables: v }): ICSSInJSStyle => {


### PR DESCRIPTION
When using the [Dropdown with multiple selection](https://microsoft.github.io/fluent-ui-react/components/dropdown/definition?showCode=false&showRtl=false&showTransparent=false&showVariables=false#variations-search-multiple-image-and-content), it expands to at most three lines of selected items. When selecting even more items, a scrollbar appears.

Currently, the scrollbar shows up underneath the toggle indicator, making it inaccessible by mouse click.
![dropdown padding](https://user-images.githubusercontent.com/2564094/73298402-192c0e80-41c2-11ea-859d-42bd33c9344d.png)

This PR moves the scrollbar into the Dropdown content, to the left of the toggle indicator.
![dropdown margin](https://user-images.githubusercontent.com/2564094/73298455-2ea13880-41c2-11ea-8c1f-44139f2aafd7.png)