### PR TITLE
Refactor alert colors to variables

### DIFF
--- a/packages/react/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertStyles.ts
@@ -6,7 +6,7 @@ import getIconFillOrOutlineStyles from '../../getIconFillOrOutlineStyles'
 
 const getIntentColorsFromProps = (
   p: AlertProps,
-  v: AlertVariables
+  v: AlertVariables,
 ): ICSSInJSStyle => {
 
   if (p.danger) {
@@ -45,7 +45,7 @@ const getIntentColorsFromProps = (
     return {
       color: v.successColor,
       backgroundColor: v.successBackgroundColor,
-      borderColor: v.successBorderColor
+      borderColor: v.successBorderColor,
     }
   }
 

--- a/packages/react/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertStyles.ts
@@ -1,4 +1,4 @@
-import { ComponentSlotStylesPrepared, ICSSInJSStyle, SiteVariablesPrepared } from '@fluentui/styles'
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles'
 import { AlertProps } from '../../../../components/Alert/Alert'
 import { AlertVariables } from './alertVariables'
 import getBorderFocusStyles from '../../getBorderFocusStyles'
@@ -6,10 +6,8 @@ import getIconFillOrOutlineStyles from '../../getIconFillOrOutlineStyles'
 
 const getIntentColorsFromProps = (
   p: AlertProps,
-  v: AlertVariables,
-  siteVars: SiteVariablesPrepared,
+  v: AlertVariables
 ): ICSSInJSStyle => {
-  const { colors } = siteVars
 
   if (p.danger) {
     return {
@@ -45,17 +43,17 @@ const getIntentColorsFromProps = (
 
   if (p.success) {
     return {
-      color: colors.green[600], // $app-green-04
-      backgroundColor: colors.grey[50], // $app-white
-      borderColor: colors.green[200], // $app-green
+      color: v.successColor,
+      backgroundColor: v.successBackgroundColor,
+      borderColor: v.successBorderColor
     }
   }
 
   if (p.warning) {
     return {
-      color: siteVars.colors.grey[450],
-      backgroundColor: colors.grey[50], // $app-white
-      borderColor: colors.yellow[400], // $app-yellow
+      color: v.warningColor,
+      backgroundColor: v.warningBackgroundColor,
+      borderColor: v.warningBorderColor,
     }
   }
 
@@ -79,7 +77,7 @@ const alertStyles: ComponentSlotStylesPrepared<AlertProps, AlertVariables> = {
     fontWeight: v.fontWeight,
     visibility: 'visible',
 
-    ...getIntentColorsFromProps(p, v, siteVariables),
+    ...getIntentColorsFromProps(p, v),
 
     ...((p.attached === 'top' || p.attached === true) && {
       borderRadius: `${v.borderRadius} ${v.borderRadius} 0 0`,

--- a/packages/react/src/themes/teams/components/Alert/alertVariables.ts
+++ b/packages/react/src/themes/teams/components/Alert/alertVariables.ts
@@ -33,10 +33,18 @@ export interface AlertVariables {
   infoBackgroundColor: string
   infoBorderColor: string
 
+  successColor: string
+  successBackgroundColor: string
+  successBorderColor: string
+
   urgent: boolean
   urgentColor: string
   urgentBackgroundColor: string
   urgentBorderColor: string
+
+  warningColor: string
+  warningBackgroundColor: string
+  warningBorderColor: string
 
   headerFontWeight: FontWeightProperty
   headerMargin: string
@@ -77,10 +85,18 @@ export default (siteVars: SiteVariablesPrepared): AlertVariables => {
     infoBackgroundColor: siteVars.colors.grey[150],
     infoBorderColor: siteVars.colors.grey[200],
 
+    successColor: siteVars.colors.green[600],
+    successBackgroundColor: siteVars.colors.grey[50],
+    successBorderColor: siteVars.colors.green[200],
+
     urgent: false,
     urgentColor: siteVars.colors.white,
     urgentBackgroundColor: siteVars.colors.red[400],
     urgentBorderColor: siteVars.colors.red[400],
+
+    warningColor: siteVars.colors.grey[450],
+    warningBackgroundColor: siteVars.colors.grey[50],
+    warningBorderColor: siteVars.colors.yellow[400],
 
     headerFontWeight: siteVars.fontWeightBold,
     headerMargin: `0 ${pxToRem(10)} 0 0`,


### PR DESCRIPTION
I'm doing some light theming for an application over the top of the teams theme.  Most of the alert types are using variables for their colors - so these can be more easily overridden. 

This is a small refactor to make this true for the success and warning states also.