### PR TITLE
perf: Add regression tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,12 @@ jobs:
           command: yarn test:circulars
       - run:
           name: Flamegrill
-          command: yarn perf:test
+          command: |
+            if [ $CIRCLE_BRANCH == 'master' ]; then
+              yarn perf:test:base
+            else
+              yarn perf:test
+            fi
       - run:
           name: Bundle Statistics (master only)
           command: |

--- a/build/dangerjs/checkPerfRegressions.ts
+++ b/build/dangerjs/checkPerfRegressions.ts
@@ -18,14 +18,7 @@ function linkToFlamegraph(value, filename) {
   )})`
 }
 
-function fluentFabricComparision(danger, markdown, warn) {
-  let perfCounts
-  try {
-    perfCounts = require(config.paths.packageDist('perf-test', 'perfCounts.json'))
-  } catch {
-    warn('No perf measurements available')
-    return
-  }
+function fluentFabricComparison(perfCounts, danger, markdown, warn) {
   const results = _.mapValues(
     _.pickBy(perfCounts, (value, key) => key.endsWith('.Fluent')),
     stats => {
@@ -66,7 +59,83 @@ function fluentFabricComparision(danger, markdown, warn) {
     ].join('\n'),
   )
 }
+function currentToMasterComparison(perfCounts, danger, markdown, warn) {
+  const results = _.map(
+    _.pickBy(perfCounts, value => _.has(value, 'analysis.regression')),
+    (stats, name) => {
+      const currentTicks = _.get(stats, 'analysis.numTicks')
+      const baselineTicks = _.get(stats, 'analysis.baseline.numTicks')
+
+      return {
+        name,
+        numTicks: currentTicks,
+        flamegraphFile: _.get(stats, 'processed.output.flamegraphFile'),
+        baseline: {
+          numTicks: baselineTicks,
+          flamegraphFile: _.get(stats, 'processed.output.flamegraphFile'),
+        },
+        isRegression: _.get(stats, 'analysis.regression.isRegression'),
+        currentToBaseline: Math.round((currentTicks / baselineTicks) * 100) / 100,
+      }
+    },
+  )
+
+  const regressions = _.sortBy(
+    _.filter(results, 'isRegression'),
+    stats => stats.currentToBaseline * -1,
+  )
+
+  if (regressions.length > 0) {
+    warn(`${regressions.length} perf regressions detected`)
+    markdown(
+      [
+        '## Regressions compared to master',
+        '',
+        'Scenario | Current PR Ticks | Baseline Ticks | Ratio',
+        ':--- | ---:| ---:| ---:',
+        ..._.map(regressions, (value, key) =>
+          [
+            value.name,
+            linkToFlamegraph(value.numTicks, value.flamegraphFile),
+            linkToFlamegraph(value.baseline.numTicks, value.baseline.flamegraphFile),
+            `${value.currentToBaseline}:1`,
+          ].join(' | '),
+        ),
+      ].join('\n'),
+    )
+  }
+
+  const noRegressions = _.sortBy(
+    _.filter(results, stats => !stats.isRegression),
+    stats => stats.currentToBaseline * -1,
+  )
+  markdown(
+    [
+      '## Perf test with no regressions',
+      '',
+      'Scenario | Current PR Ticks | Baseline Ticks | Ratio',
+      ':--- | ---:| ---:| ---:',
+      ..._.map(noRegressions, (value, key) =>
+        [
+          value.name,
+          linkToFlamegraph(value.numTicks, value.flamegraphFile),
+          linkToFlamegraph(value.baseline.numTicks, value.baseline.flamegraphFile),
+          `${value.currentToBaseline}:1`,
+        ].join(' | '),
+      ),
+    ].join('\n'),
+  )
+}
 
 export default ({ danger, markdown, warn }: DangerJS) => {
-  fluentFabricComparision(danger, markdown, warn)
+  let perfCounts
+  try {
+    perfCounts = require(config.paths.packageDist('perf-test', 'perfCounts.json'))
+  } catch {
+    warn('No perf measurements available')
+    return
+  }
+
+  fluentFabricComparison(perfCounts, danger, markdown, warn)
+  currentToMasterComparison(perfCounts, danger, markdown, warn)
 }

--- a/build/dangerjs/checkPerfRegressions.ts
+++ b/build/dangerjs/checkPerfRegressions.ts
@@ -72,7 +72,7 @@ function currentToMasterComparison(perfCounts, danger, markdown, warn) {
         flamegraphFile: _.get(stats, 'processed.output.flamegraphFile'),
         baseline: {
           numTicks: baselineTicks,
-          flamegraphFile: _.get(stats, 'processed.output.flamegraphFile'),
+          flamegraphFile: _.get(stats, 'processed.baseline.output.flamegraphFile'),
         },
         isRegression: _.get(stats, 'analysis.regression.isRegression'),
         currentToBaseline: Math.round((currentTicks / baselineTicks) * 100) / 100,
@@ -111,7 +111,7 @@ function currentToMasterComparison(perfCounts, danger, markdown, warn) {
   )
   markdown(
     [
-      '<details><summary>Perf test with no regressions</summary>',
+      '<details><summary>Perf tests with no regressions</summary>',
       '',
       'Scenario | Current PR Ticks | Baseline Ticks | Ratio',
       ':--- | ---:| ---:| ---:',

--- a/build/dangerjs/checkPerfRegressions.ts
+++ b/build/dangerjs/checkPerfRegressions.ts
@@ -89,7 +89,7 @@ function currentToMasterComparison(perfCounts, danger, markdown, warn) {
     warn(`${regressions.length} perf regressions detected`)
     markdown(
       [
-        '## Regressions compared to master',
+        '## Potential regressions comparing to master',
         '',
         'Scenario | Current PR Ticks | Baseline Ticks | Ratio',
         ':--- | ---:| ---:| ---:',
@@ -111,7 +111,7 @@ function currentToMasterComparison(perfCounts, danger, markdown, warn) {
   )
   markdown(
     [
-      '## Perf test with no regressions',
+      '<details><summary>Perf test with no regressions</summary>',
       '',
       'Scenario | Current PR Ticks | Baseline Ticks | Ratio',
       ':--- | ---:| ---:| ---:',
@@ -123,6 +123,8 @@ function currentToMasterComparison(perfCounts, danger, markdown, warn) {
           `${value.currentToBaseline}:1`,
         ].join(' | '),
       ),
+      '',
+      '</details>',
     ].join('\n'),
   )
 }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,4 +1,4 @@
-import { danger, fail, warn, markdown } from 'danger'
+import { danger, fail, warn, markdown, message } from 'danger'
 import checkChangelog from './build/dangerjs/checkChangelog'
 import detectChangedDependencies from './build/dangerjs/detectChangedDependencies'
 import detectNonApprovedDependencies from './build/dangerjs/detectNonApprovedDependencies'
@@ -8,7 +8,7 @@ import checkPerfRegressions from './build/dangerjs/checkPerfRegressions'
  * This trick (of explicitly passing Danger JS utils as function arg, instead of importing them at places where needed)
  * is necessary due to the magic DangerJS is doing with imports: https://spectrum.chat/danger/javascript/danger-js-actually-runs-your-imports-as-globals~0a005b56-31ec-4919-9a28-ced623949d4d
  */
-const dangerJS = { danger, fail, warn, markdown }
+const dangerJS = { danger, fail, warn, markdown, message }
 
 export default async () => {
   await checkChangelog(dangerJS)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "perf": "cross-env PERF=true gulp perf --times=100",
     "perf:debug": "cross-env PERF=true gulp perf:debug --debug",
     "perf:test": "yarn lerna run --stream --scope @fluentui/perf-test perf:test",
+    "perf:test:base": "yarn lerna run --stream --scope @fluentui/perf-test perf:test:base",
     "prettier": "prettier --list-different \"**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx}\"",
     "precommit": "lint-staged",

--- a/packages/perf-test/just.config.ts
+++ b/packages/perf-test/just.config.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import '@fluentui/scripts/tasks/preset'
-import { series, task } from '@fluentui/scripts'
+import { series, task, argv } from '@fluentui/scripts'
 
 // TODO: FUR integration issues
 // - FUR build fails when it comes across these new packages inside of packages/
@@ -26,7 +26,8 @@ task('perf-test:bundle', bundleStories())
 task('perf-test:run', () => {
   // delay require in case digest isn't built yet
   const runPerfTest = require('./tasks/perf-test').default
-  return runPerfTest()
+
+  return runPerfTest(argv().base)
 })
 
 // TOOD: is build doing anything meaningful? only if there's source that's not a just script?

--- a/packages/perf-test/package.json
+++ b/packages/perf-test/package.json
@@ -12,7 +12,8 @@
     "build": "just-scripts build",
     "clean": "just-scripts clean",
     "test": "just-scripts test",
-    "perf:test": "just-scripts perf-test"
+    "perf:test": "just-scripts perf-test",
+    "perf:test:base": "just-scripts perf-test --base"
   },
   "devDependencies": {
     "@fluentui/digest": "^0.43.0",
@@ -21,7 +22,8 @@
     "@types/webpack-env": "^1.14.1",
     "flamegrill": "^0.1.3",
     "ignore-not-found-export-webpack-plugin": "^1.0.1",
-    "just-scripts": "^0.35.0"
+    "just-scripts": "^0.35.0",
+    "node-fetch": "^2.6.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Compare current PR performance to latest master and show the results in the PR:

![image](https://user-images.githubusercontent.com/9615899/73517708-82976180-43fc-11ea-9c4c-72c9b61e510c.png)

If there is any potential regression found, a warning comment is added to the PR.

Ratio column show ratio of Current PR to master. The lower the better.
To detect potential regression we are NOT using Current PR to master tick ratio as those are unstable. Flamegrill's smart detection is used. That means that even if the `ratio > 1:1` the change might not be considered a regression.

Currently perf is compared to the **latest master** not the corresponding fork point.