### PR TITLE
fix(FocusZone): Cleanup DOM element references on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
-- `FocusZone`: Cleanup DOM element references when the component is unmounted @johannao76 ([2304](https://github.com/microsoft/fluent-ui-react/pull/2304))
+- `FocusZone`: Cleanup DOM element references when the component is unmounted @johannao76 ([#2304](https://github.com/microsoft/fluent-ui-react/pull/2304))
 
 ### BREAKING CHANGES
 - Add `@fluentui/styles` package for all styles' related utilities and TS types @layershifter, @mnajdova ([#2222](https://github.com/microsoft/fluent-ui-react/pull/2222))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- `FocusZone`: Cleanup DOM element references ( _activeElement, _defaultFocusElement) when the component is unmounted @johannao76 ([2304](https://github.com/microsoft/fluent-ui-react/pull/2304))
+
 ### BREAKING CHANGES
 - Add `@fluentui/styles` package for all styles' related utilities and TS types @layershifter, @mnajdova ([#2222](https://github.com/microsoft/fluent-ui-react/pull/2222))
 - Remove `animation` prop from all components @joschect ([#2239](https://github.com/microsoft/fluent-ui-react/pull/2239))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
-- `FocusZone`: Cleanup DOM element references ( _activeElement, _defaultFocusElement) when the component is unmounted @johannao76 ([2304](https://github.com/microsoft/fluent-ui-react/pull/2304))
+- `FocusZone`: Cleanup DOM element references when the component is unmounted @johannao76 ([2304](https://github.com/microsoft/fluent-ui-react/pull/2304))
 
 ### BREAKING CHANGES
 - Add `@fluentui/styles` package for all styles' related utilities and TS types @layershifter, @mnajdova ([#2222](https://github.com/microsoft/fluent-ui-react/pull/2222))

--- a/packages/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/react-bindings/src/FocusZone/FocusZone.tsx
@@ -206,6 +206,9 @@ export default class FocusZone extends React.Component<FocusZoneProps> implement
     if (this._root.current) {
       this._root.current.removeEventListener('blur', this._onBlur, true)
     }
+
+    this._activeElement = null;
+    this._defaultFocusElement = null;
   }
 
   render() {

--- a/packages/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/react-bindings/src/FocusZone/FocusZone.tsx
@@ -207,8 +207,8 @@ export default class FocusZone extends React.Component<FocusZoneProps> implement
       this._root.current.removeEventListener('blur', this._onBlur, true)
     }
 
-    this._activeElement = null;
-    this._defaultFocusElement = null;
+    this._activeElement = null
+    this._defaultFocusElement = null
   }
 
   render() {


### PR DESCRIPTION
The FocusZone component holds references to _activeElement and _defaultFocusElement. These references should be nulled out when the component is unmounted to prevent memory leaks.

Fixes #2303

