### PR TITLE
doc: Use correct accessibility package version in codesandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Documentation
 - Add per-component performance charts @miroslavstastny ([#2240](https://github.com/microsoft/fluent-ui-react/pull/2240))
+- Fix dependencies in project exported to codesandbox @miroslavstastny ([#2314](https://github.com/microsoft/fluent-ui-react/pull/2314))
 
 <!--------------------------------[ v0.43.1 ]------------------------------- -->
 ## [v0.43.1](https://github.com/microsoft/fluent-ui-react/tree/v0.43.1) (2020-01-30)

--- a/docs/src/components/Playground/renderConfig.ts
+++ b/docs/src/components/Playground/renderConfig.ts
@@ -8,6 +8,7 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as Classnames from 'classnames'
 
+const accessibilityPackageJson = require('@fluentui/accessibility/package.json')
 const docsComponentsPackageJson = require('@fluentui/docs-components/package.json')
 const projectPackageJson = require('@fluentui/react/package.json')
 
@@ -23,7 +24,7 @@ export const babelConfig = {
 
 export const imports: Record<string, { version: string; module: any }> = {
   '@fluentui/accessibility': {
-    version: projectPackageJson.version,
+    version: accessibilityPackageJson.version,
     module: Accessibility,
   },
 


### PR DESCRIPTION
@fluentui/react package version was incorrectly used for @fluentui/accessibility in project exported to codesandbox.

That breaks if @fluentui/react is released without releasing @fluentui/accessibility.