### PR TITLE
chore(Provider): refactor to function component

### DIFF
--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -1,10 +1,8 @@
 import { IStyle } from 'fela'
 import * as _ from 'lodash'
 import { Renderer, Telemetry } from '@fluentui/react-bindings'
-import * as customPropTypes from '@fluentui/react-proptypes'
 import {
   mergeSiteVariables,
-  ThemePrepared,
   StaticStyleObject,
   StaticStyle,
   StaticStyleFunction,
@@ -28,6 +26,8 @@ import {
   withSafeTypeForAs,
 } from '../../types'
 import mergeContexts from '../../utils/mergeProviderContexts'
+import { getUnhandledProps } from '@fluentui/react-bindings/src'
+import { SiteVariablesPrepared } from '@fluentui/styles/src'
 
 export interface ProviderProps extends ChildrenComponentProps {
   renderer?: Renderer
@@ -37,192 +37,176 @@ export interface ProviderProps extends ChildrenComponentProps {
   target?: Document
   theme?: ThemeInput
   variables?: ComponentVariablesInput
-  telemetryRef?: React.Ref<Telemetry>
+  telemetryRef?: React.MutableRefObject<Telemetry>
+}
+
+const renderFontFaces = (renderer: Renderer, theme: ThemeInput) => {
+  if (!theme.fontFaces) {
+    return
+  }
+
+  const renderFontObject = (font: FontFace) => {
+    if (!_.isPlainObject(font)) {
+      throw new Error(`fontFaces must be objects, got: ${typeof font}`)
+    }
+
+    renderer.renderFont(font.name, font.paths, font.props)
+  }
+
+  theme.fontFaces.forEach((font: FontFace) => {
+    renderFontObject(font)
+  })
+}
+
+const renderStaticStyles = (
+  renderer: Renderer,
+  theme: ThemeInput,
+  siteVariables: SiteVariablesPrepared,
+) => {
+  if (!theme.staticStyles) {
+    return
+  }
+
+  const renderObject = (object: StaticStyleObject) => {
+    _.forEach(object, (style, selector) => {
+      renderer.renderStatic(style as IStyle, selector)
+    })
+  }
+
+  theme.staticStyles.forEach((staticStyle: StaticStyle) => {
+    if (typeof staticStyle === 'string') {
+      renderer.renderStatic(staticStyle)
+    } else if (_.isPlainObject(staticStyle)) {
+      renderObject(staticStyle as StaticStyleObject)
+    } else if (_.isFunction(staticStyle)) {
+      const preparedSiteVariables = mergeSiteVariables(siteVariables)
+      renderObject((staticStyle as StaticStyleFunction)(preparedSiteVariables))
+    } else {
+      throw new Error(
+        `staticStyles array must contain CSS strings, style objects, or style functions, got: ${typeof staticStyle}`,
+      )
+    }
+  })
 }
 
 /**
  * The Provider passes the CSS-in-JS renderer, theme styles and other settings to Fluent UI components.
  */
-class Provider extends React.Component<WithAsProp<ProviderProps>> {
-  static displayName = 'Provider'
+const Provider: React.FC<WithAsProp<ProviderProps>> & {
+  Box: typeof ProviderBox
+  Consumer: typeof ProviderConsumer
+  handledProps: (keyof ProviderProps)[]
+} = props => {
+  const { as, children, overwrite, variables, telemetryRef } = props
+  const unhandledProps = getUnhandledProps(Provider.handledProps, props)
 
-  static propTypes = {
-    as: PropTypes.elementType,
-    variables: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-    theme: PropTypes.shape({
-      siteVariables: PropTypes.object,
-      componentVariables: PropTypes.object,
-      componentStyles: PropTypes.object,
-      fontFaces: PropTypes.arrayOf(
-        PropTypes.shape({
-          name: PropTypes.string,
-          paths: PropTypes.arrayOf(PropTypes.string),
-          style: PropTypes.shape({
-            fontStretch: PropTypes.string,
-            fontStyle: PropTypes.string,
-            fontVariant: PropTypes.string,
-            fontWeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            localAlias: PropTypes.string,
-            unicodeRange: PropTypes.string,
-          }),
-        }),
-      ),
-      staticStyles: PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
-      ),
-      animations: PropTypes.object,
-    }),
-    renderer: PropTypes.object,
-    rtl: PropTypes.bool,
-    disableAnimations: PropTypes.bool,
-    children: PropTypes.node.isRequired,
-    target: PropTypes.object,
-    telemetryRef: customPropTypes.ref,
-  }
-
-  static defaultProps = {
-    theme: {},
-  }
-
-  static Consumer = ProviderConsumer
-  static Box = ProviderBox
-  static contextType = ThemeContext
-
-  outgoingContext: ProviderContextPrepared
-  staticStylesRendered: boolean = false
-
-  telemetry: Telemetry
-
-  renderStaticStyles = (renderer: Renderer, mergedTheme: ThemePrepared) => {
-    const { siteVariables } = mergedTheme
-    const { staticStyles } = this.props.theme
-
-    if (!staticStyles) return
-
-    const renderObject = (object: StaticStyleObject) => {
-      _.forEach(object, (style, selector) => {
-        renderer.renderStatic(style as IStyle, selector)
-      })
+  const telemetry = React.useMemo<Telemetry | undefined>(() => {
+    if (!telemetryRef) {
+      return undefined
     }
 
-    staticStyles.forEach((staticStyle: StaticStyle) => {
-      if (typeof staticStyle === 'string') {
-        renderer.renderStatic(staticStyle)
-      } else if (_.isPlainObject(staticStyle)) {
-        renderObject(staticStyle as StaticStyleObject)
-      } else if (_.isFunction(staticStyle)) {
-        const preparedSiteVariables = mergeSiteVariables(siteVariables)
-        renderObject((staticStyle as StaticStyleFunction)(preparedSiteVariables))
-      } else {
-        throw new Error(
-          `staticStyles array must contain CSS strings, style objects, or style functions, got: ${typeof staticStyle}`,
-        )
+    if (!telemetryRef.current) {
+      telemetryRef.current = new Telemetry()
+    }
+
+    return telemetryRef.current
+  }, [telemetryRef])
+  const inputContext: ProviderContextInput = {
+    theme: props.theme,
+    rtl: props.rtl,
+    disableAnimations: props.disableAnimations,
+    renderer: props.renderer,
+    target: props.target,
+    telemetry,
+  }
+
+  const consumedContext: ProviderContextPrepared = React.useContext(ThemeContext)
+  const incomingContext: ProviderContextPrepared = overwrite ? ({} as any) : consumedContext
+
+  // rehydration disabled to avoid leaking styles between renderers
+  // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
+  const outgoingContext = mergeContexts(incomingContext, inputContext)
+
+  const rtlProps: { dir?: 'rtl' | 'ltr' } = {}
+  // only add dir attribute for top level provider or when direction changes from parent to child
+  if (
+    !consumedContext ||
+    (consumedContext.rtl !== outgoingContext.rtl && _.isBoolean(outgoingContext.rtl))
+  ) {
+    rtlProps.dir = outgoingContext.rtl ? 'rtl' : 'ltr'
+  }
+
+  React.useLayoutEffect(() => {
+    renderFontFaces(outgoingContext.renderer, props.theme)
+    renderStaticStyles(outgoingContext.renderer, props.theme, outgoingContext.theme.siteVariables)
+
+    if (props.target) {
+      setUpWhatInput(props.target)
+    }
+
+    return () => {
+      if (props.target) {
+        tryCleanupWhatInput(props.target)
       }
-    })
-  }
-
-  renderFontFaces = (renderer: Renderer) => {
-    const { fontFaces } = this.props.theme
-
-    if (!fontFaces) return
-
-    const renderFontObject = (font: FontFace) => {
-      if (!_.isPlainObject(font)) {
-        throw new Error(`fontFaces must be objects, got: ${typeof font}`)
-      }
-
-      renderer.renderFont(font.name, font.paths, font.props)
     }
+  }, [])
 
-    fontFaces.forEach((font: FontFace) => {
-      renderFontObject(font)
-    })
-  }
-
-  componentDidMount() {
-    this.renderFontFaces(this.outgoingContext.renderer)
-    if (this.props.target) {
-      setUpWhatInput(this.props.target)
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.props.target) {
-      tryCleanupWhatInput(this.props.target)
-    }
-  }
-
-  render() {
-    const {
-      as,
-      children,
-      disableAnimations,
-      overwrite,
-      renderer,
-      rtl,
-      target,
-      theme,
-      variables,
-      telemetryRef,
-      ...unhandledProps
-    } = this.props
-
-    if (telemetryRef) {
-      if (!this.telemetry) {
-        this.telemetry = new Telemetry()
-      }
-
-      telemetryRef['current'] = this.telemetry
-    } else if (this.telemetry) {
-      delete this.telemetry
-    }
-
-    const inputContext: ProviderContextInput = {
-      theme,
-      rtl,
-      disableAnimations,
-      renderer,
-      target,
-      telemetry: this.telemetry,
-    }
-
-    const incomingContext: ProviderContextPrepared = overwrite ? {} : this.context
-    // rehydration disabled to avoid leaking styles between renderers
-    // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
-    this.outgoingContext = mergeContexts(incomingContext, inputContext)
-
-    this.renderStaticStylesOnce(this.outgoingContext.theme)
-
-    const rtlProps: { dir?: 'rtl' | 'ltr' } = {}
-    // only add dir attribute for top level provider or when direction changes from parent to child
-    if (
-      !this.context ||
-      (this.context.rtl !== this.outgoingContext.rtl && _.isBoolean(this.outgoingContext.rtl))
-    ) {
-      rtlProps.dir = this.outgoingContext.rtl ? 'rtl' : 'ltr'
-    }
-
-    return (
-      <RendererProvider
-        renderer={this.outgoingContext.renderer}
-        {...{ rehydrate: false, targetDocument: this.outgoingContext.target }}
-      >
-        <ThemeProvider theme={this.outgoingContext} overwrite>
-          <ProviderBox as={as} variables={variables} {...unhandledProps} {...rtlProps}>
-            {children}
-          </ProviderBox>
-        </ThemeProvider>
-      </RendererProvider>
-    )
-  }
-
-  renderStaticStylesOnce = (mergedTheme: ThemePrepared) => {
-    const { staticStyles } = this.props.theme
-    if (!this.staticStylesRendered && staticStyles) {
-      this.renderStaticStyles(this.outgoingContext.renderer, mergedTheme)
-      this.staticStylesRendered = true
-    }
-  }
+  return (
+    <RendererProvider
+      renderer={outgoingContext.renderer}
+      {...{ rehydrate: false, targetDocument: outgoingContext.target }}
+    >
+      <ThemeProvider theme={outgoingContext} overwrite>
+        <ProviderBox as={as} variables={variables} {...unhandledProps} {...rtlProps}>
+          {children}
+        </ProviderBox>
+      </ThemeProvider>
+    </RendererProvider>
+  )
 }
+
+Provider.displayName = 'Provider'
+
+Provider.defaultProps = {
+  theme: {},
+}
+Provider.propTypes = {
+  as: PropTypes.elementType,
+  variables: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  theme: PropTypes.shape({
+    siteVariables: PropTypes.object,
+    componentVariables: PropTypes.object,
+    componentStyles: PropTypes.object,
+    fontFaces: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        paths: PropTypes.arrayOf(PropTypes.string),
+        style: PropTypes.shape({
+          fontStretch: PropTypes.string,
+          fontStyle: PropTypes.string,
+          fontVariant: PropTypes.string,
+          fontWeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+          localAlias: PropTypes.string,
+          unicodeRange: PropTypes.string,
+        }),
+      }),
+    ),
+    staticStyles: PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
+    ),
+    animations: PropTypes.object,
+  }),
+  renderer: PropTypes.object as PropTypes.Validator<Renderer>,
+  rtl: PropTypes.bool,
+  disableAnimations: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  overwrite: PropTypes.bool,
+  target: PropTypes.object as PropTypes.Validator<Document>,
+  telemetryRef: PropTypes.object as PropTypes.Validator<React.MutableRefObject<Telemetry>>,
+}
+Provider.handledProps = Object.keys(Provider.propTypes) as any
+
+Provider.Consumer = ProviderConsumer
+Provider.Box = ProviderBox
 
 export default withSafeTypeForAs<typeof Provider, ProviderProps & ProviderBoxProps>(Provider)

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -1,6 +1,6 @@
 import { IStyle } from 'fela'
 import * as _ from 'lodash'
-import { Renderer, Telemetry } from '@fluentui/react-bindings'
+import { getUnhandledProps, Renderer, Telemetry } from '@fluentui/react-bindings'
 import {
   mergeSiteVariables,
   StaticStyleObject,
@@ -9,6 +9,7 @@ import {
   FontFace,
   ComponentVariablesInput,
   ThemeInput,
+  SiteVariablesPrepared,
 } from '@fluentui/styles'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
@@ -26,8 +27,6 @@ import {
   withSafeTypeForAs,
 } from '../../types'
 import mergeContexts from '../../utils/mergeProviderContexts'
-import { getUnhandledProps } from '@fluentui/react-bindings/src'
-import { SiteVariablesPrepared } from '@fluentui/styles/src'
 
 export interface ProviderProps extends ChildrenComponentProps {
   renderer?: Renderer


### PR DESCRIPTION
This PR converts `Provider` to a function component, there are two goals for this:
- remove `ProviderBox` component later as we will be able to compute styles directly for `Provider`
- unblock #2192 to get more accurate solution for rendering portals