### PR TITLE
chore: fix `yarn ci`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "gulp build",
     "build:bundle": "gulp bundle:all-packages",
     "build:docs": "gulp build:docs",
-    "ci": "yarn lint && yarn prettier && yarn test --strict",
+    "ci": "yarn lint && yarn prettier && yarn test -- -- --strict",
     "clean": "yarn clean:cache && yarn clean:docs && lerna run --stream clean",
     "clean:cache": "gulp clean:cache",
     "clean:docs": "gulp clean:docs",


### PR DESCRIPTION
`yarn ci` was broken:

```
$ yarn satisfied && lerna run test --stream --strict
$ satisfied --skip-invalid
ERR! lerna Unknown argument: strict
```

Updated the command to pass `--strict` down to child packages' `yarn test`.

/cc @ecraig12345 