### PR TITLE
RFC: remove icons from themes

### DIFF
--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -16,6 +16,12 @@ import { WithAsProp, withSafeTypeForAs } from '../../types'
 
 export type IconXSpacing = 'none' | 'before' | 'after' | 'both'
 
+export type IconDefinition = {
+  className?: string
+  type: 'font' | 'svg'
+  icon?: () => React.ReactSVGElement
+}
+
 export interface IconProps extends UIComponentProps, ColorComponentProps {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility
@@ -29,7 +35,10 @@ export interface IconProps extends UIComponentProps, ColorComponentProps {
   /** An icon can show it is currently unable to be interacted with. */
   disabled?: boolean
 
+  definition?: IconDefinition
+
   /** Name of the icon. */
+  // TODO: REMOVE ME
   name: string
 
   /** An icon can provide an outline variant. */
@@ -76,15 +85,25 @@ class Icon extends UIComponent<WithAsProp<IconProps>, any> {
   }
 
   renderComponent({ ElementType, classes, unhandledProps, accessibility, theme, rtl, styles }) {
-    const { name } = this.props
-    const { icons = {} } = theme || {}
+    const { definition, name } = this.props
 
-    const maybeIcon = icons[name]
-    const isSvgIcon = maybeIcon && maybeIcon.isSvg
+    let isSvgIcon: boolean
+    let iconComponent: React.ElementType
+
+    if (definition) {
+      iconComponent = definition.icon
+      isSvgIcon = definition.type === 'svg'
+    } else {
+      const { icons = {} } = theme || {}
+      const maybeIcon = icons[name]
+
+      iconComponent = maybeIcon.icon
+      isSvgIcon = maybeIcon && maybeIcon.isSvg
+    }
 
     return (
       <ElementType className={classes.root} {...accessibility.attributes.root} {...unhandledProps}>
-        {isSvgIcon && callable(maybeIcon.icon)({ classes, rtl, props: this.props })}
+        {isSvgIcon && callable(iconComponent)({ classes, rtl, props: this.props })}
       </ElementType>
     )
   }


### PR DESCRIPTION
# Issue? 💣 

Icons in theme create bloat as they are not tree-shakable, see #2113. Currently we have **178** icons   that will be imported for Teams theme **always**. They are also defined as React JSX elements so they are not framework agnostic and can't be reused without React.

# Story ⌛️ 

We placed icons under the theme with an assumption that they are part of branding and it's **true**. If icons are the part of themes it allows to power theme switching capabilities and use the same code with different branding. 

But it's a **big lie** as it requires to align names for everything, i.e. `arrow-right` and `arrowRight` are different things and it will break theme switching. I think that our requirement with having icons under theme is broken, but can but there are some cases with embedded higher order components, see below.
 
# Proposal ✋ 

## Do not use `Icon` component internally

![image](https://user-images.githubusercontent.com/14183168/73839811-27f47000-4817-11ea-890f-f5ff244b4936.png)

- it creates a hidden dependency on `icon-menu-arrow-end`
- it creates a dependency on `Icon` component

In Semantic UI in such cases styles are defined in component:

![image](https://user-images.githubusercontent.com/14183168/73839707-ea8fe280-4816-11ea-9c96-f14087f644b2.png)
![image](https://user-images.githubusercontent.com/14183168/73839735-fed3df80-4816-11ea-8138-4fda52678da6.png)

My proposal is to embed these icons to component's styles:

```tsx
Icon.create(submenuIndicator, {
  defaultProps: () => ({
    name: 'icon-menu-arrow-end',
    styles: styles.submenuIndicator,
  }),
})
// becomes
Box.create(submenuIndicator, {
  defaultProps: () => ({
    styles: styles.submenuIndicator,
  }),
})
```

## Solve `Icon` component

I propose to remove icons from themes at all and then I see three options how icons can be used.

### `<BookIcon size='large' />`

Use icons as separate React components like in [`react-icons`](https://www.npmjs.com/package/react-icons) & [`grommet-icons`](https://icons.grommet.io/).

```tsx
<BookIcon />
<CameraIcon />
```

- 👍 obvious dependency
- 👍 each icon can have specific props
- 👍 type safe
- 👎 ???

### `<Icon name="book" />`

Register icons manually before usage like in [`react-fontawesome`](https://github.com/FortAwesome/react-fontawesome#build-a-library-to-reference-icons-throughout-your-app-more-conveniently).

```tsx
icons.register(bookIcon)
//
<Icon name="book" />
```

- 👍 keeps existing API
- 👎 not type safe
- 👎 not safe:
    - if an icon will be removed it should be removed in two places
    - easily to forgot to do registration

### `<Icon definition={bookIcon} />`

Use an object with definitions instead of `name` like in [`react-fontawesome`](https://github.com/FortAwesome/react-fontawesome#explicit-import).

```tsx
<Icon definition={bookIcon} />
<Icon definition={cameraIcon} />
```

- 👍 obvious dependency
- 👍 type safe
- 👍 close to the existing API
- 👎 custom props can be an issue

# Embedded components 🏭 

We still need to have a recipe for embedded components, I propose two options.

### Option 1: React.Context or props approach

Icons be mapped to props via `Provider` component and then can be used inside of it.

Demo: https://codesandbox.io/s/mystifying-tree-qpcq3

- 👍 type safe
- 👍 good bundle size (only used icons will be really included)
- 👎 explicit configuration, can be solved with defaults options (will increase bundle size)

### Option 2: CSS approach

Even SVGs can be used as `url()` ([converter](https://yoksel.github.io/url-encoder/)).

Demo: https://codesandbox.io/s/wandering-fire-xpqlw

- 👍 no React specific things
- 👎 can increase bundle size