### PR TITLE
chore: Add bundle analyzer to local-sandbox

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -78,7 +78,7 @@
     "tmp": "^0.0.33",
     "tsconfig-paths": "^3.7.0",
     "webpack": "^4.35.0",
-    "webpack-bundle-analyzer": "^3.3.2",
+    "webpack-bundle-analyzer": "^3.6.0",
     "webpack-dev-middleware": "^3.6.2",
     "webpack-hot-middleware": "^2.24.3"
   },

--- a/packages/local-sandbox/README.md
+++ b/packages/local-sandbox/README.md
@@ -11,3 +11,6 @@ yarn build:production
 yarn serve
 ```  
 
+## Measuring bundle size
+
+This package can be also used to analyze bundle size. After running `yarn build:production`, bundle size report is stored to **dist/report.html**. 

--- a/packages/local-sandbox/package.json
+++ b/packages/local-sandbox/package.json
@@ -19,6 +19,7 @@
     "copy-webpack-plugin": "^4.5.2",
     "express": "^4.15.4",
     "fork-ts-checker-webpack-plugin": "^1.3.3",
+    "terser-webpack-plugin": "^1.4.3",
     "typescript": "~3.7.2",
     "webpack": "^4.35.0",
     "webpack-bundle-analyzer": "^3.6.0",

--- a/packages/local-sandbox/package.json
+++ b/packages/local-sandbox/package.json
@@ -17,11 +17,12 @@
   "devDependencies": {
     "babel-loader": "^8.0.6",
     "copy-webpack-plugin": "^4.5.2",
+    "express": "^4.15.4",
     "fork-ts-checker-webpack-plugin": "^1.3.3",
     "typescript": "~3.7.2",
     "webpack": "^4.35.0",
-    "webpack-cli": "^3.3.10",
-    "express": "^4.15.4"
+    "webpack-bundle-analyzer": "^3.6.0",
+    "webpack-cli": "^3.3.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/local-sandbox/webpack.config.ts
+++ b/packages/local-sandbox/webpack.config.ts
@@ -3,8 +3,9 @@ import * as webpack from 'webpack'
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
 
-const webpackConfig: webpack.ConfigurationFactory = (env, argv) => ({
+const webpackConfig: webpack.Configuration = {
   name: 'client',
   target: 'web',
   mode: 'development',
@@ -14,7 +15,7 @@ const webpackConfig: webpack.ConfigurationFactory = (env, argv) => ({
   output: {
     filename: `[name].js`,
   },
-  devtool: 'eval-source-map',
+  devtool: 'source-map',
   module: {
     rules: [
       {
@@ -45,11 +46,23 @@ const webpackConfig: webpack.ConfigurationFactory = (env, argv) => ({
   performance: {
     hints: false, // to (temporarily) disable "WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit")
   },
-  ...(argv.mode === 'development' && {
-    optimization: {
-      minimize: false,
-    },
-  }),
-})
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        cache: true,
+        parallel: true,
+        sourceMap: true,
+        terserOptions: {
+          // https://github.com/terser/terser
+          mangle: false,
+          output: {
+            beautify: true,
+            comments: true,
+          },
+        },
+      }),
+    ],
+  },
+}
 
 module.exports = webpackConfig

--- a/packages/local-sandbox/webpack.config.ts
+++ b/packages/local-sandbox/webpack.config.ts
@@ -1,9 +1,10 @@
 import * as webpack from 'webpack'
 
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
-const webpackConfig: webpack.Configuration = {
+const webpackConfig: webpack.ConfigurationFactory = (env, argv) => ({
   name: 'client',
   target: 'web',
   mode: 'development',
@@ -33,6 +34,10 @@ const webpackConfig: webpack.Configuration = {
         from: 'public/index.html',
       },
     ]),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      openAnalyzer: false,
+    }),
   ],
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
@@ -40,9 +45,11 @@ const webpackConfig: webpack.Configuration = {
   performance: {
     hints: false, // to (temporarily) disable "WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit")
   },
-  optimization: {
-    minimize: false,
-  },
-}
+  ...(argv.mode === 'development' && {
+    optimization: {
+      minimize: false,
+    },
+  }),
+})
 
 module.exports = webpackConfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -20494,10 +20494,10 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-bundle-analyzer@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz#3da733a900f515914e729fcebcd4c40dde71fc6f"
-  integrity sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==
+webpack-bundle-analyzer@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz#39b3a8f829ca044682bc6f9e011c95deb554aefd"
+  integrity sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==
   dependencies:
     acorn "^6.0.7"
     acorn-walk "^6.1.1"
@@ -20508,7 +20508,7 @@ webpack-bundle-analyzer@^3.3.2:
     express "^4.16.3"
     filesize "^3.6.1"
     gzip-size "^5.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.15"
     mkdirp "^0.5.1"
     opener "^1.5.1"
     ws "^6.0.0"


### PR DESCRIPTION
Add bundle size analyzer to local-sandbox.

![image](https://user-images.githubusercontent.com/9615899/73856881-6cdbcf00-4836-11ea-8119-489fbe960587.png)

The purpose is to be able to manually analyze bundle size for custom scenarios.