### PR TITLE
fix(useStateManager): keep reference to `actions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix page crash when `Tooltip` content is null @delprzemo ([#2332](https://github.com/microsoft/fluent-ui-react/pull/2332))
 - Fix `document` usage in `mergeProviderContexts` to get SSR working @layershifter ([#2330](https://github.com/microsoft/fluent-ui-react/pull/2330))
 - Fix `input` descenders being cropped in the Teams theme @bcalvery ([#2335](https://github.com/microsoft/fluent-ui-react/pull/2335))
+- Use referentially equal objects for `actions` in `useStateManager` @layershifter ([#2347](https://github.com/microsoft/fluent-ui-react/pull/2347))
 
 ### Features
 - Added sourcemaps to the dist output to simplify debugging @miroslavstastny ([#2329](https://github.com/microsoft/fluent-ui-react/pull/2329))

--- a/packages/react-bindings/src/hooks/useStateManager.ts
+++ b/packages/react-bindings/src/hooks/useStateManager.ts
@@ -73,14 +73,13 @@ const useStateManager = <
   // frame.
   // It keeps behavior consistency between React state tools and our managers
   // https://github.com/facebook/react/issues/11527#issuecomment-360199710
-
-  if (process.env.NODE_ENV === 'production') {
-    return { state: latestManager.current.state, actions: latestActions }
-  }
-
   // Object.freeze() is used only in dev-mode to avoid usage mistakes
+
   return {
-    state: Object.freeze(latestManager.current.state),
+    state:
+      process.env.NODE_ENV === 'production'
+        ? latestManager.current.state
+        : Object.freeze(latestManager.current.state),
     actions: latestActions,
   }
 }

--- a/packages/react-bindings/src/hooks/useStateManager.ts
+++ b/packages/react-bindings/src/hooks/useStateManager.ts
@@ -36,6 +36,7 @@ const useStateManager = <
     mapPropsToState = () => ({} as Partial<State>),
     sideEffects = [],
   } = options
+  const latestActions = React.useMemo<Actions>(() => ({} as Actions), [managerFactory])
   const latestManager = React.useRef<Manager<State, Actions> | null>(null)
 
   // Heads up! forceUpdate() is used only for triggering rerenders, stateManager is SSOT
@@ -58,19 +59,29 @@ const useStateManager = <
     ],
   })
 
+  // We need to keep the same reference to an object with actions to allow usage them as
+  // a dependency in useCallback() hook
+  Object.assign(latestActions, latestManager.current.actions)
+
+  // For development environments we disallow ability to extend object with other properties to
+  // avoid misusage
+  if (process.env.NODE_ENV !== 'production') {
+    if (Object.isExtensible(latestActions)) Object.preventExtensions(latestActions)
+  }
+
   // We need to pass exactly `manager.state` to provide the same state object during the same render
   // frame.
   // It keeps behavior consistency between React state tools and our managers
   // https://github.com/facebook/react/issues/11527#issuecomment-360199710
 
   if (process.env.NODE_ENV === 'production') {
-    return { state: latestManager.current.state, actions: latestManager.current.actions }
+    return { state: latestManager.current.state, actions: latestActions }
   }
 
   // Object.freeze() is used only in dev-mode to avoid usage mistakes
   return {
     state: Object.freeze(latestManager.current.state),
-    actions: Object.freeze(latestManager.current.actions),
+    actions: latestActions,
   }
 }
 

--- a/packages/react-bindings/test/hooks/useStateManager-test.tsx
+++ b/packages/react-bindings/test/hooks/useStateManager-test.tsx
@@ -69,14 +69,15 @@ type ActionsComponentProps = {
 }
 
 const ActionsComponent: React.FunctionComponent<ActionsComponentProps> = props => {
-  const { actions } = useStateManager(createTestManager)
+  const { actions, state } = useStateManager(createTestManager)
+  const handleClick = React.useCallback(() => actions.toggle(), [actions])
 
   props.onRender()
   React.useEffect(() => {
     props.onUpdate()
   }, [actions])
 
-  return <div onClick={() => actions.toggle()} />
+  return <div data-open={state.open} onClick={handleClick} />
 }
 
 describe('useStateManager', () => {
@@ -170,11 +171,24 @@ describe('useStateManager', () => {
     const onUpdate = jest.fn()
     const wrapper = mount(<ActionsComponent onRender={onRender} onUpdate={onUpdate} />)
 
+    expect(wrapper.find('div').prop('data-open')).toBe(false)
+
     ReactTestUtils.act(() => {
       wrapper.find('div').simulate('click')
     })
+    wrapper.update()
 
+    expect(wrapper.find('div').prop('data-open')).toBe(true)
     expect(onRender).toHaveBeenCalledTimes(2)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+
+    ReactTestUtils.act(() => {
+      wrapper.find('div').simulate('click')
+    })
+    wrapper.update()
+
+    expect(wrapper.find('div').prop('data-open')).toBe(false)
+    expect(onRender).toHaveBeenCalledTimes(3)
     expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react-bindings/test/hooks/useStateManager-test.tsx
+++ b/packages/react-bindings/test/hooks/useStateManager-test.tsx
@@ -1,6 +1,6 @@
 import { useStateManager } from '@fluentui/react-bindings'
 import { createManager, ManagerFactory } from '@fluentui/state'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import * as React from 'react'
 import * as ReactTestUtils from 'react-dom/test-utils'
 
@@ -61,6 +61,22 @@ const TestComponent: React.FunctionComponent<TestComponentProps> = props => {
       <button className={props.color} onClick={() => actions.toggle()} />
     </>
   )
+}
+
+type ActionsComponentProps = {
+  onRender: () => void
+  onUpdate: () => void
+}
+
+const ActionsComponent: React.FunctionComponent<ActionsComponentProps> = props => {
+  const { actions } = useStateManager(createTestManager)
+
+  props.onRender()
+  React.useEffect(() => {
+    props.onUpdate()
+  }, [actions])
+
+  return <div onClick={() => actions.toggle()} />
 }
 
 describe('useStateManager', () => {
@@ -147,5 +163,18 @@ describe('useStateManager', () => {
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onChange).toHaveBeenNthCalledWith(1, 'foo')
     expect(onChange).toHaveBeenNthCalledWith(2, 'foo')
+  })
+
+  it('actions are referentially equal between renders', () => {
+    const onRender = jest.fn()
+    const onUpdate = jest.fn()
+    const wrapper = mount(<ActionsComponent onRender={onRender} onUpdate={onUpdate} />)
+
+    ReactTestUtils.act(() => {
+      wrapper.find('div').simulate('click')
+    })
+
+    expect(onRender).toHaveBeenCalledTimes(2)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
This PR fixes an issue with `useStateManager()` hook to keep the same references for `actions` as currently it's impossible to use it with `ReactuseCallback()` hook:

```tsx
const handleClick = React.useCallback(() => {
  actions.toggle()
}, [actions])
```