### PR TITLE
fix(PerfTest): test name must match filename

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentPerfExample/ComponentPerfChart.tsx
+++ b/docs/src/components/ComponentDoc/ComponentPerfExample/ComponentPerfChart.tsx
@@ -27,7 +27,7 @@ export const ComponentPerfChart = ({ perfTestName }) => {
     case FILTER_BY.RELEASE:
       filteredData = data.filter(entry => entry.tag)
 
-      if (!data[0].tag) {
+      if (!data[0]?.tag) {
         const unreleased = { ...data[0], tag: 'UNRELEASED' }
         filteredData.unshift(unreleased)
       }

--- a/docs/src/examples/components/Tree/Performance/TreeWith60ListItems.perf.tsx
+++ b/docs/src/examples/components/Tree/Performance/TreeWith60ListItems.perf.tsx
@@ -66,11 +66,11 @@ const titleRenderer = (Component, { content, header, headerMedia, media, ...rest
   )
 }
 
-const Tree60WithListItems = () => (
+const TreeWith60ListItems = () => (
   <Tree items={items} defaultActiveItemIds={['1', '2', '3']} renderItemTitle={titleRenderer} />
 )
 
-Tree60WithListItems.iterations = 1
-Tree60WithListItems.filename = 'Tree60WithListItems.perf.tsx'
+TreeWith60ListItems.iterations = 1
+TreeWith60ListItems.filename = 'TreeWith60ListItems.perf.tsx'
 
-export default Tree60WithListItems
+export default TreeWith60ListItems


### PR DESCRIPTION
Fix name of `TreeWith60ListItems`.
The name inside the test must match its filename and currently there is no check for that.