### PR TITLE
chore: refactor perf flags

### DIFF
--- a/packages/react-bindings/src/hooks/useStyles.ts
+++ b/packages/react-bindings/src/hooks/useStyles.ts
@@ -60,8 +60,6 @@ const useStyles = <StyleProps extends PrimitiveProps>(
   const context: StylesContextValue<{ renderRule: RendererRenderRule }> =
     React.useContext(ThemeContext) || defaultContext
 
-  const { enableStylesCaching = true, enableVariablesCaching = true } = context.performance || {}
-
   const {
     className = process.env.NODE_ENV === 'production' ? '' : 'no-classname-🙉',
     mapPropsToStyles = () => ({} as StyleProps),
@@ -86,10 +84,7 @@ const useStyles = <StyleProps extends PrimitiveProps>(
     rtl,
     saveDebug: fluentUIDebug => (debug.current = { fluentUIDebug }),
     theme: context.theme,
-    performance: {
-      enableStylesCaching,
-      enableVariablesCaching,
-    },
+    performance: context.performance,
   })
 
   return { classes, styles: resolvedStyles }

--- a/packages/react-bindings/src/styles/resolveStyles.ts
+++ b/packages/react-bindings/src/styles/resolveStyles.ts
@@ -51,7 +51,7 @@ const resolveStyles = (
     rtl,
     disableAnimations,
     renderer,
-    performance = {},
+    performance,
   } = options || {}
 
   const { className, design, styles, variables, ...stylesProps } = props

--- a/packages/react-bindings/src/styles/types.ts
+++ b/packages/react-bindings/src/styles/types.ts
@@ -68,7 +68,6 @@ export type Renderer = Omit<FelaRenderer, 'renderRule'> & {
 }
 
 export interface StylesContextPerformance {
-  enableSanitizeCssPlugin: boolean
   enableStylesCaching: boolean
   enableVariablesCaching: boolean
 }

--- a/packages/react-bindings/src/styles/types.ts
+++ b/packages/react-bindings/src/styles/types.ts
@@ -68,18 +68,24 @@ export type Renderer = Omit<FelaRenderer, 'renderRule'> & {
 }
 
 export interface StylesContextPerformance {
-  enableStylesCaching?: boolean
-  enableVariablesCaching?: boolean
+  enableSanitizeCssPlugin: boolean
+  enableStylesCaching: boolean
+  enableVariablesCaching: boolean
 }
+
+export type StylesContextPerformanceInput = Partial<StylesContextPerformance>
 
 export type StylesContextInputValue<R = Renderer> = {
   disableAnimations?: boolean
-  performance?: StylesContextPerformance
+  performance?: StylesContextPerformanceInput
   renderer?: R
   theme?: ThemeInput
 }
 
-export type StylesContextValue<R = Renderer> = Required<StylesContextInputValue<R>> & {
+export type StylesContextValue<R = Renderer> = {
+  disableAnimations: boolean
+  performance: StylesContextPerformanceInput
+  renderer: R
   theme: ThemePrepared
 }
 

--- a/packages/react-bindings/test/hooks/useStyles-test.tsx
+++ b/packages/react-bindings/test/hooks/useStyles-test.tsx
@@ -38,6 +38,7 @@ const TestProvider: React.FC<{ theme: ThemeInput }> = props => {
   return (
     <ThemeContext.Provider
       value={{
+        performance: {},
         theme,
       }}
     >

--- a/packages/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/react-bindings/test/styles/resolveStyles-test.ts
@@ -6,7 +6,7 @@ import {
   ICSSInJSStyle,
 } from '@fluentui/styles'
 import resolveStyles from '../../src/styles/resolveStyles'
-import { ResolveStylesOptions } from '../../src/styles/types'
+import { ResolveStylesOptions, StylesContextPerformance } from '../../src/styles/types'
 
 const componentStyles: ComponentSlotStylesPrepared<{}, { color: string }> = {
   root: ({ variables: v }): ICSSInJSStyle => ({
@@ -18,19 +18,18 @@ const resolvedVariables: ComponentVariablesObject = {
   color: 'red',
 }
 
+const defaultPerformanceOptions: StylesContextPerformance = {
+  enableStylesCaching: true,
+  enableVariablesCaching: true,
+}
+
 const resolveStylesOptions = (options?: {
   displayName?: ResolveStylesOptions['displayName']
   performance?: ResolveStylesOptions['performance']
   props?: ResolveStylesOptions['props']
 }): ResolveStylesOptions => {
-  const {
-    displayName = 'Test',
-    performance = {
-      enableVariablesCaching: true,
-      enableStylesCaching: true,
-    },
-    props = {},
-  } = options || {}
+  const { displayName = 'Test', performance = defaultPerformanceOptions, props = {} } =
+    options || {}
 
   return {
     theme: {
@@ -188,7 +187,9 @@ describe('resolveStyles', () => {
 
   test('does not cache styles if caching is disabled', () => {
     spyOn(componentStyles, 'root').and.callThrough()
-    const options = resolveStylesOptions({ performance: { enableStylesCaching: false } })
+    const options = resolveStylesOptions({
+      performance: { ...defaultPerformanceOptions, enableStylesCaching: false },
+    })
     const { resolvedStyles } = resolveStyles(options, resolvedVariables)
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables)
 
@@ -199,7 +200,9 @@ describe('resolveStyles', () => {
 
   test('does not cache classes if caching is disabled', () => {
     const renderStyles = jest.fn().mockReturnValue('a')
-    const options = resolveStylesOptions({ performance: { enableStylesCaching: false } })
+    const options = resolveStylesOptions({
+      performance: { ...defaultPerformanceOptions, enableStylesCaching: false },
+    })
     const { classes } = resolveStyles(options, resolvedVariables, renderStyles)
     const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles)
 
@@ -228,7 +231,7 @@ describe('resolveStyles', () => {
     _.forEach(propsInlineOverrides, (props, idx) => {
       const options = resolveStylesOptions({
         props,
-        performance: { enableStylesCaching: false },
+        performance: { ...defaultPerformanceOptions, enableStylesCaching: false },
       })
 
       const { resolvedStyles } = resolveStyles(options, resolvedVariables)
@@ -255,7 +258,7 @@ describe('resolveStyles', () => {
     _.forEach(propsInlineOverrides, props => {
       const options = resolveStylesOptions({
         props,
-        performance: { enableStylesCaching: false },
+        performance: { ...defaultPerformanceOptions, enableStylesCaching: false },
       })
       const { classes } = resolveStyles(options, resolvedVariables, renderStyles)
       const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles)

--- a/packages/react/src/components/Animation/Animation.tsx
+++ b/packages/react/src/components/Animation/Animation.tsx
@@ -204,7 +204,10 @@ const Animation: React.FC<AnimationProps> & {
       disableAnimations: context.disableAnimations,
       renderer: context.renderer,
       rtl: context.rtl,
-      performance: {},
+      performance: {
+        enableStylesCaching: false,
+        enableVariablesCaching: false,
+      },
       saveDebug: _.noop,
       theme: context.theme,
     })

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -4,7 +4,7 @@ import {
   getElementType,
   getUnhandledProps,
   Renderer,
-  StylesContextPerformance,
+  StylesContextPerformanceInput,
   Telemetry,
   unstable_getStyles,
   useIsomorphicLayoutEffect,
@@ -44,7 +44,7 @@ export interface ProviderProps extends ChildrenComponentProps, UIComponentProps 
   renderer?: Renderer
   rtl?: boolean
   disableAnimations?: boolean
-  performance?: StylesContextPerformance
+  performance?: StylesContextPerformanceInput
   overwrite?: boolean
   target?: Document
   theme?: ThemeInput
@@ -135,10 +135,10 @@ const Provider: React.FC<WithAsProp<ProviderProps>> & {
   }
 
   const consumedContext: ProviderContextPrepared = React.useContext(ThemeContext)
-  const incomingContext: ProviderContextPrepared = overwrite ? ({} as any) : consumedContext
+  const incomingContext: ProviderContextInput | ProviderContextPrepared = overwrite
+    ? {}
+    : consumedContext
 
-  // rehydration disabled to avoid leaking styles between renderers
-  // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
   const outgoingContext = mergeContexts(incomingContext, inputContext)
 
   const rtlProps: { dir?: 'rtl' | 'ltr' } = {}
@@ -199,6 +199,8 @@ const Provider: React.FC<WithAsProp<ProviderProps>> & {
           ...unhandledProps,
         }
 
+  // rehydration disabled to avoid leaking styles between renderers
+  // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
   return (
     <RendererProvider
       renderer={outgoingContext.renderer}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,9 +1,4 @@
-import {
-  StylesContextInputValue,
-  StylesContextValue,
-  StylesContextPerformance,
-  Telemetry,
-} from '@fluentui/react-bindings'
+import { StylesContextInputValue, StylesContextValue, Telemetry } from '@fluentui/react-bindings'
 import * as React from 'react'
 
 import { ShorthandFactory } from './utils/factories'
@@ -179,7 +174,6 @@ export interface ProviderContextInput extends StylesContextInputValue {
   rtl?: boolean
   target?: Document
   telemetry?: Telemetry
-  performance?: StylesContextPerformance
 }
 
 export interface ProviderContextPrepared extends StylesContextValue {

--- a/packages/react/src/utils/mergeProviderContexts.ts
+++ b/packages/react/src/utils/mergeProviderContexts.ts
@@ -1,13 +1,9 @@
-import { Renderer } from '@fluentui/react-bindings'
+import { Renderer, StylesContextPerformance, StylesContextPerformanceInput } from '@fluentui/react-bindings'
 import { mergeThemes } from '@fluentui/styles'
 
 import { ProviderContextPrepared, ProviderContextInput } from '../types'
 import { createRenderer, felaRenderer } from './felaRenderer'
 import isBrowser from './isBrowser'
-import {
-  StylesContextPerformance,
-  StylesContextPerformanceInput,
-} from '@fluentui/react-bindings/src'
 
 const registeredRenderers = new WeakMap<Document, Renderer>()
 

--- a/packages/react/src/utils/mergeProviderContexts.ts
+++ b/packages/react/src/utils/mergeProviderContexts.ts
@@ -4,6 +4,10 @@ import { mergeThemes } from '@fluentui/styles'
 import { ProviderContextPrepared, ProviderContextInput } from '../types'
 import { createRenderer, felaRenderer } from './felaRenderer'
 import isBrowser from './isBrowser'
+import {
+  StylesContextPerformance,
+  StylesContextPerformanceInput,
+} from '@fluentui/react-bindings/src'
 
 const registeredRenderers = new WeakMap<Document, Renderer>()
 
@@ -33,7 +37,10 @@ export const mergeRenderers = (current: Renderer, next?: Renderer, target?: Docu
   return createdRenderer
 }
 
-export const mergePerformanceOptions = (target, ...sources) => {
+export const mergePerformanceOptions = (
+  target: StylesContextPerformance | StylesContextPerformanceInput,
+  ...sources: StylesContextPerformanceInput[]
+) => {
   return Object.assign(target, ...sources)
 }
 

--- a/packages/react/src/utils/mergeProviderContexts.ts
+++ b/packages/react/src/utils/mergeProviderContexts.ts
@@ -1,7 +1,7 @@
 import {
   Renderer,
   StylesContextPerformance,
-  StylesContextPerformanceInput
+  StylesContextPerformanceInput,
 } from '@fluentui/react-bindings'
 import { mergeThemes } from '@fluentui/styles'
 

--- a/packages/react/src/utils/mergeProviderContexts.ts
+++ b/packages/react/src/utils/mergeProviderContexts.ts
@@ -1,4 +1,8 @@
-import { Renderer, StylesContextPerformance, StylesContextPerformanceInput } from '@fluentui/react-bindings'
+import {
+  Renderer,
+  StylesContextPerformance,
+  StylesContextPerformanceInput
+} from '@fluentui/react-bindings'
 import { mergeThemes } from '@fluentui/styles'
 
 import { ProviderContextPrepared, ProviderContextInput } from '../types'

--- a/packages/react/src/utils/renderComponent.tsx
+++ b/packages/react/src/utils/renderComponent.tsx
@@ -68,7 +68,6 @@ const renderComponent = <P extends {}>(
 
   const { setStart, setEnd } = useTelemetry(displayName, context.telemetry)
   const rtl = context.rtl || false
-  const enableVariablesCaching = context.performance?.enableVariablesCaching
 
   setStart()
 
@@ -93,8 +92,7 @@ const renderComponent = <P extends {}>(
     saveDebug,
     theme: context.theme || emptyTheme,
     performance: {
-      enableVariablesCaching:
-        typeof enableVariablesCaching === 'boolean' ? enableVariablesCaching : true,
+      ...context.performance,
       enableStylesCaching: false, // we cannot enable caching for class components
     },
   })

--- a/packages/react/test/specs/utils/mergeProviderContexts/mergeProviderContexts-test.ts
+++ b/packages/react/test/specs/utils/mergeProviderContexts/mergeProviderContexts-test.ts
@@ -1,4 +1,7 @@
-import mergeProviderContexts, { mergeRenderers } from 'src/utils/mergeProviderContexts'
+import mergeProviderContexts, {
+  mergePerformanceOptions,
+  mergeRenderers,
+} from 'src/utils/mergeProviderContexts'
 import { felaRenderer } from 'src/utils/felaRenderer'
 
 describe('mergeRenderers', () => {
@@ -21,6 +24,30 @@ describe('mergeRenderers', () => {
 
     expect(renderer).toHaveProperty('renderRule')
     expect(mergeRenderers(jest.fn() as any, null, target)).toBe(renderer)
+  })
+})
+
+describe('mergePerformanceOptions', () => {
+  test(`options from "sources" always override`, () => {
+    expect(mergePerformanceOptions({ enableVariablesCaching: true }, {})).toMatchObject({
+      enableVariablesCaching: true,
+    })
+    expect(mergePerformanceOptions({ enableVariablesCaching: true }, undefined)).toMatchObject({
+      enableVariablesCaching: true,
+    })
+
+    expect(
+      mergePerformanceOptions(
+        { enableVariablesCaching: true, enableStylesCaching: true },
+        { enableStylesCaching: false },
+      ),
+    ).toMatchObject({})
+    expect(
+      mergePerformanceOptions(
+        { enableVariablesCaching: true, enableStylesCaching: true },
+        { enableStylesCaching: undefined },
+      ),
+    ).toMatchObject({})
   })
 })
 


### PR DESCRIPTION
This PR performs a small refactor to avoid defining default values for `performance` flags in multiple places.