### PR TITLE
Hide Safari default input outline

### DIFF
--- a/packages/react/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/react/src/themes/teams/components/Input/inputStyles.ts
@@ -28,7 +28,7 @@ const inputStyles: ComponentSlotStylesPrepared<InputProps, InputVariables> = {
     borderStyle: 'solid',
     borderWidth: v.borderWidth,
 
-    outline: 0,
+    outline: 'none',
     padding: v.inputPadding,
     position: 'relative',
 


### PR DESCRIPTION
Fixes issue #2376 where ugly default outline appeared on focused input in Safari.
Before:
![safari](https://user-images.githubusercontent.com/4189399/75048961-ab75b880-54c9-11ea-8a91-fc402362692c.png)
After:
<img width="236" alt="Screenshot 2020-02-21 at 16 44 52" src="https://user-images.githubusercontent.com/4189399/75048983-b597b700-54c9-11ea-8f07-d202f45f1cf6.png">
