### PR TITLE
chore(DropdownItem): refactor to functional component with hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Chat`, `ChatItem`, `ChatMessage` components which are passed to styles functions @layershifter ([#2366](https://github.com/microsoft/fluent-ui-react/pull/2366))
 - `sanitize-css` plugin is disabled for production mode by default @layershifter ([#2340](https://github.com/microsoft/fluent-ui-react/pull/2340))
 - Standardise component onChange callback names and test them in `isConformant` @silviuavram ([#2293](https://github.com/microsoft/fluent-ui-react/pull/2293))
+- Restricted prop set in the `DropdownItem` styles @silviuavram ([#2382](https://github.com/microsoft/fluent-ui-react/pull/2382))
 
 ### Fixes
 - Remove dependency on Lodash in TypeScript typings @layershifter ([#2323](https://github.com/microsoft/fluent-ui-react/pull/2323))

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -32,7 +32,6 @@ export interface DropdownItemSlotClassNames {
   image: string
   checkableIndicator: string
   wrapper: string
-  checkableIndicatorWrapper: string
 }
 
 export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
@@ -82,6 +81,7 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
   setStart()
 
   const {
+    accessibilityItemProps,
     className,
     content,
     design,
@@ -128,20 +128,12 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
   })
   const endMediaElement =
     selected && checkable
-      ? Box.create(
-          Icon.create(checkableIndicator, {
-            defaultProps: () => ({
-              className: DropdownItem.slotClassNames.checkableIndicator,
-              styles: resolvedStyles.checkableIndicator,
-            }),
+      ? Icon.create(checkableIndicator, {
+          defaultProps: () => ({
+            className: DropdownItem.slotClassNames.checkableIndicator,
+            styles: resolvedStyles.checkableIndicator,
           }),
-          {
-            defaultProps: () => ({
-              className: DropdownItem.slotClassNames.checkableIndicatorWrapper,
-              styles: resolvedStyles.endMedia,
-            }),
-          },
-        )
+        })
       : null
   const imageElement = Box.create(
     Image.create(image, {
@@ -160,7 +152,12 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
   )
 
   const element = (
-    <ElementType className={classes.root} onClick={handleClick} {...unhandledProps}>
+    <ElementType
+      className={classes.root}
+      onClick={handleClick}
+      {...accessibilityItemProps}
+      {...unhandledProps}
+    >
       {imageElement}
 
       <div className={cx(DropdownItem.slotClassNames.wrapper, classes.main)}>
@@ -208,7 +205,6 @@ DropdownItem.slotClassNames = {
   content: `${DropdownItem.className}__content`,
   header: `${DropdownItem.className}__header`,
   image: `${DropdownItem.className}__image`,
-  checkableIndicatorWrapper: `${DropdownItem.className}__checkable-indicator-wrapper`,
   checkableIndicator: `${DropdownItem.className}__checkable-indicator`,
 }
 

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -2,17 +2,26 @@ import * as customPropTypes from '@fluentui/react-proptypes'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'lodash'
-
+// @ts-ignore
+import { ThemeContext } from 'react-fela'
 import {
-  UIComponent,
-  RenderResultConfig,
-  createShorthandFactory,
-  commonPropTypes,
-  ShorthandFactory,
-} from '../../utils'
-import { ShorthandValue, ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types'
+  getElementType,
+  getUnhandledProps,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings'
+import cx from 'classnames'
+
+import { createShorthandFactory, commonPropTypes } from '../../utils'
+import {
+  ShorthandValue,
+  ComponentEventHandler,
+  WithAsProp,
+  withSafeTypeForAs,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types'
 import { UIComponentProps } from '../../utils/commonPropInterfaces'
-import ListItem from '../List/ListItem'
 import Icon, { IconProps } from '../Icon/Icon'
 import Image, { ImageProps } from '../Image/Image'
 import Box, { BoxProps } from '../Box/Box'
@@ -22,6 +31,8 @@ export interface DropdownItemSlotClassNames {
   header: string
   image: string
   checkableIndicator: string
+  wrapper: string
+  checkableIndicatorWrapper: string
 }
 
 export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
@@ -61,96 +72,143 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
   selected?: boolean
 }
 
-class DropdownItem extends UIComponent<WithAsProp<DropdownItemProps>> {
-  static displayName = 'DropdownItem'
+const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> &
+  FluentComponentStaticProps<DropdownItemProps> & {
+    slotClassNames: DropdownItemSlotClassNames
+  } = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext)
+  const { setStart, setEnd } = useTelemetry(DropdownItem.displayName, context.telemetry)
 
-  static create: ShorthandFactory<DropdownItemProps>
+  setStart()
 
-  static className = 'ui-dropdown__item'
+  const {
+    className,
+    content,
+    design,
+    header,
+    image,
+    styles,
+    checkable,
+    checkableIndicator,
+    selected,
+    variables,
+  } = props
 
-  static slotClassNames: DropdownItemSlotClassNames
-
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      accessibility: false,
-      children: false,
-      content: false,
-    }),
-    accessibilityItemProps: PropTypes.object,
-    active: PropTypes.bool,
-    content: customPropTypes.itemShorthand,
-    checkable: PropTypes.bool,
-    checkableIndicator: customPropTypes.itemShorthandWithoutJSX,
-    header: customPropTypes.itemShorthand,
-    image: customPropTypes.itemShorthandWithoutJSX,
-    onClick: PropTypes.func,
-    isFromKeyboard: PropTypes.bool,
-    selected: PropTypes.bool,
-  }
-
-  handleClick = e => {
-    _.invoke(this.props, 'onClick', e, this.props)
-  }
-
-  renderComponent({ classes, styles, unhandledProps }: RenderResultConfig<DropdownItemProps>) {
-    const {
-      content,
-      header,
-      image,
-      accessibilityItemProps,
+  const { classes, styles: resolvedStyles } = useStyles(DropdownItem.displayName, {
+    className: DropdownItem.className,
+    mapPropsToStyles: () => ({
       selected,
-      checkable,
-      checkableIndicator,
-    } = this.props
-    return (
-      <ListItem
-        className={DropdownItem.className}
-        styles={styles.root}
-        onClick={this.handleClick}
-        header={Box.create(header, {
-          defaultProps: () => ({
-            className: DropdownItem.slotClassNames.header,
-            styles: styles.header,
-          }),
-        })}
-        media={Image.create(image, {
-          defaultProps: () => ({
-            avatar: true,
-            className: DropdownItem.slotClassNames.image,
-            styles: styles.image,
-          }),
-        })}
-        content={Box.create(content, {
-          defaultProps: () => ({
-            className: DropdownItem.slotClassNames.content,
-            styles: styles.content,
-          }),
-        })}
-        endMedia={
-          selected &&
-          checkable && {
-            content: Icon.create(checkableIndicator, {
-              defaultProps: () => ({
-                className: DropdownItem.slotClassNames.checkableIndicator,
-                styles: styles.checkableIndicator,
-              }),
-            }),
-            styles: styles.endMedia,
-          }
-        }
-        truncateContent
-        truncateHeader
-        {...accessibilityItemProps}
-        {...unhandledProps}
-      />
-    )
+      hasContent: !!content,
+      hasContentMedia: false,
+      hasHeader: !!header,
+      hasHeaderMedia: false,
+    }),
+    mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
+    rtl: context.rtl,
+  })
+
+  const ElementType = getElementType(props)
+  const unhandledProps = getUnhandledProps(DropdownItem.handledProps, props)
+
+  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+    _.invoke(props, 'onClick', e, props)
   }
+
+  const contentElement = Box.create(content, {
+    defaultProps: () => ({
+      className: DropdownItem.slotClassNames.content,
+      styles: resolvedStyles.content,
+    }),
+  })
+  const headerElement = Box.create(header, {
+    defaultProps: () => ({
+      className: DropdownItem.slotClassNames.header,
+      styles: resolvedStyles.header,
+    }),
+  })
+  const endMediaElement =
+    selected && checkable
+      ? Box.create(
+          Icon.create(checkableIndicator, {
+            defaultProps: () => ({
+              className: DropdownItem.slotClassNames.checkableIndicator,
+              styles: resolvedStyles.checkableIndicator,
+            }),
+          }),
+          {
+            defaultProps: () => ({
+              className: DropdownItem.slotClassNames.checkableIndicatorWrapper,
+              styles: resolvedStyles.endMedia,
+            }),
+          },
+        )
+      : null
+  const imageElement = Box.create(
+    Image.create(image, {
+      defaultProps: () => ({
+        avatar: true,
+        className: DropdownItem.slotClassNames.image,
+        styles: resolvedStyles.image,
+      }),
+    }),
+    {
+      defaultProps: () => ({
+        className: DropdownItem.slotClassNames.image,
+        styles: resolvedStyles.media,
+      }),
+    },
+  )
+
+  const element = (
+    <ElementType className={classes.root} onClick={handleClick} {...unhandledProps}>
+      {imageElement}
+
+      <div className={cx(DropdownItem.slotClassNames.wrapper, classes.main)}>
+        {headerElement}
+        {contentElement}
+      </div>
+
+      {endMediaElement}
+    </ElementType>
+  )
+
+  setEnd()
+
+  return element
 }
 
+DropdownItem.className = 'ui-dropdown__item'
+DropdownItem.displayName = 'DropdownItem'
+
+DropdownItem.defaultProps = {
+  as: 'li',
+}
+
+DropdownItem.propTypes = {
+  ...commonPropTypes.createCommon({
+    accessibility: false,
+    children: false,
+    content: false,
+  }),
+  accessibilityItemProps: PropTypes.object,
+  active: PropTypes.bool,
+  content: customPropTypes.itemShorthand,
+  checkable: PropTypes.bool,
+  checkableIndicator: customPropTypes.itemShorthandWithoutJSX,
+  header: customPropTypes.itemShorthand,
+  image: customPropTypes.itemShorthandWithoutJSX,
+  onClick: PropTypes.func,
+  isFromKeyboard: PropTypes.bool,
+  selected: PropTypes.bool,
+}
+DropdownItem.handledProps = Object.keys(DropdownItem.propTypes) as any
+
 DropdownItem.slotClassNames = {
+  wrapper: `${DropdownItem.className}__wrapper`,
   content: `${DropdownItem.className}__content`,
   header: `${DropdownItem.className}__header`,
   image: `${DropdownItem.className}__image`,
+  checkableIndicatorWrapper: `${DropdownItem.className}__checkable-indicator-wrapper`,
   checkableIndicator: `${DropdownItem.className}__checkable-indicator`,
 }
 

--- a/packages/react/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItem.tsx
@@ -31,7 +31,7 @@ export interface DropdownItemSlotClassNames {
   header: string
   image: string
   checkableIndicator: string
-  wrapper: string
+  main: string
 }
 
 export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
@@ -81,12 +81,14 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
   setStart()
 
   const {
+    active,
     accessibilityItemProps,
     className,
     content,
     design,
     header,
     image,
+    isFromKeyboard,
     styles,
     checkable,
     checkableIndicator,
@@ -97,11 +99,11 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
   const { classes, styles: resolvedStyles } = useStyles(DropdownItem.displayName, {
     className: DropdownItem.className,
     mapPropsToStyles: () => ({
+      active,
+      isFromKeyboard,
       selected,
       hasContent: !!content,
-      hasContentMedia: false,
       hasHeader: !!header,
-      hasHeaderMedia: false,
     }),
     mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
     rtl: context.rtl,
@@ -160,7 +162,7 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
     >
       {imageElement}
 
-      <div className={cx(DropdownItem.slotClassNames.wrapper, classes.main)}>
+      <div className={cx(DropdownItem.slotClassNames.main, classes.main)}>
         {headerElement}
         {contentElement}
       </div>
@@ -201,7 +203,7 @@ DropdownItem.propTypes = {
 DropdownItem.handledProps = Object.keys(DropdownItem.propTypes) as any
 
 DropdownItem.slotClassNames = {
-  wrapper: `${DropdownItem.className}__wrapper`,
+  main: `${DropdownItem.className}__main`,
   content: `${DropdownItem.className}__content`,
   header: `${DropdownItem.className}__header`,
   image: `${DropdownItem.className}__image`,

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownItemStyles.ts
@@ -12,7 +12,10 @@ export type DropdownItemStylesProps = Pick<
   hasHeader?: boolean
 }
 
-const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, DropdownVariables> = {
+const dropdownItemStyles: ComponentSlotStylesPrepared<
+  DropdownItemStylesProps,
+  DropdownVariables
+> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
     display: 'flex',
     alignItems: 'center',
@@ -50,7 +53,7 @@ const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, Dropdow
   }),
   header: ({ props: p, variables: v }): ICSSInJSStyle => ({
     flexGrow: 1,
-    lineHeight: v.headerLineHeight,
+    lineHeight: v.listItemHeaderLineHeight,
 
     fontSize: v.listItemHeaderFontSize,
     // if the item doesn't have content - i.e. it is header only - then it should use the content color
@@ -67,7 +70,7 @@ const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, Dropdow
   }),
   content: ({ variables: v }): ICSSInJSStyle => ({
     flexGrow: 1,
-    lineHeight: v.contentLineHeight,
+    lineHeight: v.listItemContentLineHeight,
     fontSize: v.listItemContentFontSize,
     color: v.listItemContentColor,
   }),

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownItemStyles.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownItemStyles.ts
@@ -4,8 +4,18 @@ import DropdownItem, { DropdownItemProps } from '../../../../components/Dropdown
 import getBorderFocusStyles from '../../getBorderFocusStyles'
 import { pxToRem } from '../../../../utils'
 
+export type DropdownItemStylesProps = Pick<
+  DropdownItemProps,
+  'selected' | 'active' | 'isFromKeyboard'
+> & {
+  hasContent?: boolean
+  hasHeader?: boolean
+}
+
 const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, DropdownVariables> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
+    display: 'flex',
+    alignItems: 'center',
     minHeight: 0,
     padding: `${pxToRem(4)} ${pxToRem(11)}`,
     whiteSpace: 'nowrap',
@@ -22,12 +32,12 @@ const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, Dropdow
       ...(!p.isFromKeyboard && {
         color: v.listItemColorHover,
         backgroundColor: v.listItemBackgroundColorHover,
-        ...(p.header && {
+        ...(p.hasHeader && {
           [`& .${DropdownItem.slotClassNames.header}`]: {
             color: v.listItemColorHover,
           },
         }),
-        ...(p.content && {
+        ...(p.hasContent && {
           [`& .${DropdownItem.slotClassNames.content}`]: {
             color: v.listItemColorHover,
           },
@@ -39,10 +49,13 @@ const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, Dropdow
     margin: `${pxToRem(3)} ${pxToRem(12)} ${pxToRem(3)} ${pxToRem(4)}`,
   }),
   header: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    flexGrow: 1,
+    lineHeight: v.headerLineHeight,
+
     fontSize: v.listItemHeaderFontSize,
     // if the item doesn't have content - i.e. it is header only - then it should use the content color
     color: v.listItemContentColor,
-    ...(p.content && {
+    ...(p.hasContent && {
       // if there is content it needs to be "tightened up" to the header
       marginBottom: pxToRem(-1),
       color: v.listItemHeaderColor,
@@ -53,6 +66,8 @@ const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, Dropdow
     }),
   }),
   content: ({ variables: v }): ICSSInJSStyle => ({
+    flexGrow: 1,
+    lineHeight: v.contentLineHeight,
     fontSize: v.listItemContentFontSize,
     color: v.listItemContentColor,
   }),
@@ -61,7 +76,14 @@ const dropdownItemStyles: ComponentSlotStylesPrepared<DropdownItemProps, Dropdow
     left: pxToRem(3),
   }),
   endMedia: () => ({
+    flexShrink: 0,
     lineHeight: pxToRem(16),
+  }),
+  main: () => ({
+    display: 'flex',
+    flexDirection: 'column',
+    flexGrow: 1,
+    minWidth: 0, // needed for the truncate styles to work
   }),
 }
 

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownItemVariables.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownItemVariables.ts
@@ -1,14 +1,3 @@
 import dropdownVariables from './dropdownVariables'
 
-export interface DropdownItemVariables {
-  headerLineHeight: string
-  contentLineHeight: string
-}
-
-export default (siteVariables): DropdownItemVariables => ({
-  // Header
-  // TODO: prod app uses 17.5px here, it should be 16px per the design guide!
-  headerLineHeight: siteVariables.lineHeightSmall,
-  contentLineHeight: siteVariables.lineHeightSmall,
-  ...dropdownVariables,
-})
+export default dropdownVariables

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownItemVariables.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownItemVariables.ts
@@ -1,3 +1,14 @@
 import dropdownVariables from './dropdownVariables'
 
-export default dropdownVariables
+export interface DropdownItemVariables {
+  headerLineHeight: string
+  contentLineHeight: string
+}
+
+export default (siteVariables): DropdownItemVariables => ({
+  // Header
+  // TODO: prod app uses 17.5px here, it should be 16px per the design guide!
+  headerLineHeight: siteVariables.lineHeightSmall,
+  contentLineHeight: siteVariables.lineHeightSmall,
+  ...dropdownVariables,
+})

--- a/packages/react/src/themes/teams/components/Dropdown/dropdownVariables.ts
+++ b/packages/react/src/themes/teams/components/Dropdown/dropdownVariables.ts
@@ -33,6 +33,8 @@ export interface DropdownVariables {
   listItemColorActive: string
   listItemSelectedFontWeight: number
   listItemSelectedColor: string
+  listItemHeaderLineHeight: string
+  listItemContentLineHeight: string
   selectedItemColor: string
   selectedItemBackgroundColor: string
   selectedItemColorFocus: string
@@ -76,6 +78,9 @@ export default (siteVars): DropdownVariables => ({
   listItemColorActive: siteVars.colors.grey[750],
   listItemSelectedFontWeight: siteVars.fontWeightSemibold,
   listItemSelectedColor: siteVars.colors.grey[750],
+  // TODO: prod app uses 17.5px here, it should be 16px per the design guide!
+  listItemHeaderLineHeight: siteVars.lineHeightSmall,
+  listItemContentLineHeight: siteVars.lineHeightSmall,
   selectedItemBackgroundColor: 'undefined',
   selectedItemColorFocus: siteVars.bodyColor,
   selectedItemBackgroundColorFocus: siteVars.colors.brand[200],

--- a/packages/react/test/specs/components/Dropdown/DropdownItem-test.tsx
+++ b/packages/react/test/specs/components/Dropdown/DropdownItem-test.tsx
@@ -1,0 +1,9 @@
+import DropdownItem from 'src/components/Dropdown/DropdownItem'
+import { isConformant } from 'test/specs/commonTests'
+
+describe('DropdownItem', () => {
+  isConformant(DropdownItem, {
+    constructorName: 'DropdownItem',
+    hasAccessibilityProp: false,
+  })
+})


### PR DESCRIPTION
Inspired heavily by `ListItem`. Removed the use of `ListItem` and created the slots similarly to how `ListItem` does it. Also added some `listItemStyles` to `dropdownItemStyles` in order to compensate from not using `ListItem` anymore.

# BREAKING CHANGES

Only limited amount of props are passed to component's styles functions.

| `DropdownItem` |
| --- |
| `active` |
| `isFromKeyboard` |
| `selected` |
| `hasContent` |
| `hasHeader` |